### PR TITLE
Unit tests for monitor

### DIFF
--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -90,14 +90,14 @@ class TTLMonitorWidget(QWidget):
         """
         super().__init__(parent=parent)
         self.monitor = monitor
-        self.monitor.updated_callback = self._setValue
+        self.monitor.updated_callback = self._updateValue
         # widgets
         self.stateLabel = QLabel("--", self)
         # layout
         layout = QHBoxLayout(self)
         layout.addWidget(self.stateLabel)
 
-    def _setValue(self, value: Optional[bool]):
+    def _updateValue(self, value: Optional[bool]):
         """Sets the current value on the label.
 
         This method is internal since it is intended to be called only by the monitor callback.

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -93,13 +93,15 @@ class TTLMonitorWidget(QWidget):
         self.monitor.updated_callback = self._updateValue
         # widgets
         self.stateLabel = QLabel("--", self)
-        self._setValue(monitor.get_value())
+        self._setTextWith(monitor.get_value())
         # layout
         layout = QHBoxLayout(self)
         layout.addWidget(self.stateLabel)
 
-    def _setValue(self, value: Optional[bool]):
-        """Sets the current value on the label.
+    def _setTextWith(self, value: Optional[bool]):
+        """Sets the current text on the label with value.
+
+        This does not emit any signal.
 
         Args:
             value: TTL state value.
@@ -121,5 +123,5 @@ class TTLMonitorWidget(QWidget):
         Args:
             value: TTL state value which is passed by the monitor.
         """
-        self._setValue(value)
+        self._setTextWith(value)
         self.valueUpdated.emit(value)

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -85,6 +85,8 @@ class TTLMonitorWidget(QWidget):
     def __init__(self, monitor: Monitor[Optional[bool]], parent: Optional[QWidget] = None):
         """Extended.
 
+        Based on the current value of monitor, stateLabel text will be initialized.
+
         Args:
             monitor: A Monitor object whose value will be displayed on the widget.
         """

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -93,6 +93,7 @@ class TTLMonitorWidget(QWidget):
         self.monitor.updated_callback = self._updateValue
         # widgets
         self.stateLabel = QLabel("--", self)
+        self._setValue(monitor.get_value())
         # layout
         layout = QHBoxLayout(self)
         layout.addWidget(self.stateLabel)

--- a/iquip/monitor.py
+++ b/iquip/monitor.py
@@ -97,14 +97,11 @@ class TTLMonitorWidget(QWidget):
         layout = QHBoxLayout(self)
         layout.addWidget(self.stateLabel)
 
-    def _updateValue(self, value: Optional[bool]):
+    def _setValue(self, value: Optional[bool]):
         """Sets the current value on the label.
 
-        This method is internal since it is intended to be called only by the monitor callback.
-        It changes the label text based on the value.
-        
         Args:
