### PR TITLE
Implement additional functions of explorer

### DIFF
--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -1,5 +1,6 @@
 """App module for showing the experiment list and opening an experiment."""
 
+import threading
 import posixpath
 from typing import Optional, Tuple, Union
 
@@ -54,8 +55,8 @@ class ExplorerApp(qiwis.BaseApp):  # pylint: disable=too-few-public-methods
         It assumes that all experiment files are in self.repositoryPath.
         """
         self.explorerFrame.fileTree.clear()
-        self._addFile(self.repositoryPath, self.explorerFrame.fileTree)
-
+        threading.Thread(target=lambda: self._addFile(self.repositoryPath, self.explorerFrame.fileTree)).start()
+        
     def _addFile(self, path: str, parent: Union[QTreeWidget, QTreeWidgetItem]):
         """Searches all files in path and adds them into parent.
 

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -33,10 +33,10 @@ class ExplorerFrame(QWidget):
 
 class FileFinderThread(QThread):
     """QThread for finding the file list using a command line.
-    
+
     Signals:
         finished(experimentList): Fetching the file list is finished.
-    
+
     Attributes:
         path: The path of the directory to search experiment files.
         parent: The widget corresponding to the path.
@@ -45,8 +45,18 @@ class FileFinderThread(QThread):
     finished = pyqtSignal(list)
 
     def __init__(self, path: str, parent: Union[QTreeWidget, QTreeWidgetItem]):
+        super().__init__()
         self.path = path
         self.parent = parent
+
+    def run(self):
+        """Fetches the file list using a command line.
+
+        After finished, the finished signal is emitted.
+        """
+        experimentList = cmdtools.run_command(f"artiq_client ls {self.path}").stdout
+        experimentList = experimentList.split("\n")[:-1]  # The last one is always an empty string.
+        self.finished.emit(experimentList)
 
 
 class ExplorerApp(qiwis.BaseApp):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -124,11 +124,12 @@ class ExplorerApp(qiwis.BaseApp):
         Args:
             experimentFileItem: The file item to get its full path.
         """
-        path = experimentFileItem.text(0)
+        path = [experimentFileItem.text(0)]
         while experimentFileItem.parent():
             experimentFileItem = experimentFileItem.parent()
-            path = posixpath.join(experimentFileItem.text(0), path)
-        path = posixpath.join(self.repositoryPath, path)
+            path.append(experimentFileItem.text(0))
+        path.append(self.repositoryPath)
+        path = posixpath.join(*reversed(path))
         return path
 
     def frames(self) -> Tuple[ExplorerFrame]:

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -34,14 +34,14 @@ class _FileFinderThread(QThread):
     """QThread for finding the file list using a command line.
 
     Signals:
-        finished(experimentList, widget): Fetching the file list is finished.
+        fetched(experimentList, widget): The file list is fetched.
 
     Attributes:
         path: The path of the directory to search for experiment files.
         widget: The widget corresponding to the path.
     """
 
