### PR TITLE
Able to open the builder and submit the experiment

### DIFF
--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -171,6 +171,12 @@ class BuilderApp(qiwis.BaseApp):
 
     @pyqtSlot()
     def submit(self):
+        """Submits the experiment with the build arguments.
+        
+        Once the submitButton is clicked, this is called.
+
+        TODO(BECATRUE): Apply the editted arguments. It will be implemented in Basic Runner project.
+        """
         experimentArgs = {
             argName: argInfo[0]["default"]
             for argName, argInfo in self.experimentInfo.arginfo.items()
@@ -184,6 +190,15 @@ class BuilderApp(qiwis.BaseApp):
         self.thread.start()
 
     def onSubmitted(self, rid: int):
+        """Prints the rid after submitted.
+
+        This is the callback function of ExperimentSubmitThread.
+
+        Args:
+            rid: The run identifier of the submitted experiment.
+        
+        TODO(BECATRUE): It will be developed in Log Viewer project.
+        """
         print(f"RID: {rid}")
 
     def frames(self) -> Tuple[BuilderFrame]:

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -86,6 +86,8 @@ class ExperimentInfoThread(QThread):
                 experimentClsName,
                 ExperimentInfo(**experimentInfo)
             )
+        else:
+            print("The selected item is a non-experiment file.")
 
 
 class ExperimentSubmitThread(QThread):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -100,7 +100,7 @@ class ExperimentSubmitThread(QThread):
     def __init__(
         self,
         experimentPath: str,
-        experimentArgs: Dict[str, Any], 
+        experimentArgs: Dict[str, Any],
         callback: Callable[[int], None],
         parent: Optional[QObject] = None
     ):
@@ -153,7 +153,7 @@ class BuilderApp(qiwis.BaseApp):
         experimentClsName: str,
         experimentInfo: Dict[str, Any],
         parent: Optional[QObject] = None