-            value: TTL state value which is passed by the monitor.
+            value: TTL state value.
         """
         if value is None:
             text = "--"
@@ -112,5 +109,16 @@ class TTLMonitorWidget(QWidget):
             text = "HIGH"
         else:
             text = "LOW"
-        self.valueUpdated.emit(value)
         self.stateLabel.setText(text)
+
+    def _updateValue(self, value: Optional[bool]):
+        """Updates the current value on the label and emits the signal.
+
+        This method is internal since it is intended to be called only by the monitor callback.
+        It changes the label text based on the value.
+        
+        Args:
+            value: TTL state value which is passed by the monitor.
+        """
+        self._setValue(value)
+        self.valueUpdated.emit(value)

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -1,0 +1,17 @@
+[MASTER]
+extension-pkg-whitelist=PyQt5
+init-hook="from pylint.config import find_pylintrc; from pathlib import Path; import sys; sys.path.append(str(Path(find_pylintrc()).parent))"
+
+[BASIC]
+argument-rgx=_?_?(?:(?:[a-z0-9]+(?:_[a-z0-9]+)*_?_?)|(?:[a-z0-9]+(?:[A-Z][a-z0-9]*)*))$
+attr-rgx=_?_?(?:(?:[a-z0-9]+(?:_[a-z0-9]+)*_?_?)|(?:[a-z0-9]+(?:[A-Z][a-z0-9]*)*))$
+method-rgx=_?_?(?:(?:[a-z0-9]+(?:_[a-z0-9]+)*_?_?)|(?:[a-z0-9]+(?:[A-Z][a-z0-9]*)*))$
+variable-rgx=_?_?(?:(?:[a-z0-9]+(?:_[a-z0-9]+)*_?_?)|(?:[a-z0-9]+(?:[A-Z][a-z0-9]*)*))$
+
+[MESSAGES CONTROL]
+disable=
+    missing-docstring,
+    protected-access,
+
+[TYPECHECK]
+ignored-modules=qiwis

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -1,6 +1,5 @@
 [MASTER]
 extension-pkg-whitelist=PyQt5
-init-hook="from pylint.config import find_pylintrc; from pathlib import Path; import sys; sys.path.append(str(Path(find_pylintrc()).parent))"
 
 [BASIC]
 argument-rgx=_?_?(?:(?:[a-z0-9]+(?:_[a-z0-9]+)*_?_?)|(?:[a-z0-9]+(?:[A-Z][a-z0-9]*)*))$

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -12,6 +12,3 @@ variable-rgx=_?_?(?:(?:[a-z0-9]+(?:_[a-z0-9]+)*_?_?)|(?:[a-z0-9]+(?:[A-Z][a-z0-9
 disable=
     missing-docstring,
     protected-access,
-
-[TYPECHECK]
-ignored-modules=qiwis

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -81,10 +81,13 @@ class TestTTLMonitorWidget(unittest.TestCase):
             mocked_set_value.assert_called_once_with(True)
             callback.assert_not_called()
 
-    def test_init_label(self):
+    def test_set_value(self):
         for value, text in ((True, "HIGH"), (False, "LOW"), (None, "--")):
-            _, widget = self.get_widget_with(value)
+            _, widget = self.get_widget_with(None)
+            with mock.patch.object(widget, "valueUpdated") as mocked_signal:
+                widget._setValue(value)
             self.assertEqual(widget.stateLabel.text(), text)
+            mocked_signal.assert_not_called()
 
     def get_widget_with(
         self,

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -62,7 +62,7 @@ class TestTTLMonitorWidget(unittest.TestCase):
 
     def setUp(self):
         self.qapp = QApplication([])
-    
+
     def tearDown(self):
         del self.qapp
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -78,8 +78,8 @@ class TestTTLMonitorWidget(unittest.TestCase):
         with mock.patch.object(monitor.TTLMonitorWidget, "_updateValue") as mocked_set_value:
             widget = monitor.TTLMonitorWidget(monitor=mon)
             widget.monitor.updated_callback(True)
-            mocked_set_value.assert_called_once_with(True)
-            callback.assert_not_called()
+        mocked_set_value.assert_called_once_with(True)
+        callback.assert_not_called()
 
     def test_set_text_with(self):
         for value, text in ((True, "HIGH"), (False, "LOW"), (None, "--")):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -2,6 +2,9 @@
 
 import unittest
 from unittest import mock
+from typing import Optional
+
+from PyQt5.QtWidgets import QApplication
 
 from iquip import monitor
 
@@ -52,6 +55,21 @@ class TestMonitor(unittest.TestCase):
         """
         mon = monitor.Monitor(initial_value="value")
         self.assertEqual(mon._read(), mon._value)
+
+
+class TestTTLMonitorWidget(unittest.TestCase):
+    """Unit tests for TTLMonitorWidget class."""
+
+    def setUp(self):
+        self.qapp = QApplication([])
+    
+    def tearDown(self):
+        del self.qapp
+
+    def test_init_monitor(self):
+        mon = monitor.Monitor[Optional[bool]](initial_value=None)
+        widget = monitor.TTLMonitorWidget(monitor=mon)
+        self.assertIs(widget.monitor, mon)
 
 
 if __name__ == "__main__":

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -67,7 +67,7 @@ class TestTTLMonitorWidget(unittest.TestCase):
         del self.qapp
 
     def test_init_monitor(self):
-        mon, widget = self.get_widget_with(None)
+        mon, widget = get_ttl_monitor_widget_with(None)
         self.assertIs(widget.monitor, mon)
 
     def test_init_callback(self):
@@ -83,31 +83,31 @@ class TestTTLMonitorWidget(unittest.TestCase):
 
     def test_set_text_with(self):
         for value, text in ((True, "HIGH"), (False, "LOW"), (None, "--")):