-    finished = pyqtSignal(list, object)
+    fetched = pyqtSignal(list, object)
 
     def __init__(
         self,
@@ -59,7 +59,7 @@ class _FileFinderThread(QThread):
         super().__init__(parent=parent)
         self.path = path
         self.widget = widget
-        self.finished.connect(callback)
+        self.fetched.connect(callback)
 
     def run(self):
         """Overridden.
@@ -67,11 +67,11 @@ class _FileFinderThread(QThread):
         Fetches the file list using a command line.
 
         Searches for only files in path, not in deeper path and adds them into the widget.
-        After finished, the finished signal is emitted.
+        After finished, the fetched signal is emitted.
         """
         experimentList = cmdtools.run_command(f"artiq_client ls {self.path}").stdout
         experimentList = experimentList.split("\n")[:-1]  # The last one is always an empty string.
-        self.finished.emit(experimentList, self.widget)
+        self.fetched.emit(experimentList, self.widget)
 
 
 class ExplorerApp(qiwis.BaseApp):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -34,11 +34,11 @@ class FileFinderThread(QThread):
     """QThread for finding the file list using a command line.
 
     Signals:
-        finished(experimentList, parent): Fetching the file list is finished.
+        finished(experimentList, widget): Fetching the file list is finished.
 
     Attributes:
         path: The path of the directory to search for experiment files.
-        parent: The widget corresponding to the path.
+        widget: The widget corresponding to the path.
     """
 
     finished = pyqtSignal(list, object)
@@ -46,7 +46,7 @@ class FileFinderThread(QThread):
     def __init__(
         self,
         path: str,
-        parent: Union[QTreeWidget, QTreeWidgetItem],
+        widget: Union[QTreeWidget, QTreeWidgetItem],
         callback: Callable[[List[str], Union[QTreeWidget, QTreeWidgetItem]], None]
     ):
         """
@@ -55,13 +55,13 @@ class FileFinderThread(QThread):
         """
         super().__init__()
         self.path = path
-        self.parent = parent
+        self.widget = widget
         self.finished.connect(callback)
 
     def run(self):
         """Fetches the file list using a command line.
 
-        Searches for only files in path, not in deeper path and adds them into parent.
+        Searches for only files in path, not in deeper path and adds them into the widget.
         After finished, the finished signal is emitted.
         """
         experimentList = cmdtools.run_command(f"artiq_client ls {self.path}").stdout

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -73,7 +73,7 @@ class ExplorerApp(qiwis.BaseApp):
         if experimentFileItem.childCount() != 1 or experimentFileItem.child(0).columnCount() != 0:
             return
         # Remove the empty item of an unloaded directory.
-        experimentFileItem.removeChild(experimentFileItem.child(0))
+        experimentFileItem.takeChild(0)
         experimentPath = self.getFullPath(experimentFileItem)
         threading.Thread(
             target=lambda: self._addFile(experimentPath, experimentFileItem)

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -62,7 +62,8 @@ class ExplorerApp(qiwis.BaseApp):
 
     @pyqtSlot(QTreeWidgetItem)
     def lazyLoadFile(self, item: QTreeWidgetItem):
-        pass
+        if item.childCount() != 1 or item.child(0).columnCount() != 0:
+            return
 
     # pylint: disable=no-self-use
     def _addFile(self, path: str, parent: Union[QTreeWidget, QTreeWidgetItem]):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -118,7 +118,7 @@ class ExplorerApp(qiwis.BaseApp):
 
     def getFullPath(self, experimentFileItem: QTreeWidgetItem) -> str:
         """Finds the full path of the file item and returns it.
-        
+
         Args:
             experimentFileItem: The file item to get its full path.
         """

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -49,9 +49,11 @@ class FileFinderThread(QThread):
         widget: Union[QTreeWidget, QTreeWidgetItem],
         callback: Callable[[List[str], Union[QTreeWidget, QTreeWidgetItem]], None]
     ):
-        """
+        """Extended.
+
         Args:
             callback: The callback method called after this thread is finished.
+            See the attributes section in FileFinderThread.
         """
         super().__init__()
         self.path = path
@@ -66,7 +68,7 @@ class FileFinderThread(QThread):
         """
         experimentList = cmdtools.run_command(f"artiq_client ls {self.path}").stdout
         experimentList = experimentList.split("\n")[:-1]  # The last one is always an empty string.
-        self.finished.emit(experimentList, self.parent)
+        self.finished.emit(experimentList, self.widget)
 
 
 class ExplorerApp(qiwis.BaseApp):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -78,7 +78,6 @@ class ExplorerApp(qiwis.BaseApp):
             target=lambda: self._addFile(experimentPath, experimentFileItem)
         ).start()
 
-    # pylint: disable=no-self-use
     def _addFile(self, path: str, parent: Union[QTreeWidget, QTreeWidgetItem]):
         """Searches only files in path, not in deeper path and adds them into parent.
 

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -37,7 +37,7 @@ class FileFinderThread(QThread):
         finished(experimentList, parent): Fetching the file list is finished.
 
     Attributes:
-        path: The path of the directory to search experiment files.
+        path: The path of the directory to search for experiment files.
         parent: The widget corresponding to the path.
     """
 

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -4,7 +4,7 @@ import threading
 import posixpath
 from typing import Optional, Tuple, Union
 
-from PyQt5.QtCore import QObject, pyqtSlot
+from PyQt5.QtCore import QObject, QThread, pyqtSlot
 from PyQt5.QtWidgets import (
     QPushButton, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 )
@@ -29,6 +29,10 @@ class ExplorerFrame(QWidget):
         layout.addWidget(self.reloadButton)
         layout.addWidget(self.fileTree)
         layout.addWidget(self.openButton)