-    ):
+    ):  # pylint: disable=too-many-arguments
         """Extended.
         
         Args:

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -128,7 +128,7 @@ class ExperimentSubmitThread(QThread):
 
         If only the experiment was submitted well regardless of whether it runs successfully or not,
         the server returns the run identifier.
-        After finished, the submitted signal is emitted.
+        After submitted, the submitted signal is emitted.
         """
         try:
             params = {

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -29,67 +29,6 @@ class BuilderFrame(QWidget):
         layout.addWidget(self.submitButton)
 
 
-class ExperimentInfoThread(QThread):
-    """QThread for obtaining the experiment information from the proxy server.
-    
-    Signals:
-        fetched(experimentPath, experimentClsName, experimentInfo):
-          The experiment infomation is fetched.
-    
-    Attributes:
-        experimentPath: The path of the experiment file.
-    """
-
-    fetched = pyqtSignal(str, str, ExperimentInfo)
-
-    def __init__(
-        self,
-        experimentPath: str,
-        callback: Callable[[str, str, ExperimentInfo], None],
-        parent: Optional[QObject] = None
-    ):
-        """Extended.
-        
-        Args:
-            experimentPath: See the attributes section in ExperimentInfoThread.
-            callback: The callback method called after this thread is finished.
-        """
-        super().__init__(parent=parent)
-        self.experimentPath = experimentPath
-        self.fetched.connect(callback, type=Qt.QueuedConnection)
-
-    def run(self):
-        """Overridden.
-        
-        Fetches the experiment information from the proxy server.
-        
-        If the path is a directory, 500 Server error occurs.
-        If the path is a non-experiment file, the server returns an empty dictionary.
-
-        The experiment information is an instance of protocols.ExperimentInfo.
-        After finished, the fetched signal is emitted.
-        """
-        try:
-            response = requests.get("http://127.0.0.1:8000/experiment/info/",
-                                    params={"file": self.experimentPath},
-                                    timeout=10)
-            response.raise_for_status()
-            data = response.json()
-        except requests.exceptions.RequestException as err:
-            print(err)
-            return
-        if data:
-            experimentClsName = next(iter(data))
-            experimentInfo = data[experimentClsName]
-            self.fetched.emit(
-                self.experimentPath,
-                experimentClsName,
-                ExperimentInfo(**experimentInfo)
-            )
-        else:
-            print("The selected item is a non-experiment file.")
-
-
 class ExperimentSubmitThread(QThread):
     """QThread for submitting the experiment with its build arguments.
     

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -137,6 +137,7 @@ class ExperimentSubmitThread(QThread):
             }
         except TypeError:
             print("Failed to convert the build arguments to a JSON string.")
+            return
         try:
             response = requests.get("http://127.0.0.1:8000/experiment/submit/",
                                     params=params,

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -13,7 +13,11 @@ import qiwis
 from iquip.protocols import ExperimentInfo
 
 class BuilderFrame(QWidget):
-    """Frame for showing the build arguments and requesting to submit it."""
+    """Frame for showing the build arguments and requesting to submit it.
+    
+    Attributes:
+        submitButton: The button for submitting the experiment.
+    """
 
     def __init__(self, parent: Optional[QWidget] = None):
         """Extended."""

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -2,7 +2,7 @@
 
 from typing import Optional, Tuple
 
-from PyQt5.QtCore import QObject
+from PyQt5.QtCore import QObject, Qt, QThread
 from PyQt5.QtWidgets import (
     QPushButton, QVBoxLayout, QWidget
 )
@@ -20,6 +20,33 @@ class BuilderFrame(QWidget):
         # layout
         layout = QVBoxLayout(self)
         layout.addWidget(self.submitButton)
+
+
+class ExperimentInfoThread(QThread):
+    """QThread for obtaining the experiment information from the proxy server.
+    
+    Signals:
+        fetched(experimentPath, experimentInfo): The experiment infomation is fetched.
+    
+    Attributes:
+        experimentPath: The path of the experiment file.
+    """
+
+    def __init__(
+        self,
+        experimentPath: str,
+        callback,
+        parent: Optional[QObject] = None
+    ):
+        """Extended.
+        
+        Args:
+            experimentPath: See the attributes section in ExperimentInfoThread.
+            callback: The callback method called after this thread is finished.
+        """
+        super().__init__(parent=parent)
+        self.experimentPath = experimentPath
+        self.fetched.connect(callback, type=Qt.QueuedConnection)
 
 
 class BuilderApp(qiwis.BaseApp):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -1,0 +1,6 @@
+"""App module for editting the build arguments and submitting the experiment."""
+
+import qiwis
+
+class BuilderApp(qiwis.BaseApp):
+    """App for editting the build arguments and submitting the experiment."""

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -2,12 +2,14 @@
 
 from typing import Optional, Tuple
 
-from PyQt5.QtCore import QObject, Qt, QThread
+import requests
+from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal
 from PyQt5.QtWidgets import (
     QPushButton, QVBoxLayout, QWidget
 )
 
 import qiwis
+from iquip.protocols import ExperimentInfo
 
 class BuilderFrame(QWidget):
     """Frame for showing the build arguments and requesting to submit it."""
@@ -26,11 +28,14 @@ class ExperimentInfoThread(QThread):
     """QThread for obtaining the experiment information from the proxy server.
     
     Signals:
-        fetched(experimentPath, experimentInfo): The experiment infomation is fetched.
+        fetched(experimentPath, experimentClsName, experimentInfo):
+          The experiment infomation is fetched.
     
     Attributes:
         experimentPath: The path of the experiment file.
     """
+
+    fetched = pyqtSignal(str, str, ExperimentInfo)
 
     def __init__(
         self,
@@ -47,6 +52,35 @@ class ExperimentInfoThread(QThread):
         super().__init__(parent=parent)
         self.experimentPath = experimentPath
         self.fetched.connect(callback, type=Qt.QueuedConnection)
+
+    def run(self):
+        """Overridden.
+        
+        Fetches the experiment information from the proxy server.
+        
+        If the path is a directory, 500 Server error occurs.
+        If the path is a non-experiment file, the server returns an empty dictionary.
+
+        The experiment information is an instance of protocols.ExperimentInfo.
+        After finished, the fetched signal is emitted.
+        """
+        try:
+            response = requests.get("http://127.0.0.1:8000/experiment/info/",
+                                    params={"file": self.experimentPath},
+                                    timeout=10)
+            response.raise_for_status()
+            data = response.json()
+        except requests.exceptions.RequestException as err:
+            print(err)
+            return
+        if data:
+            experimentClsName = next(iter(data))
+            experimentInfo = data[experimentClsName]
+            self.fetched.emit(
+                self.experimentPath,
+                experimentClsName,
+                ExperimentInfo(**experimentInfo)
+            )
 
 
 class BuilderApp(qiwis.BaseApp):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -126,7 +126,7 @@ class ExperimentSubmitThread(QThread):
         
         Submits the experiment to the proxy server.
 
-        If only the experiment was submitted well regardless of whether it runs successfully or not,
+        Whenever the experiment is submitted well regardless of whether it runs successfully or not,
         the server returns the run identifier.
         After submitted, the submitted signal is emitted.
         """

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -1,6 +1,43 @@
 """App module for editting the build arguments and submitting the experiment."""
 
+from typing import Optional, Tuple
+
+from PyQt5.QtCore import QObject
+from PyQt5.QtWidgets import (
+    QPushButton, QVBoxLayout, QWidget
+)
+
 import qiwis
 
+class BuilderFrame(QWidget):
+    """Frame for showing the build arguments and requesting to submit it."""
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        """Extended."""
+        super().__init__(parent=parent)
+        # widgets
+        self.submitButton = QPushButton("Submit", self)
+        # layout
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.submitButton)
+
+
 class BuilderApp(qiwis.BaseApp):
