### PR TITLE
Single TTL monitor widget

### DIFF
--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -1,6 +1,5 @@
 """Module for monitoring devices."""
 
-import enum
 from typing import Any, TypeVar, Generic, Optional, Callable
 
 from PyQt5.QtWidgets import QWidget, QLabel, QHBoxLayout

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -10,7 +10,13 @@ class Monitor(Generic[T]):
     """An interface for a monitor.
     
     Monitors watch a single value, and notify any change of the value by calling
-      a callback function.
+    a callback function.
+    
+    In a Monitor object, there is two kinds of values: the public self.value()
+    and the internal self._value.
+    In most cases they will be the same, as self.value() returns self._value by default.
+    However, for some reason, one might want to keep it different.
+    In such cases, be aware of which kind of value you are using.
     """
 
     def __init__(

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -17,12 +17,6 @@ class Monitor(Generic[T]):
 
     This class can be used as a concrete Monitor if the usage is simple enough
     and there is no need to implement self._read().
-    
-    In a Monitor object, there is two kinds of values: the public self.value()
-    and the internal self._value.
-    In most cases they will be the same, as self.value() returns self._value by default.
-    However, for some reason, one might want to keep it different.
-    In such cases, be aware of which kind of value you are using.
     """
 
     def __init__(
@@ -42,18 +36,18 @@ class Monitor(Generic[T]):
         """Returns the latest value."""
         return self._value
 
-    def set_value(self, _value: T):
+    def set_value(self, value: T):
         """Sets the current monitored value.
         
         This method will be called by the value source, to notify the value change.
         This will call the callback function.
 
         Args:
-            _value: The new value, which should be the same kind of the internal self._value.
+            value: The new value.
         """
-        self._value = _value
+        self._value = value
         if self.updated_callback is not None:
-            self.updated_callback(self.value())
+            self.updated_callback(value)
 
     def update(self):
         """Updates the current value by actively reading the value.
@@ -67,9 +61,6 @@ class Monitor(Generic[T]):
         """Actively reads the current value and returns it.
         
         Unless this is overriden, it just returns the latest value.
-        
-        The return value must be the same kind of the internal self._value,
-        in case where self.value() differs from self._value.
         """
         return self._value
 

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -53,21 +53,13 @@ class Monitor(Generic[T]):
         if self.updated_callback is not None:
             self.updated_callback(self.value())
 
-    def update(self, callback: bool = True) -> Optional[T]:
-        """Returns the current value or None if it is unknown or invalid.
+    def update(self):
+        """Updates the current value by actively reading the value.
         
-        This method will actively read the value and update the current value if it is changed.
-        It could be helpful when the monitor is newly created and has no value yet,
+        This could be helpful when the monitor is newly created and has no value yet,
         or the value source does not support reporting all the changes.
-
-        Args:
-            callback: Whether to call updated_callback, with the updated value.
-              If updated_callback is None, it is ignored.
         """
-        self._value = self._read()
-        if callback and self.updated_callback is not None:
-            self.updated_callback(self.value())
-        return self.value()
+        self.set_value(self._read())
 
     def _read(self) -> Optional[T]:
         """Actively reads the current value and returns it.

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -34,7 +34,7 @@ class Monitor(Generic[T]):
         self.updated_callback = updated_callback
         self._value = None
         if initial_update:
-            self.update(callback=True)
+            self.update()
 
     def value(self) -> Optional[T]:
         """Returns the latest value or None if it is unknown or invalid."""

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -40,6 +40,19 @@ class Monitor(Generic[T]):
         """Returns the latest value or None if it is unknown or invalid."""
         return self._value
 
+    def set_value(self, _value: Optional[T]):
+        """Sets the current monitored value.
+        
+        This method will be called by the value source, to notify the value change.
+        This will call the callback function.
+
+        Args:
+            _value: The new value, which should be the same kind of the internal self._value.
+        """
+        self._value = _value
+        if self.updated_callback is not None:
+            self.updated_callback(self.value())
+
     def update(self, callback: bool = True) -> Optional[T]:
         """Returns the current value or None if it is unknown or invalid.
         

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -23,3 +23,12 @@ class Monitor(Generic[T]):
     def value(self) -> Optional[T]:
         """Returns the latest value or None if it is unknown or invalid."""
         return None
+
+    def update(self) -> Optional[T]:
+        """Returns the current value or None if it is unknown or invalid.
+        
+        This method will actively read the value and update the current value if it is changed.
+        It could be helpful when the monitor is newly created and has no value yet,
+        or the value source does not support reporting all the changes.
+        """
+        return None

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -1,1 +1,25 @@
 """Module for monitoring devices."""
+
+from typing import Any, TypeVar, Generic, Optional, Callable
+
+
+T = TypeVar("T")
+
+
+class Monitor(Generic[T]):
+    """An interface for a monitor.
+    
+    Monitors watch a single value, and notify any change of the value by calling
+      a callback function.
+    """
+
+    def __init__(self, updated_callback: Optional[Callable[[T], Any]] = None):
+        """
+        Args:
+            updated_callback: A function which will be called when the value is updated.
+        """
+        self.updated_callback = updated_callback
+
+    def value(self) -> Optional[T]:
+        """Returns the latest value or None if it is unknown or invalid."""
+        return None

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -73,7 +73,7 @@ class TTLMonitorWidget(QWidget):
         self.monitor = monitor
         self.monitor.updated_callback = self._setValue
         # widgets
-        self.stateLabel = QLabel("-")
+        self.stateLabel = QLabel("--")
         # layout
         layout = QHBoxLayout(self)
         layout.addWidget(self.stateLabel)

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -97,6 +97,7 @@ class TTLMonitorWidget(QWidget):
     def __init__(self, monitor: TTLMonitor, parent: Optional[QWidget] = None):
         super().__init__(parent=parent)
         self.monitor = monitor
+        self.monitor.updated_callback = self._setValue
         # widgets
         self.stateLabel = QLabel("-")
         # layout

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -94,5 +94,6 @@ class TTLMonitor(Monitor[bool]):
 class TTLMonitorWidget(QWidget):
     """Single TTL channel monitor widget."""
 
-    def __init__(self, parent: Optional[QWidget] = None):
+    def __init__(self, monitor: TTLMonitor, parent: Optional[QWidget] = None):
         super().__init__(parent=parent)
+        self.monitor = monitor

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -5,7 +5,6 @@ from typing import Any, TypeVar, Generic, Optional, Callable
 from PyQt5.QtWidgets import QWidget, QLabel, QHBoxLayout
 from PyQt5.QtCore import pyqtSignal
 
-
 T = TypeVar("T")
 
 

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -2,6 +2,8 @@
 
 from typing import Any, TypeVar, Generic, Optional, Callable
 
+from PyQt5.QtWidgets import QWidget
+
 
 T = TypeVar("T")
 
@@ -73,3 +75,10 @@ class Monitor(Generic[T]):
         in case where self.value() differs from self._value.
         """
         return self._value
+
+
+class TTLMonitorWidget(QWidget):
+    """Single TTL channel monitor widget."""
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        super().__init__(parent=parent)

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -3,7 +3,7 @@
 import enum
 from typing import Any, TypeVar, Generic, Optional, Callable
 
-from PyQt5.QtWidgets import QWidget
+from PyQt5.QtWidgets import QWidget, QLabel, QHBoxLayout
 
 
 T = TypeVar("T")
@@ -97,3 +97,8 @@ class TTLMonitorWidget(QWidget):
     def __init__(self, monitor: TTLMonitor, parent: Optional[QWidget] = None):
         super().__init__(parent=parent)
         self.monitor = monitor
+        # widgets
+        self.stateLabel = QLabel("-")
+        # layout
+        layout = QHBoxLayout(self)
+        layout.addWidget(self.stateLabel)

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -82,9 +82,10 @@ class TTLMonitorWidget(QWidget):
         """Sets the current value on the label.
 
         This method is internal since it is intended to be called only by the monitor callback.
+        It changes the label text based on the value.
         
         Args:
-            value: True, False or None.
+            value: TTL state value which is passed by the monitor.
         """
         if value is None:
             text = "--"

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -87,7 +87,7 @@ class TTLMonitorWidget(QWidget):
         self.monitor = monitor
         self.monitor.updated_callback = self._setValue
         # widgets
-        self.stateLabel = QLabel("--")
+        self.stateLabel = QLabel("--", self)
         # layout
         layout = QHBoxLayout(self)
         layout.addWidget(self.stateLabel)

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -65,17 +65,11 @@ class Monitor(Generic[T]):
         return self._value
 
 
-class TTLMonitor(Monitor[bool]):
+class TTLMonitor(Monitor[Optional[bool]]):
     """Single TTL channel monitor.
     
     The possible states are: True (HIGH), False (LOW) or None (UNKNOWN).
     """
-
-    class State(enum.Enum):
-        """Enum for TTL states."""
-        HIGH = True
-        LOW = False
-        UNKNOWN = None
 
 
 class TTLMonitorWidget(QWidget):
@@ -99,6 +93,10 @@ class TTLMonitorWidget(QWidget):
         Args:
             value: True, False or None.
         """
-        state = TTLMonitor.State(value)
-        text = "-" if state is TTLMonitor.State.UNKNOWN else state.name
+        if value is None:
+            text = "--"
+        elif value:
+            text = "HIGH"
+        else:
+            text = "LOW"
         self.stateLabel.setText(text)

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -83,6 +83,11 @@ class TTLMonitorWidget(QWidget):
     valueUpdated = pyqtSignal(object)
 
     def __init__(self, monitor: Monitor[Optional[bool]], parent: Optional[QWidget] = None):
+        """Extended.
+
+        Args:
+            monitor: A Monitor object whose value will be displayed on the widget.
+        """
         super().__init__(parent=parent)
         self.monitor = monitor
         self.monitor.updated_callback = self._setValue

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -65,7 +65,16 @@ class Monitor(Generic[T]):
 
 
 class TTLMonitorWidget(QWidget):
-    """Single TTL channel monitor widget."""
+    """Single TTL channel monitor widget.
+    
+    Attributes:
+        monitor: A TTL monitor object, whose values are True, False or None, which
+          represent HIGH, LOW or UNDEFINED, respectively.
+          Its updated_callback function is _setValue method of this TTLMonitorWidget instance,
+          which implies that onlt the monitor can change the widget value state.
+        stateLabel: A QLabel object which represents the current monitor value.
+          See _setValue() for the exact text for each state.
+    """
 
     def __init__(self, monitor: Monitor[Optional[bool]], parent: Optional[QWidget] = None):
         super().__init__(parent=parent)

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -31,7 +31,7 @@ class Monitor(Generic[T]):
         self.updated_callback = updated_callback
         self._value = initial_value
 
-    def value(self) -> T:
+    def get_value(self) -> T:
         """Returns the latest value."""
         return self._value
 

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -7,10 +7,13 @@ T = TypeVar("T")
 
 
 class Monitor(Generic[T]):
-    """An interface for a monitor.
+    """A basic monitor class with a generic value type T.
     
     Monitors watch a single value, and notify any change of the value by calling
     a callback function.
+
+    This class can be used as a concrete Monitor if the usage is simple enough
+    and there is no need to implement self._read().
     
     In a Monitor object, there is two kinds of values: the public self.value()
     and the internal self._value.

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -24,11 +24,15 @@ class Monitor(Generic[T]):
         """Returns the latest value or None if it is unknown or invalid."""
         return None
 
-    def update(self) -> Optional[T]:
+    def update(self, callback: bool = True) -> Optional[T]:
         """Returns the current value or None if it is unknown or invalid.
         
         This method will actively read the value and update the current value if it is changed.
         It could be helpful when the monitor is newly created and has no value yet,
         or the value source does not support reporting all the changes.
+
+        Args:
+            callback: Whether to call updated_callback, with the updated value.
+              If updated_callback is None, it is ignored.
         """
         return None

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -3,6 +3,7 @@
 from typing import Any, TypeVar, Generic, Optional, Callable
 
 from PyQt5.QtWidgets import QWidget, QLabel, QHBoxLayout
+from PyQt5.QtCore import pyqtSignal
 
 
 T = TypeVar("T")
@@ -66,6 +67,10 @@ class Monitor(Generic[T]):
 
 class TTLMonitorWidget(QWidget):
     """Single TTL channel monitor widget.
+
+    Signals:
+        valueUpdated: Emitted when the monitor value is updated. The argument is
+          True, False or None.
     
     Attributes:
         monitor: A TTL monitor object, whose values are True, False or None, which
@@ -75,6 +80,8 @@ class TTLMonitorWidget(QWidget):
         stateLabel: A QLabel object which represents the current monitor value.
           See _setValue() for the exact text for each state.
     """
+
+    valueUpdated = pyqtSignal(object)
 
     def __init__(self, monitor: Monitor[Optional[bool]], parent: Optional[QWidget] = None):
         super().__init__(parent=parent)
@@ -101,4 +108,5 @@ class TTLMonitorWidget(QWidget):
             text = "HIGH"
         else:
             text = "LOW"
+        self.valueUpdated.emit(value)
         self.stateLabel.setText(text)

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -65,17 +65,10 @@ class Monitor(Generic[T]):
         return self._value
 
 
-class TTLMonitor(Monitor[Optional[bool]]):
-    """Single TTL channel monitor.
-    
-    The possible states are: True (HIGH), False (LOW) or None (UNKNOWN).
-    """
-
-
 class TTLMonitorWidget(QWidget):
     """Single TTL channel monitor widget."""
 
-    def __init__(self, monitor: TTLMonitor, parent: Optional[QWidget] = None):
+    def __init__(self, monitor: Monitor[Optional[bool]], parent: Optional[QWidget] = None):
         super().__init__(parent=parent)
         self.monitor = monitor
         self.monitor.updated_callback = self._setValue

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -19,10 +19,11 @@ class Monitor(Generic[T]):
             updated_callback: A function which will be called when the value is updated.
         """
         self.updated_callback = updated_callback
+        self._value = None
 
     def value(self) -> Optional[T]:
         """Returns the latest value or None if it is unknown or invalid."""
-        return None
+        return self._value
 
     def update(self, callback: bool = True) -> Optional[T]:
         """Returns the current value or None if it is unknown or invalid.

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -1,0 +1,1 @@
+"""Module for monitoring devices."""

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -1,5 +1,6 @@
 """Module for monitoring devices."""
 
+import enum
 from typing import Any, TypeVar, Generic, Optional, Callable
 
 from PyQt5.QtWidgets import QWidget
@@ -75,6 +76,19 @@ class Monitor(Generic[T]):
         in case where self.value() differs from self._value.
         """
         return self._value
+
+
+class TTLMonitor(Monitor[bool]):
+    """Single TTL channel monitor.
+    
+    The possible states are: True (HIGH), False (LOW) or None (UNKNOWN).
+    """
+
+    class State(enum.Enum):
+        """Enum for TTL states."""
+        HIGH = True
+        LOW = False
+        UNKNOWN = None
 
 
 class TTLMonitorWidget(QWidget):

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -102,3 +102,15 @@ class TTLMonitorWidget(QWidget):
         # layout
         layout = QHBoxLayout(self)
         layout.addWidget(self.stateLabel)
+
+    def _setValue(self, value: Optional[bool]):
+        """Sets the current value on the label.
+
+        This method is internal since it is intended to be called only by the monitor callback.
+        
+        Args:
+            value: True, False or None.
+        """
+        state = TTLMonitor.State(value)
+        text = "-" if state is TTLMonitor.State.UNKNOWN else state.name
+        self.stateLabel.setText(text)

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -27,26 +27,22 @@ class Monitor(Generic[T]):
 
     def __init__(
         self,
+        initial_value: T,
         updated_callback: Optional[Callable[[T], Any]] = None,
-        initial_update: bool = True,
     ):
         """
         Args:
+            initial_value: The initial value of self._value.
             updated_callback: A function which will be called when the value is updated.
-            initial_update: Whether to update the value from the beginning.
-              If True, it updates the value and always call the callback function.
-              If False, it does not update the value, so the current value remains None.
         """
         self.updated_callback = updated_callback
-        self._value = None
-        if initial_update:
-            self.update()
+        self._value = initial_value
 
-    def value(self) -> Optional[T]:
-        """Returns the latest value or None if it is unknown or invalid."""
+    def value(self) -> T:
+        """Returns the latest value."""
         return self._value
 
-    def set_value(self, _value: Optional[T]):
+    def set_value(self, _value: T):
         """Sets the current monitored value.
         
         This method will be called by the value source, to notify the value change.
@@ -67,7 +63,7 @@ class Monitor(Generic[T]):
         """
         self.set_value(self._read())
 
-    def _read(self) -> Optional[T]:
+    def _read(self) -> T:
         """Actively reads the current value and returns it.
         
         Unless this is overriden, it just returns the latest value.

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -13,13 +13,22 @@ class Monitor(Generic[T]):
       a callback function.
     """
 
-    def __init__(self, updated_callback: Optional[Callable[[T], Any]] = None):
+    def __init__(
+        self,
+        updated_callback: Optional[Callable[[T], Any]] = None,
+        initial_update: bool = True,
+    ):
         """
         Args:
             updated_callback: A function which will be called when the value is updated.
+            initial_update: Whether to update the value from the beginning.
+              If True, it updates the value and always call the callback function.
+              If False, it does not update the value, so the current value remains None.
         """
         self.updated_callback = updated_callback
         self._value = None
+        if initial_update:
+            self.update(callback=True)
 
     def value(self) -> Optional[T]:
         """Returns the latest value or None if it is unknown or invalid."""

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -36,4 +36,17 @@ class Monitor(Generic[T]):
             callback: Whether to call updated_callback, with the updated value.
               If updated_callback is None, it is ignored.
         """
-        return None
+        self._value = self._read()
+        if callback and self.updated_callback is not None:
+            self.updated_callback(self.value())
+        return self.value()
+
+    def _read(self) -> Optional[T]:
+        """Actively reads the current value and returns it.
+        
+        Unless this is overriden, it just returns the latest value.
+        
+        The return value must be the same kind of the internal self._value,
+        in case where self.value() differs from self._value.
+        """
+        return self._value

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -75,7 +75,7 @@ class TTLMonitorWidget(QWidget):
         monitor: A TTL monitor object, whose values are True, False or None, which
           represent HIGH, LOW or UNDEFINED, respectively.
           Its updated_callback function is _setValue method of this TTLMonitorWidget instance,
-          which implies that onlt the monitor can change the widget value state.
+          which implies that only the monitor can change the widget value state.
         stateLabel: A QLabel object which represents the current monitor value.
           See _setValue() for the exact text for each state.
     """


### PR DESCRIPTION
This closes #15.

In this PR, only the `Monitor` and `TTLMonitorWidget` are implemented.
Since they are too _abstract_, I will make unit tests for those after this PR.