-            _, widget = self.get_widget_with(None)
+            _, widget = get_ttl_monitor_widget_with(None)
             with mock.patch.object(widget, "valueUpdated") as mocked_signal:
                 widget._setTextWith(value)
             self.assertEqual(widget.stateLabel.text(), text)
             mocked_signal.assert_not_called()
 
     def test_update_value(self):
-        _, widget = self.get_widget_with(None)
+        _, widget = get_ttl_monitor_widget_with(None)
         with mock.patch.multiple(widget, _setTextWith=mock.DEFAULT, valueUpdated=mock.DEFAULT):
             widget._updateValue(True)
             widget._setTextWith.assert_called_once_with(True)
             widget.valueUpdated.emit.assert_called_once_with(True)
 
-    def get_widget_with(
-        self,
-        initial_value: Optional[bool],
-    ) -> Tuple[monitor.Monitor[Optional[bool]], monitor.TTLMonitorWidget]:
-        """Returns a new TTLMonitorWidget and Monitor with initial_value.
 
-        Args:
-            initial_value: The initial value of the new Monitor.
-        """
-        mon = monitor.Monitor[Optional[bool]](initial_value=initial_value)
-        widget = monitor.TTLMonitorWidget(monitor=mon)
-        return mon, widget
+def get_ttl_monitor_widget_with(
+    initial_value: Optional[bool],
+) -> Tuple[monitor.Monitor[Optional[bool]], monitor.TTLMonitorWidget]:
+    """Returns a new TTLMonitorWidget and Monitor with initial_value.
+
+    Args:
+        initial_value: The initial value of the new Monitor.
+    """
+    mon = monitor.Monitor[Optional[bool]](initial_value=initial_value)
+    widget = monitor.TTLMonitorWidget(monitor=mon)
+    return mon, widget
 
 
 if __name__ == "__main__":

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -76,7 +76,7 @@ class TestTTLMonitorWidget(unittest.TestCase):
         callback = mock.MagicMock()
         mon = monitor.Monitor[Optional[bool]](
             initial_value=None, updated_callback=callback)
-        with mock.patch.object(monitor.TTLMonitorWidget, "_setValue") as mocked_set_value:
+        with mock.patch.object(monitor.TTLMonitorWidget, "_updateValue") as mocked_set_value:
             widget = monitor.TTLMonitorWidget(monitor=mon)
             widget.monitor.updated_callback(True)
             mocked_set_value.assert_called_once_with(True)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -89,6 +89,13 @@ class TestTTLMonitorWidget(unittest.TestCase):
             self.assertEqual(widget.stateLabel.text(), text)
             mocked_signal.assert_not_called()
 