-    """App for editting the build arguments and submitting the experiment."""
+    """App for editting the build arguments and submitting the experiment.
+    
+    Attributes:
+        builderFrame: The frame that shows the build arguments and requests to submit it.
+    """
+
+    def __init__(self, name: str, experimentPath: str, parent: Optional[QObject] = None):
+        """Extended.
+        
+        Args:
+            experimentPath: The path of the experiment file.
+        """
+        super().__init__(name, parent=parent)
+        self.builderFrame = BuilderFrame()
+
+    def frames(self) -> Tuple[BuilderFrame]:
+        """Overridden."""
+        return (self.builderFrame,)

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -94,7 +94,7 @@ class ExperimentSubmitThread(QThread):
     """QThread for submitting the experiment with its build arguments.
     
     Signals:
-        submitted(rid): The experiment is submitted.
+        submitted(rid): The experiment is submitted. The rid is a run identifier.
     
     Attributes:
         experimentPath: The path of the experiment file.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -135,6 +135,9 @@ class ExperimentSubmitThread(QThread):
                 "file": self.experimentPath,
                 "args": json.dumps(self.experimentArgs)
             }
+        except TypeError:
+            print("Failed to convert the build arguments to a JSON string.")
+        try:
             response = requests.get("http://127.0.0.1:8000/experiment/submit/",
                                     params=params,
                                     timeout=10)

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -126,7 +126,8 @@ class ExperimentSubmitThread(QThread):
         
         Submits the experiment to the proxy server.
 
-        Regardless of whether it is successful or not, the server returns the run identifier.
+        If only the experiment was submitted well regardless of whether it runs successfully or not,
+        the server returns the run identifier.
         After finished, the submitted signal is emitted.
         """
         try:

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -36,7 +36,7 @@ class ExplorerFrame(QWidget):
 
 
 class _FileFinderThread(QThread):
-    """QThread for finding the file list using a command line.
+    """QThread for finding the file list from the proxy server.
 
     Signals:
         fetched(experimentList, widget): The file list is fetched.