+
+
+class FileFinderThread(QThread):
+    """QThread for finding the file list using a command line."""
 
 
 class ExplorerApp(qiwis.BaseApp):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -32,9 +32,13 @@ class ExplorerFrame(QWidget):
 
 
 class FileFinderThread(QThread):
-    """QThread for finding the file list using a command line."""
+    """QThread for finding the file list using a command line.
+    
+    Signals:
+        finished(experimentList): Fetching the file list is finished.
+    """
 
-    finished = pyqtSignal()
+    finished = pyqtSignal(list)
 
 
 class ExplorerApp(qiwis.BaseApp):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -4,7 +4,7 @@ import threading
 import posixpath
 from typing import Optional, Tuple, Union
 
-from PyQt5.QtCore import QObject, QThread, pyqtSlot
+from PyQt5.QtCore import QObject, QThread, pyqtSlot, pyqtSignal
 from PyQt5.QtWidgets import (
     QPushButton, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 )
@@ -33,6 +33,8 @@ class ExplorerFrame(QWidget):
 
 class FileFinderThread(QThread):
     """QThread for finding the file list using a command line."""
+
+    finished = pyqtSignal()
 
 
 class ExplorerApp(qiwis.BaseApp):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -57,7 +57,8 @@ class ExplorerApp(qiwis.BaseApp):
         """
         self.explorerFrame.fileTree.clear()
         threading.Thread(
-            target=lambda: self._addFile(self.repositoryPath, self.explorerFrame.fileTree)
+            target=self._addFile,
+            args=(self.repositoryPath, self.explorerFrame.fileTree)
         ).start()
 
     @pyqtSlot(QTreeWidgetItem)
@@ -76,7 +77,8 @@ class ExplorerApp(qiwis.BaseApp):
         experimentFileItem.takeChild(0)
         experimentPath = self.getFullPath(experimentFileItem)
         threading.Thread(
-            target=lambda: self._addFile(experimentPath, experimentFileItem)
+            target=self._addFile,
+            args=(experimentPath, experimentFileItem)
         ).start()
 
     def _addFile(self, path: str, parent: Union[QTreeWidget, QTreeWidgetItem]):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -36,9 +36,17 @@ class FileFinderThread(QThread):
     
     Signals:
         finished(experimentList): Fetching the file list is finished.
+    
+    Attributes:
+        path: The path of the directory to search experiment files.
+        parent: The widget corresponding to the path.
     """
 
     finished = pyqtSignal(list)
+
+    def __init__(self, path: str, parent: Union[QTreeWidget, QTreeWidgetItem]):
+        self.path = path
+        self.parent = parent
 
 
 class ExplorerApp(qiwis.BaseApp):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -52,11 +52,12 @@ class FileFinderThread(QThread):
     def run(self):
         """Fetches the file list using a command line.
 
+        Searches only files in path, not in deeper path and adds them into parent.
         After finished, the finished signal is emitted.
         """
         experimentList = cmdtools.run_command(f"artiq_client ls {self.path}").stdout
         experimentList = experimentList.split("\n")[:-1]  # The last one is always an empty string.
-        self.finished.emit(experimentList)
+        self.finished.emit(experimentList, self.parent)
 
 
 class ExplorerApp(qiwis.BaseApp):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -61,7 +61,9 @@ class FileFinderThread(QThread):
         self.finished.connect(callback)
 
     def run(self):
-        """Fetches the file list using a command line.
+        """Overridden.
+        
+        Fetches the file list using a command line.
 
         Searches for only files in path, not in deeper path and adds them into the widget.
         After finished, the finished signal is emitted.

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -53,8 +53,8 @@ class _FileFinderThread(QThread):
         """Extended.
 
         Args:
+            path, widget: See the attributes section in _FileFinderThread.
             callback: The callback method called after this thread is finished.
-            See the attributes section in _FileFinderThread.
         """
         super().__init__(parent=parent)
         self.path = path

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -3,7 +3,7 @@
 import posixpath
 from typing import Callable, List, Optional, Tuple, Union
 
-from PyQt5.QtCore import QObject, QThread, pyqtSlot, pyqtSignal
+from PyQt5.QtCore import QObject, Qt, QThread, pyqtSlot, pyqtSignal
 from PyQt5.QtWidgets import (
     QPushButton, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 )