+    def test_update_value(self):
+        _, widget = self.get_widget_with(None)
+        with mock.patch.multiple(widget, _setTextWith=mock.DEFAULT, valueUpdated=mock.DEFAULT):
+            widget._updateValue(True)
+            widget._setTextWith.assert_called_once_with(True)
+            widget.valueUpdated.emit.assert_called_once_with(True)
+
     def get_widget_with(
         self,
         initial_value: Optional[bool],

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -42,10 +42,10 @@ class TestMonitor(unittest.TestCase):
 
     def test_update(self):
         mon = monitor.Monitor(initial_value="old")
-        with mock.patch.multiple(mon, set_value=mock.DEFAULT, _read=mock.DEFAULT):
-            mon._read.return_value = "new"
+        with mock.patch.multiple(mon, set_value=mock.DEFAULT, _read=mock.DEFAULT) as mocked:
+            mocked["_read"].return_value = "new"
             mon.update()
-            mon.set_value.assert_called_once_with("new")
+        mocked["set_value"].assert_called_once_with("new")
 
     def test_read(self):
         """Tests if _read() returns self._value.

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -22,6 +22,10 @@ class TestMonitor(unittest.TestCase):
         mon.updated_callback(None)
         callback.assert_called_once_with(None)
 
+    def test_init_updated_callback_default(self):
+        mon = monitor.Monitor(initial_value="value")
+        self.assertIsNone(mon.updated_callback)
+
     def test_get_value(self):
         for value in (True, None, 1.0, "value", object()):
             mon = monitor.Monitor(initial_value=value)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -11,12 +11,12 @@ from iquip import monitor
 class TestMonitor(unittest.TestCase):
     """Unit tests for Monitor class."""
 
-    def test_initial_value(self):
+    def test_init_initial_value(self):
         for value in (True, None, 1.0, "value", object()):
             mon = monitor.Monitor(initial_value=value)
             self.assertEqual(mon._value, value)
 
-    def test_updated_callback(self):
+    def test_init_updated_callback(self):
         callback = mock.MagicMock()
         mon = monitor.Monitor(initial_value=None, updated_callback=callback)
         mon.updated_callback(None)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,6 +1,7 @@
 """Unit tests for monitor module."""
 
 import unittest
+from unittest import mock
 
 from iquip import monitor
 
@@ -11,6 +12,12 @@ class TestMonitor(unittest.TestCase):
         for value in (True, None, 1.0, "value", object()):
             mon = monitor.Monitor(initial_value=value)
             self.assertEqual(mon._value, value)
+
+    def test_updated_callback(self):
+        callback = mock.MagicMock()
+        mon = monitor.Monitor(initial_value=None, updated_callback=callback)
+        mon.updated_callback(None)
+        callback.assert_called_once_with(None)
 
 
 if __name__ == "__main__":

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -37,6 +37,13 @@ class TestMonitor(unittest.TestCase):
         mon.set_value("new")
         callback.assert_called_once_with("new")
 
+    def test_update(self):
+        mon = monitor.Monitor(initial_value="old")
+        with mock.patch.multiple(mon, set_value=mock.DEFAULT, _read=mock.DEFAULT):
+            mon._read.return_value = "new"
+            mon.update()
+            mon.set_value.assert_called_once_with("new")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -81,11 +81,11 @@ class TestTTLMonitorWidget(unittest.TestCase):
             mocked_set_value.assert_called_once_with(True)
             callback.assert_not_called()
 
-    def test_set_value(self):
+    def test_set_text_with(self):
         for value, text in ((True, "HIGH"), (False, "LOW"), (None, "--")):
             _, widget = self.get_widget_with(None)
             with mock.patch.object(widget, "valueUpdated") as mocked_signal:
-                widget._setValue(value)
+                widget._setTextWith(value)
             self.assertEqual(widget.stateLabel.text(), text)
             mocked_signal.assert_not_called()
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -44,6 +44,15 @@ class TestMonitor(unittest.TestCase):
             mon.update()
             mon.set_value.assert_called_once_with("new")
 
+    def test_read(self):
+        """Tests if _read() returns self._value.
+
+        Although _read() will be overridden in most cases,
+        this tests the default behavior of this method.
+        """
+        mon = monitor.Monitor(initial_value="value")
+        self.assertEqual(mon._read(), mon._value)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -19,6 +19,11 @@ class TestMonitor(unittest.TestCase):
         mon.updated_callback(None)
         callback.assert_called_once_with(None)
 
+    def test_get_value(self):
+        for value in (True, None, 1.0, "value", object()):
+            mon = monitor.Monitor(initial_value=value)
+            self.assertEqual(mon.get_value(), mon._value)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -71,6 +71,17 @@ class TestTTLMonitorWidget(unittest.TestCase):
         widget = monitor.TTLMonitorWidget(monitor=mon)
         self.assertIs(widget.monitor, mon)
 
+    def test_init_callback(self):
+        """Tests if the updated_callback is overwritten by _setValue()."""
+        callback = mock.MagicMock()
+        mon = monitor.Monitor[Optional[bool]](
+            initial_value=None, updated_callback=callback)
+        with mock.patch.object(monitor.TTLMonitorWidget, "_setValue") as mocked_set_value:
+            widget = monitor.TTLMonitorWidget(monitor=mon)
+            widget.monitor.updated_callback(True)
+            mocked_set_value.assert_called_once_with(True)
+            callback.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -91,10 +91,12 @@ class TestTTLMonitorWidget(unittest.TestCase):
 
     def test_update_value(self):
         _, widget = get_ttl_monitor_widget_with(None)
-        with mock.patch.multiple(widget, _setTextWith=mock.DEFAULT, valueUpdated=mock.DEFAULT):
+        with mock.patch.multiple(
+            widget, _setTextWith=mock.DEFAULT, valueUpdated=mock.DEFAULT
+        ) as mocked:
             widget._updateValue(True)
-            widget._setTextWith.assert_called_once_with(True)
-            widget.valueUpdated.emit.assert_called_once_with(True)
+        mocked["_setTextWith"].assert_called_once_with(True)
+        mocked["valueUpdated"].emit.assert_called_once_with(True)
 
 
 def get_ttl_monitor_widget_with(

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -2,7 +2,7 @@
 
 import unittest
 from unittest import mock
-from typing import Optional
+from typing import Optional, Tuple
 
 from PyQt5.QtWidgets import QApplication
 
@@ -67,8 +67,7 @@ class TestTTLMonitorWidget(unittest.TestCase):
         del self.qapp
 
     def test_init_monitor(self):
-        mon = monitor.Monitor[Optional[bool]](initial_value=None)
-        widget = monitor.TTLMonitorWidget(monitor=mon)
+        mon, widget = self.get_widget_with(None)
         self.assertIs(widget.monitor, mon)
 
     def test_init_callback(self):
@@ -84,9 +83,21 @@ class TestTTLMonitorWidget(unittest.TestCase):
 
     def test_init_label(self):
         for value, text in ((True, "HIGH"), (False, "LOW"), (None, "--")):
-            mon = monitor.Monitor[Optional[bool]](initial_value=value)
-            widget = monitor.TTLMonitorWidget(monitor=mon)
+            _, widget = self.get_widget_with(value)
             self.assertEqual(widget.stateLabel.text(), text)
+
+    def get_widget_with(
+        self,
+        initial_value: Optional[bool],
+    ) -> Tuple[monitor.Monitor[Optional[bool]], monitor.TTLMonitorWidget]:
+        """Returns a new TTLMonitorWidget and Monitor with initial_value.
+
+        Args:
+            initial_value: The initial value of the new Monitor.
+        """
+        mon = monitor.Monitor[Optional[bool]](initial_value=initial_value)
+        widget = monitor.TTLMonitorWidget(monitor=mon)
+        return mon, widget
 
 
 if __name__ == "__main__":

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,1 @@
+"""Unit tests for monitor module."""

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -82,6 +82,12 @@ class TestTTLMonitorWidget(unittest.TestCase):
             mocked_set_value.assert_called_once_with(True)
             callback.assert_not_called()
 
+    def test_init_label(self):
+        for value, text in ((True, "HIGH"), (False, "LOW"), (None, "--")):
+            mon = monitor.Monitor[Optional[bool]](initial_value=value)
+            widget = monitor.TTLMonitorWidget(monitor=mon)
+            self.assertEqual(widget.stateLabel.text(), text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,1 +1,17 @@
 """Unit tests for monitor module."""
+
+import unittest
+
+from iquip import monitor
+
+class TestMonitor(unittest.TestCase):
+    """Unit tests for Monitor class."""
+
+    def test_initial_value(self):
+        for value in (True, None, 1.0, "value", object()):
+            mon = monitor.Monitor(initial_value=value)
+            self.assertEqual(mon._value, value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -31,6 +31,12 @@ class TestMonitor(unittest.TestCase):
             mon.set_value(new_value)
             self.assertEqual(mon._value, new_value)
 
+    def test_set_value_callback(self):
+        callback = mock.MagicMock()
+        mon = monitor.Monitor(initial_value="old", updated_callback=callback)
+        mon.set_value("new")
+        callback.assert_called_once_with("new")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -24,6 +24,13 @@ class TestMonitor(unittest.TestCase):
             mon = monitor.Monitor(initial_value=value)
             self.assertEqual(mon.get_value(), mon._value)
 
+    def test_set_value(self):
+        values = ((True, False), (1, 0), ("old", "new"))
+        for init_value, new_value in values:
+            mon = monitor.Monitor(initial_value=init_value)
+            mon.set_value(new_value)
+            self.assertEqual(mon._value, new_value)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This closes #24.

I apologize for the large diffs..

This PR includes:
- Unit tests for the current `iquip.monitor` module (implemented in #23)
- Tiny improvement in `iquip.monitor`: initialization of state label text
- `.pylintrc` file for pylinting test codes

You can run the unit test by:
```console
python -m unittest tests.test_monitor
```

You can run the pylint checker by:
```console
pylint tests.test_monitor --rcfile tests/.pylintrc
```