@@ -69,7 +69,7 @@ class _FileFinderThread(QThread):
     def run(self):
         """Overridden.
 
-        Fetches the file list using a command line.
+        Fetches the file list from the proxy server.
 
         Searches for only files in path, not in deeper path and adds them into the widget.
         After finished, the fetched signal is emitted.

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -18,7 +18,7 @@ class ExplorerFrame(QWidget):
 
     Attributes:
         fileTree: The tree widget for showing the file structure.
-        reloadButton: The buttont for reloading the fileTree.
+        reloadButton: The button for reloading the fileTree.
         openButton: The button for opening the selected experiment file.
     """
 

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -10,6 +10,8 @@ from PyQt5.QtWidgets import (
 )
 
 import qiwis
+from iquip.protocols import ExperimentInfo
+from iquip.apps.builder import ExperimentInfoThread
 
 class ExplorerFrame(QWidget):
     """Frame for showing the experiment list and opening an experiment.
@@ -166,11 +168,29 @@ class ExplorerApp(qiwis.BaseApp):
 
         Once the openButton is clicked, this is called.
         If the selected element is a directory, it will be ignored.
-
-        TODO(BECATRUE): Open the experiment builder. It will be implemented in Basic Runner project.
         """
         experimentFileItem = self.explorerFrame.fileTree.currentItem()
-        experimentPath = self.fullPath(experimentFileItem)  # pylint: disable=unused-variable
+        experimentPath = self.fullPath(experimentFileItem)
+        self.thread = ExperimentInfoThread(experimentPath, self.openBuilder, self)
+        self.thread.start()
+
+    def openBuilder(
+        self,
+        experimentPath: str,
+        experimentClsName: str,
+        experimentInfo: ExperimentInfo
+    ):
+        """Opens the experiment builder with its information.
+        
+        This is the callback function of apps.builder.ExperimentInfoThread.
+        The experiment is guaranteed to be the correct experiment file.
+
+        Args:
+            experimentPath: The path of the experiment file.
+            experimentClsName: The class name of the experiment.
+            experimentInfo: The experiment information. See protocols.ExperimentInfo.
+        """
+
 
     def fullPath(self, experimentFileItem: QTreeWidgetItem) -> str:
         """Finds the full path of the file item and returns it.

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -11,7 +11,7 @@ from PyQt5.QtWidgets import (
 
 import qiwis
 from iquip.protocols import ExperimentInfo
-from iquip.apps.builder import ExperimentInfoThread
+from iquip.apps.thread import ExperimentInfoThread
 
 class ExplorerFrame(QWidget):
     """Frame for showing the experiment list and opening an experiment.

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -190,7 +190,20 @@ class ExplorerApp(qiwis.BaseApp):
             experimentClsName: The class name of the experiment.
             experimentInfo: The experiment information. See protocols.ExperimentInfo.
         """
-
+        self.qiwiscall.createApp(
+            name=f"builder_{experimentPath}",
+            info=qiwis.AppInfo(
+                module="iquip.apps.builder",
+                cls="BuilderApp",
+                show=True,
+                pos="right",
+                args={
+                    "experimentPath": experimentPath,
+                    "experimentClsName": experimentClsName,
+                    "experimentInfo": experimentInfo
+                }
+            )
+        )
 
     def fullPath(self, experimentFileItem: QTreeWidgetItem) -> str:
         """Finds the full path of the file item and returns it.