@@ -59,7 +59,7 @@ class _FileFinderThread(QThread):
         super().__init__(parent=parent)
         self.path = path
         self.widget = widget
-        self.fetched.connect(callback)
+        self.fetched.connect(callback, type=Qt.QueuedConnection)
 
     def run(self):
         """Overridden.

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -47,7 +47,8 @@ class FileFinderThread(QThread):
         self,
         path: str,
         widget: Union[QTreeWidget, QTreeWidgetItem],
-        callback: Callable[[List[str], Union[QTreeWidget, QTreeWidgetItem]], None]
+        callback: Callable[[List[str], Union[QTreeWidget, QTreeWidgetItem]], None],
+        parent: Optional[QObject] = None
     ):
         """Extended.
 
@@ -55,7 +56,7 @@ class FileFinderThread(QThread):
             callback: The callback method called after this thread is finished.
             See the attributes section in FileFinderThread.
         """
-        super().__init__()
+        super().__init__(parent=parent)
         self.path = path
         self.widget = widget
         self.finished.connect(callback)
@@ -101,7 +102,8 @@ class ExplorerApp(qiwis.BaseApp):
         self.thread = FileFinderThread(
             self.repositoryPath,
             self.explorerFrame.fileTree,
-            self._addFile
+            self._addFile,
+            self
         )
         self.thread.start()
 
@@ -123,7 +125,8 @@ class ExplorerApp(qiwis.BaseApp):
         self.thread = FileFinderThread(
             experimentPath,
             experimentFileItem,
-            self._addFile
+            self._addFile,
+            self
         )
         self.thread.start()
 

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -30,7 +30,7 @@ class ExplorerFrame(QWidget):
         layout.addWidget(self.openButton)
 
 
-class FileFinderThread(QThread):
+class _FileFinderThread(QThread):
     """QThread for finding the file list using a command line.
 
     Signals:
@@ -54,7 +54,7 @@ class FileFinderThread(QThread):
 
         Args:
             callback: The callback method called after this thread is finished.
-            See the attributes section in FileFinderThread.
+            See the attributes section in _FileFinderThread.
         """
         super().__init__(parent=parent)
         self.path = path
@@ -99,7 +99,7 @@ class ExplorerApp(qiwis.BaseApp):
         It assumes that all experiment files are in self.repositoryPath.
         """
         self.explorerFrame.fileTree.clear()