--- a/iquip/apps/thread.py
+++ b/iquip/apps/thread.py
@@ -1,0 +1,68 @@
+"""Module for common threads in apps."""
+
+from typing import Callable, Optional
+
+import requests
+from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal
+
+from iquip.protocols import ExperimentInfo
+
+class ExperimentInfoThread(QThread):
+    """QThread for obtaining the experiment information from the proxy server.
+    
+    Signals:
+        fetched(experimentPath, experimentClsName, experimentInfo):
+          The experiment infomation is fetched.
+    
+    Attributes:
+        experimentPath: The path of the experiment file.
+    """
+
+    fetched = pyqtSignal(str, str, ExperimentInfo)
+
+    def __init__(
+        self,
+        experimentPath: str,
+        callback: Callable[[str, str, ExperimentInfo], None],
+        parent: Optional[QObject] = None
+    ):
+        """Extended.
+        
+        Args:
+            experimentPath: See the attributes section in ExperimentInfoThread.
+            callback: The callback method called after this thread is finished.
+        """
+        super().__init__(parent=parent)
+        self.experimentPath = experimentPath
+        self.fetched.connect(callback, type=Qt.QueuedConnection)
+
+    def run(self):
+        """Overridden.
+        
+        Fetches the experiment information from the proxy server.
+        
+        If the path is a directory, 500 Server error occurs.
+        If the path is a non-experiment file, the server returns an empty dictionary.
+
+        The experiment information is an instance of protocols.ExperimentInfo.
+        After finished, the fetched signal is emitted.
+        """
+        try:
+            response = requests.get("http://127.0.0.1:8000/experiment/info/",
+                                    params={"file": self.experimentPath},
+                                    timeout=10)
+            response.raise_for_status()
+            data = response.json()
+        except requests.exceptions.RequestException as err:
+            print(err)
+            return
+        if data:
+            experimentClsName = next(iter(data))
+            experimentInfo = data[experimentClsName]
+            self.fetched.emit(
+                self.experimentPath,
+                experimentClsName,
+                ExperimentInfo(**experimentInfo)
+            )
+        else:
+            print("The selected item is a non-experiment file.")

--- a/iquip/protocols.py
+++ b/iquip/protocols.py
@@ -1,0 +1,17 @@
+"""Protocol module for defining common forms."""
+
+import dataclasses
+from typing import Any, Dict
+
+@dataclasses.dataclass
+class ExperimentInfo:
+    """Experiment Information.
+    
+    Fields:
+        name: The experiment name which is set as the docstring in the experiment file.
+        arginfo: The dictionary containing arguments of the experiment.
+          Each key is an argument name and its value contains the argument type,
+          the default value, and the additional information for the argument.
+    """
+    name: str
+    argInfo: Dict[str, Any]

--- a/iquip/protocols.py
+++ b/iquip/protocols.py
@@ -14,4 +14,4 @@ class ExperimentInfo:
           the default value, and the additional information for the argument.
     """
     name: str
-    argInfo: Dict[str, Any]
+    arginfo: Dict[str, Any]


### PR DESCRIPTION
This is related to #42.

First, I'm sorry I have a lot of reviews😂

I implemented three things:
1. Open the builder of the selected experiment (`explorer.py`)
2. Submit the experiment _with the default arguments_ (`builder.py`)
3. For simplicity, define the experiment info format, similar to `ExperimentInfo` in artiq-proxy (`protocols.py`)

### Open the builder
First of all, we need to check if the selected item is a valid experiment file.
We can check it through a request to `/experiment/info/`.
If the item is a directory or a non-experiment file, it returns a 500 Server error or an empty directory, respectively.
This function is implemented in `apps.builder.ExperimentInfoThread`.

After checking it, the explorer app requests to open the builder using `qiwiscall`.

### Submit the experiment
The builder app knows all arguments from the `qiwiscall`, so it doesn't need to request to the proxy server.
To submit it, I implemented `apps.builder.ExperimentSubmitThread` and it shows the rid after submitting.

### Result
- Try to open the builder
<img width="80%" src="https://github.com/snu-quiqcl/iquip/assets/76851886/4e320ae4-8a64-4a5a-ba07-4d5981f39828">

- Submit the experiment
<img width="80%" src="https://github.com/snu-quiqcl/iquip/assets/76851886/0215ca05-bf64-4872-b3a6-6716129a2f78">

### Not implemented (TODO)
1. Show the basic info such as the experiment path and the class name.
2. Show the build arguments and edit them
4. Set the scheduling arguments such as a due date and a priority.