-        self.thread = FileFinderThread(
+        self.thread = _FileFinderThread(
             self.repositoryPath,
             self.explorerFrame.fileTree,
             self._addFile,
@@ -122,7 +122,7 @@ class ExplorerApp(qiwis.BaseApp):
         # Remove the empty item of an unloaded directory.
         experimentFileItem.takeChild(0)
         experimentPath = self.fullPath(experimentFileItem)
-        self.thread = FileFinderThread(
+        self.thread = _FileFinderThread(
             experimentPath,
             experimentFileItem,
             self._addFile,
@@ -137,7 +137,7 @@ class ExplorerApp(qiwis.BaseApp):
 
         Args:
             experimentList: The list of files under the parent path.
-            parent: See FileFinderThread class.
+            parent: See _FileFinderThread class.
         """
         for experimentFile in experimentList:
             if experimentFile.startswith("_"):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -45,6 +45,7 @@ class ExplorerApp(qiwis.BaseApp):
         self.explorerFrame = ExplorerFrame()
         self.loadFileTree()
         # connect signals to slots
+        self.explorerFrame.fileTree.itemExpanded.connect(self.lazyLoadFile)
         self.explorerFrame.reloadButton.clicked.connect(self.loadFileTree)
         self.explorerFrame.openButton.clicked.connect(self.openExperiment)
 
@@ -58,6 +59,10 @@ class ExplorerApp(qiwis.BaseApp):
         threading.Thread(
             target=lambda: self._addFile(self.repositoryPath, self.explorerFrame.fileTree)
         ).start()
+
+    @pyqtSlot(QTreeWidgetItem)
+    def lazyLoadFile(self, item: QTreeWidgetItem):
+        pass
 
     # pylint: disable=no-self-use
     def _addFile(self, path: str, parent: Union[QTreeWidget, QTreeWidgetItem]):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -102,12 +102,15 @@ class ExplorerApp(qiwis.BaseApp):
         experimentFileItem = self.explorerFrame.fileTree.currentItem()
         if experimentFileItem.childCount():
             return
-        experimentPath = experimentFileItem.text(0)
-        while experimentFileItem.parent():
-            experimentFileItem = experimentFileItem.parent()
-            experimentPath = posixpath.join(experimentFileItem.text(0), experimentPath)
-        experimentPath = posixpath.join(self.repositoryPath, experimentPath)
+        experimentPath = self.getFullPath(experimentFileItem)  # pylint: disable=unused-variable
 
+    def getFullPath(self, item: QTreeWidgetItem):
+        path = item.text(0)
+        while item.parent():
+            item = item.parent()
+            path = posixpath.join(item.text(0), path)
+        path = posixpath.join(self.repositoryPath, path)
+        return path
 
     def frames(self) -> Tuple[ExplorerFrame]:
         """Overridden."""

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -1,6 +1,5 @@
 """App module for showing the experiment list and opening an experiment."""
 
-import threading
 import posixpath
 from typing import Callable, List, Optional, Tuple, Union
 

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -171,13 +171,12 @@ class ExplorerApp(qiwis.BaseApp):
         Args:
             experimentFileItem: The file item to get its full path.
         """
-        path = [experimentFileItem.text(0)]
+        paths = [experimentFileItem.text(0)]
         while experimentFileItem.parent():
             experimentFileItem = experimentFileItem.parent()
-            path.append(experimentFileItem.text(0))
-        path.append(self.repositoryPath)
-        path = posixpath.join(*reversed(path))
-        return path
+            paths.append(experimentFileItem.text(0))
+        paths.append(self.repositoryPath)
+        return posixpath.join(*reversed(paths))
 
     def frames(self) -> Tuple[ExplorerFrame]:
         """Overridden."""

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -161,8 +161,6 @@ class ExplorerApp(qiwis.BaseApp):
         TODO(BECATRUE): Open the experiment builder. It will be implemented in Basic Runner project.
         """
         experimentFileItem = self.explorerFrame.fileTree.currentItem()
-        if experimentFileItem.childCount():
-            return
         experimentPath = self.fullPath(experimentFileItem)  # pylint: disable=unused-variable
 
     def fullPath(self, experimentFileItem: QTreeWidgetItem) -> str:

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -72,6 +72,7 @@ class ExplorerApp(qiwis.BaseApp):
         """
         if experimentFileItem.childCount() != 1 or experimentFileItem.child(0).columnCount() != 0:
             return
+        # Remove the empty item of an unloaded directory.
         experimentFileItem.removeChild(experimentFileItem.child(0))
         experimentPath = self.getFullPath(experimentFileItem)
         threading.Thread(

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -75,7 +75,7 @@ class ExplorerApp(qiwis.BaseApp):
             return
         # Remove the empty item of an unloaded directory.
         experimentFileItem.takeChild(0)
-        experimentPath = self.getFullPath(experimentFileItem)
+        experimentPath = self.fullPath(experimentFileItem)
         threading.Thread(
             target=self._addFile,
             args=(experimentPath, experimentFileItem)
@@ -116,9 +116,9 @@ class ExplorerApp(qiwis.BaseApp):
         experimentFileItem = self.explorerFrame.fileTree.currentItem()
         if experimentFileItem.childCount():
             return
-        experimentPath = self.getFullPath(experimentFileItem)  # pylint: disable=unused-variable
+        experimentPath = self.fullPath(experimentFileItem)  # pylint: disable=unused-variable
 
-    def getFullPath(self, experimentFileItem: QTreeWidgetItem) -> str:
+    def fullPath(self, experimentFileItem: QTreeWidgetItem) -> str:
         """Finds the full path of the file item and returns it.
 
         Args:

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -61,7 +61,7 @@ class FileFinderThread(QThread):
     def run(self):
         """Fetches the file list using a command line.
 
-        Searches only files in path, not in deeper path and adds them into parent.
+        Searches for only files in path, not in deeper path and adds them into parent.
         After finished, the finished signal is emitted.
         """
         experimentList = cmdtools.run_command(f"artiq_client ls {self.path}").stdout

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -104,11 +104,11 @@ class ExplorerApp(qiwis.BaseApp):
             return
         experimentPath = self.getFullPath(experimentFileItem)  # pylint: disable=unused-variable
 
-    def getFullPath(self, item: QTreeWidgetItem):
-        path = item.text(0)
-        while item.parent():
-            item = item.parent()
-            path = posixpath.join(item.text(0), path)
+    def getFullPath(self, experimentFileItem: QTreeWidgetItem):
+        path = experimentFileItem.text(0)
+        while experimentFileItem.parent():
+            experimentFileItem = experimentFileItem.parent()
+            path = posixpath.join(experimentFileItem.text(0), path)
         path = posixpath.join(self.repositoryPath, path)
         return path
 

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -72,6 +72,7 @@ class ExplorerApp(qiwis.BaseApp):
 
         Args:
             path: The path of the directory to search experiment files.
+            parent: The widget corresponding to the path.
         """
         experimentList = cmdtools.run_command(f"artiq_client ls {path}").stdout
         experimentList = experimentList.split("\n")[:-1]  # The last one is always an empty string.

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -73,7 +73,9 @@ class ExplorerApp(qiwis.BaseApp):
             if experimentFile.endswith("/"):
                 experimentFileItem = QTreeWidgetItem(parent)
                 experimentFileItem.setText(0, experimentFile[:-1])
-                self._addFile(posixpath.join(path, experimentFile), experimentFileItem)
+                # Make an empty item for indicating that it is a directory.
+                QTreeWidgetItem(experimentFileItem)
+                # self._addFile(posixpath.join(path, experimentFile), experimentFileItem)
             elif experimentFile.endswith(".py"):
                 experimentFileItem = QTreeWidgetItem(parent)
                 experimentFileItem.setText(0, experimentFile)

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -61,9 +61,14 @@ class ExplorerApp(qiwis.BaseApp):
         ).start()
 
     @pyqtSlot(QTreeWidgetItem)
-    def lazyLoadFile(self, item: QTreeWidgetItem):
-        if item.childCount() != 1 or item.child(0).columnCount() != 0:
+    def lazyLoadFile(self, experimentFileItem: QTreeWidgetItem):
+        if experimentFileItem.childCount() != 1 or experimentFileItem.child(0).columnCount() != 0:
             return
+        experimentFileItem.removeChild(experimentFileItem.child(0))
+        experimentPath = self.getFullPath(experimentFileItem)
+        threading.Thread(
+            target=lambda: self._addFile(experimentPath, experimentFileItem)
+        ).start()
 
     # pylint: disable=no-self-use
     def _addFile(self, path: str, parent: Union[QTreeWidget, QTreeWidgetItem]):
@@ -85,7 +90,6 @@ class ExplorerApp(qiwis.BaseApp):
                 experimentFileItem.setText(0, experimentFile[:-1])
                 # Make an empty item for indicating that it is a directory.
                 QTreeWidgetItem(experimentFileItem)
-                # self._addFile(posixpath.join(path, experimentFile), experimentFileItem)
             elif experimentFile.endswith(".py"):
                 experimentFileItem = QTreeWidgetItem(parent)
                 experimentFileItem.setText(0, experimentFile)

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -55,8 +55,11 @@ class ExplorerApp(qiwis.BaseApp):
         It assumes that all experiment files are in self.repositoryPath.
         """
         self.explorerFrame.fileTree.clear()
-        threading.Thread(target=lambda: self._addFile(self.repositoryPath, self.explorerFrame.fileTree)).start()
-        
+        threading.Thread(
+            target=lambda: self._addFile(self.repositoryPath, self.explorerFrame.fileTree)
+        ).start()
+
+    # pylint: disable=no-self-use
     def _addFile(self, path: str, parent: Union[QTreeWidget, QTreeWidgetItem]):
         """Searches all files in path and adds them into parent.
 

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -50,6 +50,10 @@ class FileFinderThread(QThread):
         parent: Union[QTreeWidget, QTreeWidgetItem],
         callback: Callable[[List[str], Union[QTreeWidget, QTreeWidgetItem]], None]
     ):
+        """
+        Args:
+            callback: The callback method called after this thread is finished.
+        """
         super().__init__()
         self.path = path
         self.parent = parent

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -108,7 +108,12 @@ class ExplorerApp(qiwis.BaseApp):
             return
         experimentPath = self.getFullPath(experimentFileItem)  # pylint: disable=unused-variable
 
-    def getFullPath(self, experimentFileItem: QTreeWidgetItem):
+    def getFullPath(self, experimentFileItem: QTreeWidgetItem) -> str:
+        """Finds the full path of the file item and returns it.
+        
+        Args:
+            experimentFileItem: The file item to get its full path.
+        """
         path = experimentFileItem.text(0)
         while experimentFileItem.parent():
             experimentFileItem = experimentFileItem.parent()

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -130,25 +130,25 @@ class ExplorerApp(qiwis.BaseApp):
         )
         self.thread.start()
 
-    def _addFile(self, experimentList: List[str], parent: Union[QTreeWidget, QTreeWidgetItem]):
-        """Adds the files into the children of the parent.
+    def _addFile(self, experimentList: List[str], widget: Union[QTreeWidget, QTreeWidgetItem]):
+        """Adds the files into the children of the widget.
 
         A file or directory which starts with "_" will be ignored, e.g. __pycache__/.
 
         Args:
-            experimentList: The list of files under the parent path.
-            parent: See _FileFinderThread class.
+            experimentList: The list of files under the widget path.
+            widget: See _FileFinderThread class.
         """
         for experimentFile in experimentList:
             if experimentFile.startswith("_"):
                 continue
             if experimentFile.endswith("/"):
-                experimentFileItem = QTreeWidgetItem(parent)
+                experimentFileItem = QTreeWidgetItem(widget)
                 experimentFileItem.setText(0, experimentFile[:-1])
                 # Make an empty item for indicating that it is a directory.
                 QTreeWidgetItem(experimentFileItem)
             elif experimentFile.endswith(".py"):
-                experimentFileItem = QTreeWidgetItem(parent)
+                experimentFileItem = QTreeWidgetItem(widget)
                 experimentFileItem.setText(0, experimentFile)
 
     @pyqtSlot()

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -31,7 +31,7 @@ class ExplorerFrame(QWidget):
         layout.addWidget(self.openButton)
 
 
-class ExplorerApp(qiwis.BaseApp):  # pylint: disable=too-few-public-methods
+class ExplorerApp(qiwis.BaseApp):
     """App for showing the experiment list and opening an experiment."""
 
     def __init__(self, name: str, masterPath: str = ".", parent: Optional[QObject] = None):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -62,6 +62,14 @@ class ExplorerApp(qiwis.BaseApp):
 
     @pyqtSlot(QTreeWidgetItem)
     def lazyLoadFile(self, experimentFileItem: QTreeWidgetItem):
+        """Loads the experiment file in the directory.
+
+        This will be called when a directory item is expanded,
+        so it makes loading files lazy.
+
+        Args:
+            experimentFileItem: The expanded file item.
+        """
         if experimentFileItem.childCount() != 1 or experimentFileItem.child(0).columnCount() != 0:
             return
         experimentFileItem.removeChild(experimentFileItem.child(0))
@@ -72,7 +80,7 @@ class ExplorerApp(qiwis.BaseApp):
 
     # pylint: disable=no-self-use
     def _addFile(self, path: str, parent: Union[QTreeWidget, QTreeWidgetItem]):
-        """Searches all files in path and adds them into parent.
+        """Searches only files in path, not in deeper path and adds them into parent.
 
         A file or directory which starts with "_" will be ignored, e.g. __pycache__/.
 

--- a/setup.json
+++ b/setup.json
@@ -6,7 +6,7 @@
             "show": true,
             "pos": "left",
             "args": {
-                "masterPath": "/home/rabi/artiq/"
+                "masterPath": "/home/jaehun/quiqcl/artiq/examples/"
             }
         }
     }

--- a/setup.json
+++ b/setup.json
@@ -6,7 +6,7 @@
             "show": true,
             "pos": "left",
             "args": {
-                "masterPath": "/home/jaehun/quiqcl/artiq/examples/"
+                "masterPath": "/home/rabi/artiq/"
             }
         }
     }


### PR DESCRIPTION
I implemented the additional function of #20, #21, and resolved the Pylint issue of #28.

# Threading for calling the command line
- Just used `theading.Thread`.
- In according to an [example](https://wiki.qt.io/Updating-QML-content-from-Python-threads), it may be no problem.

# Lazy loading of file structure
- When initially loaded, directories have an empty item underneath to indicate that it is a directory.
- When the directory is expanded for the first time, `_addFile()` is called and the lower files are loaded.

Close #20, Close #21, and Close #28.