### PR TITLE
Add the build argument entries

### DIFF
--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -133,7 +133,7 @@ class _NumberEntry(_BaseEntry):
             step: The step between values changed by the up and down button.
             min: The minimum value. None for no minimum.
             max: The maximum value. None for no maximum.
-            ndecimals: The maximum number of decimals.
+            ndecimals: The number of displayed decimals.
             default: The default value. If None, it is set to the min value.
             scale, type: See the attributes section in _NumberEntry.
         """

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -50,18 +50,19 @@ class _BaseEntry(QWidget):
 
 
 class _BooleanEntry(_BaseEntry):
-    """Entry class for a boolean value."""
-
-    def __init__(self, name: str, default: bool = False, parent: Optional[QWidget] = None):
-        """Extended.
-        
-        Args:
+    """Entry class for a boolean value.
+    
+    Attributes:
+        argInfo: Each key and its value are:
             default: The default value.
-        """
-        super().__init__(name, parent=parent)
+    """
+
+    def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
+        """Extended."""
+        super().__init__(name, argInfo, parent=parent)
         # widgets
         self.checkBox = QCheckBox(self)
-        self.checkBox.setChecked(default)
+        self.checkBox.setChecked(self.argInfo["default"])
         # layout
         self.layout.addWidget(self.checkBox)
 
@@ -312,6 +313,7 @@ class BuilderApp(qiwis.BaseApp):
                 "EnumerationValue": _EnumerationEntry,
                 "NumberValue": _NumberEntry
             }[argInfo.pop("ty")]
+            print(argName)
             widget = entryCls(argName, argInfo)
             item = QListWidgetItem(self.builderFrame.argsListWidget)
             item.setSizeHint(widget.sizeHint())

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -109,7 +109,7 @@ class _NumberEntry(_BaseEntry):
     """Entry class for a number value.
     
     Attributes:
-        scale: The scale factor that actually applies.
+        scale: The scale factor that is multiplied to the number value.
         type: The type of the value. If "int", value() returns an integer value.
     """
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -59,7 +59,7 @@ class _BooleanEntry(_BaseEntry):
         super().__init__(name, parent=parent)
         # widgets
         self.checkBox = QCheckBox(self)
-        self.checkBox.setCheckState(default)
+        self.checkBox.setChecked(default)
         # layout
         self.layout.addWidget(self.checkBox)
 
@@ -68,7 +68,7 @@ class _BooleanEntry(_BaseEntry):
         
         Returns the status of the checkBox.
         """
-        return self.checkBox.checkState()
+        return self.checkBox.isChecked()
 
 
 class _EnumerationEntry(_BaseEntry):
@@ -154,7 +154,7 @@ class _NumberEntry(_BaseEntry):
         
         Returns the value of the comboBox.
         """
-        return self.comboBox.currentText()
+        return self.spinBox.value()
 
 
 class _StringEntry(_BaseEntry):
@@ -323,13 +323,12 @@ class BuilderApp(qiwis.BaseApp):
         """Submits the experiment with the build arguments.
         
         Once the submitButton is clicked, this is called.
-
-        TODO(BECATRUE): Apply the editted arguments. It will be implemented in Basic Runner project.
         """
-        experimentArgs = {
-            argName: argInfo[0]["default"]
-            for argName, argInfo in self.experimentInfo.arginfo.items()
-        }
+        experimentArgs = {}
+        for row in range(self.builderFrame.argsListWidget.count()):
+            item = self.builderFrame.argsListWidget.item(row)
+            widget = self.builderFrame.argsListWidget.itemWidget(item)
+            experimentArgs[widget.name] = widget.value()
         self.thread = ExperimentSubmitThread(
             self.experimentPath,
             experimentArgs,

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -23,6 +23,7 @@ class _BaseEntry(QWidget):
         name: The argument name.
         argInfo: The dictionary with the argument options.
         nameLabel: The label for showing the argument name.
+        layout: The QHBoxLayout with the nameLabel.
     """
 
     def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
@@ -39,7 +40,6 @@ class _BaseEntry(QWidget):
         # layout
         self.layout = QHBoxLayout(self)
         self.layout.addWidget(self.nameLabel)
-        self.setLayout(self.layout)
 
     def value(self) -> Any:
         """Returns the entered or selected value.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -1,7 +1,7 @@
 """App module for editting the build arguments and submitting the experiment."""
 
 import json
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
@@ -110,6 +110,7 @@ class _NumberEntry(_BaseEntry):
     
     Attributes:
         scale: The scale factor that actually applies.
+        type: The type of the value. If "int", value() returns an integer value.
     """
 
     def __init__(
@@ -121,7 +122,7 @@ class _NumberEntry(_BaseEntry):
         min: float,  # pylint: disable=redefined-builtin
         max: float,  # pylint: disable=redefined-builtin
         ndecimals: int,
-        type: str,  # pylint: disable=unused-argument,redefined-builtin
+        type: str,  # pylint: disable=redefined-builtin
         default: Optional[float] = None,
         parent: Optional[QWidget] = None
     ):  # pylint: disable=too-many-arguments
@@ -129,16 +130,16 @@ class _NumberEntry(_BaseEntry):
         
         Args:
             unit: The unit of the value.
-            scale: See the attributes section in _NumberEntry.
             step: The step between values changed by the up and down button.
             min: The minimum value.
             max: The maximum value.
             ndecimals: The maximum number of decimals.
-            _type: The type of the value. This is not used.
             default: The default value. If it does not exist, it is set to the min value.
+            scale, type: See the attributes section in _NumberEntry.
         """
         super().__init__(name, parent=parent)
         self.scale = scale
+        self.type = type
         # widgets
         self.spinBox = QDoubleSpinBox(self)
         self.spinBox.setSuffix(unit)
@@ -149,12 +150,13 @@ class _NumberEntry(_BaseEntry):
         # layout
         self.layout.addWidget(self.spinBox)
 
-    def value(self) -> str:
+    def value(self) -> Union[int, float]:
         """Overridden.
         
         Returns the value of the comboBox.
         """
-        return self.spinBox.value()
+        typeCls = int if self.type == "int" else float
+        return typeCls(self.spinBox.value())
 
 
 class _StringEntry(_BaseEntry):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -43,11 +43,10 @@ class _BooleanEntry(_BaseEntry, QCheckBox):
     If there is no default value, it is set to False.
     """
 
-    def __init__(self, name: str, parent: Optional[QWidget] = None, **kwargs: Any):
+    def __init__(self, name: str, parent: Optional[QWidget] = None, default: bool = False):
         """Extended."""
-        _BaseEntry.__init__(name=name)
-        QCheckBox.__init__(parent=parent)
-        default = kwargs["default", False]
+        _BaseEntry.__init__(self, name=name)
+        QCheckBox.__init__(self, parent=parent)
         self.initEntry(default)
 
     def initEntry(self, default: bool):
@@ -80,6 +79,7 @@ class BuilderFrame(QWidget):
         layout = QVBoxLayout(self)
         layout.addWidget(self.argsListWidget)
         layout.addWidget(self.submitButton)
+        self.setLayout(layout)
 
 
 class ExperimentSubmitThread(QThread):
@@ -185,7 +185,15 @@ class BuilderApp(qiwis.BaseApp):
         Args:
             experimentInfo: The experiment information.
         """
-        print(experimentInfo)
+        for argName, _argInfo in experimentInfo.arginfo.items():
+            argInfo = _argInfo[0]  # All the remaining elements are None.
+            entryCls = {
+                "BooleanValue": _BooleanEntry
+            }[argInfo.pop("ty")]
+            widget = entryCls(argName, self.builderFrame, **argInfo)
+            item = QListWidgetItem(self.builderFrame.argsListWidget)
+            self.builderFrame.argsListWidget.addItem(item)
+            self.builderFrame.argsListWidget.setItemWidget(item, widget)
 
     @pyqtSlot()
     def submit(self):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -313,7 +313,6 @@ class BuilderApp(qiwis.BaseApp):
                 "EnumerationValue": _EnumerationEntry,
                 "NumberValue": _NumberEntry
             }[argInfo.pop("ty")]
-            print(argName)
             widget = entryCls(argName, argInfo)
             item = QListWidgetItem(self.builderFrame.argsListWidget)
             item.setSizeHint(widget.sizeHint())

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -310,8 +310,7 @@ class BuilderApp(qiwis.BaseApp):
         Args:
             experimentInfo: The experiment information.
         """
-        for argName, _argInfo in experimentInfo.arginfo.items():
-            argInfo = _argInfo[0]  # All the remaining elements are None.
+        for argName, (argInfo, *_) in experimentInfo.arginfo.items():
             entryCls = {
                 "BooleanValue": _BooleanEntry,
                 "StringValue": _StringEntry,

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -134,7 +134,7 @@ class _NumberEntry(_BaseEntry):
             min: The minimum value. None for no minimum.
             max: The maximum value. None for no maximum.
             ndecimals: The maximum number of decimals.
-            default: The default value. If it does not exist, it is set to the min value.
+            default: The default value. If None, it is set to the min value.
             scale, type: See the attributes section in _NumberEntry.
         """
         super().__init__(name, parent=parent)

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -1,7 +1,6 @@
 """App module for editting the build arguments and submitting the experiment."""
 
 import json
-from abc import ABCMeta, abstractmethod
 from typing import Any, Callable, Dict, Optional, Tuple
 
 import requests
@@ -13,8 +12,8 @@ from PyQt5.QtWidgets import (
 import qiwis
 from iquip.protocols import ExperimentInfo
 
-class _Entry(metaclass=ABCMeta):
-    """Abstract class for an argument entry.
+class _BaseEntry:
+    """Base class for all argument entries.
 
     In each subclass, value() must be implemented to return the selected value.
 
@@ -30,12 +29,15 @@ class _Entry(metaclass=ABCMeta):
         """
         self.name = name
 
-    @abstractmethod
     def value(self) -> Any:
-        pass
+        """Returns the entered or selected value.
+        
+        This must be overridden in the subclass.
+        """
+        raise NotImplementedError
 
 
-class _BooleanEntry(_Entry, QCheckBox):
+class _BooleanEntry(_BaseEntry, QCheckBox):
     """Entry class for a boolean value.
 
     If there is no default value, it is set to False.
@@ -43,13 +45,13 @@ class _BooleanEntry(_Entry, QCheckBox):
 
     def __init__(self, name: str, parent: Optional[QWidget] = None, **kwargs: Any):
         """Extended."""
-        _Entry.__init__(name=name)
+        _BaseEntry.__init__(name=name)
         QCheckBox.__init__(parent=parent)
         default = kwargs["default", False]
         self.initEntry(default)
 
     def initEntry(self, default: bool):
-        """Initialize the entry.
+        """Initializes the entry.
         
         Attributes:
             default: The default value.
@@ -178,11 +180,12 @@ class BuilderApp(qiwis.BaseApp):
         self.builderFrame.submitButton.clicked.connect(self.submit)
 
     def initArgsEntry(self, experimentInfo: ExperimentInfo):
-        """Initialize the build arguments entry.
+        """Initializes the build arguments entry.
         
         Args:
             experimentInfo: The experiment information.
         """
+        print(experimentInfo)
 
     @pyqtSlot()
     def submit(self):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -127,6 +127,8 @@ class _NumberEntry(_BaseEntry):
             ndecimals: The number of displayed decimals.
             type: The type of the value. If "int", value() returns an integer value.
         spinBox: The spinbox showing the number value.
+    
+    TODO(BECATRUE): The operations of unit and scale will be concretized in Basic Runner project.
     """
 
     def __init__(

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, Optional, Tuple
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
-    QPushButton, QVBoxLayout, QWidget
+    QCheckBox, QPushButton, QVBoxLayout, QWidget
 )
 
 import qiwis
@@ -33,6 +33,32 @@ class _Entry(metaclass=ABCMeta):
     @abstractmethod
     def value(self):
         pass
+
+
+class _BooleanEntry(_Entry, QCheckBox):
+    """Entry class for a boolean value.
+
+    If there is no default value, it is set to False.
+    """
+
+    def __init__(self, name: str, parent: Optional[QWidget] = None, **kwargs: Any):
+        """Extended.
+
+        Args:
+            name: See the attributes section in _Entry.
+        """
+        _Entry.__init__(name=name)
+        QCheckBox.__init__(parent=parent)
+        default = kwargs["default", False]
+        self.initEntry(default)
+
+    def initEntry(self, default: bool):
+        """Initialize the entry.
+        
+        Attributes:
+            default: The default value.
+        """
+        self.setCheckState(default)
 
 
 class BuilderFrame(QWidget):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -190,6 +190,7 @@ class BuilderFrame(QWidget):
     """Frame for showing the build arguments and requesting to submit it.
     
     Attributes:
+        argsListWidget: The list widget with the build arguments.
         submitButton: The button for submitting the experiment.
     """
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -119,8 +119,8 @@ class _NumberEntry(_BaseEntry):
         unit: str,
         scale: float,
         step: float,
-        min: float,  # pylint: disable=redefined-builtin
-        max: float,  # pylint: disable=redefined-builtin
+        min: Optional[float],  # pylint: disable=redefined-builtin
+        max: Optional[float],  # pylint: disable=redefined-builtin
         ndecimals: int,
         type: str,  # pylint: disable=redefined-builtin
         default: Optional[float] = None,
@@ -131,8 +131,8 @@ class _NumberEntry(_BaseEntry):
         Args:
             unit: The unit of the value.
             step: The step between values changed by the up and down button.
-            min: The minimum value.
-            max: The maximum value.
+            min: The minimum value. None for no minimum.
+            max: The maximum value. None for no maximum.
             ndecimals: The maximum number of decimals.
             default: The default value. If it does not exist, it is set to the min value.
             scale, type: See the attributes section in _NumberEntry.
@@ -144,7 +144,10 @@ class _NumberEntry(_BaseEntry):
         self.spinBox = QDoubleSpinBox(self)
         self.spinBox.setSuffix(unit)
         self.spinBox.setSingleStep(step / scale)
-        self.spinBox.setRange(min / scale, max / scale)
+        if min is not None:
+            self.spinBox.setMinimum(min / scale)
+        if max is not None:
+            self.spinBox.setMaximum(max / scale)
         self.spinBox.setDecimals(ndecimals)
         self.spinBox.setValue((min if default is None else default) / scale)
         # layout

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -1,7 +1,7 @@
 """App module for editting the build arguments and submitting the experiment."""
 
 import json
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
@@ -69,6 +69,36 @@ class _BooleanEntry(_BaseEntry):
         Returns the status of the checkBox.
         """
         return self.checkBox.checkState()
+
+
+class _EnumerationEntry(_BaseEntry):
+    """Entry class for an enumeration value."""
+
+    def __init__(
+        self,
+        name: str,
+        choices: List[str],
+        default: str = "",
+        parent: Optional[QWidget] = None
+    ):
+        """Extended.
+        
+        Args:
+            default: The default value. If it does not exist, it is set to an empty string.
+        """
+        super().__init__(name, parent=parent)
+        # widgets
+        self.lineEdit = QLineEdit(self)
+        self.lineEdit.setText(default)
+        # layout
+        self.layout.addWidget(self.lineEdit)
+
+    def value(self) -> str:
+        """Overridden.
+        
+        Returns the value of the lineEdit.
+        """
+        return self.lineEdit.text()
 
 
 class _StringEntry(_BaseEntry):
@@ -180,7 +210,7 @@ class BuilderApp(qiwis.BaseApp):
 
     There are four types of build arguments.
       BooleanValue: Set to True or False.
-      EnumerateValue: Set to one of the pre-defined candidates.
+      EnumerationValue: Set to one of the pre-defined candidates.
       NumberValue: Set to a number with a specific unit and scale.
       StringValue: Set to a string.
     
@@ -222,7 +252,8 @@ class BuilderApp(qiwis.BaseApp):
             argInfo = _argInfo[0]  # All the remaining elements are None.
             entryCls = {
                 "BooleanValue": _BooleanEntry,
-                "StringValue": _StringEntry
+                "StringValue": _StringEntry,
+                "EnumerationValue": _EnumerationEntry
             }[argInfo.pop("ty")]
             widget = entryCls(argName, **argInfo)
             item = QListWidgetItem(self.builderFrame.argsListWidget)

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -317,7 +317,7 @@ class BuilderApp(qiwis.BaseApp):
                 "EnumerationValue": _EnumerationEntry,
                 "NumberValue": _NumberEntry
             }[argInfo.pop("ty")]
-            widget = entryCls(argName, **argInfo)
+            widget = entryCls(argName, argInfo)
             item = QListWidgetItem(self.builderFrame.argsListWidget)
             item.setSizeHint(widget.sizeHint())
             self.builderFrame.argsListWidget.addItem(item)

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -74,28 +74,31 @@ class _BooleanEntry(_BaseEntry):
 
 
 class _EnumerationEntry(_BaseEntry):
-    """Entry class for an enumeration value."""
+    """Entry class for an enumeration value.
+    
+    Attributes:
+        argInfo: Each key and its value are:
+            choices: The pre-defined candidates.
+            default: The default value. If it does not exist, it is set to the first candidate.
+    """
 
     def __init__(
         self,
         name: str,
-        choices: List[str],
-        default: Optional[str] = None,
+        argInfo: Dict[str, Any],
         parent: Optional[QWidget] = None
     ):
-        """Extended.
-        
-        Args:
-            choices: The pre-defined candidates.
-            default: The default value. If it does not exist, it is set to the first candidate.
-        """
-        super().__init__(name, parent=parent)
+        """Extended."""
+        super().__init__(name, argInfo, parent=parent)
         # widgets
         self.comboBox = QComboBox(self)
-        for choice in choices:
+        for choice in self.argInfo["choices"]:
             self.comboBox.addItem(choice)
-        if choices:
-            self.comboBox.setCurrentText(choices[0] if default is None else default)
+        if self.argInfo["choices"]:
+            self.comboBox.setCurrentText(
+                self.argInfo["choices"][0] if self.argInfo["default"] is None 
+                else self.argInfo["default"]
+            )
         # layout
         self.layout.addWidget(self.comboBox)
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -309,6 +309,8 @@ class BuilderApp(qiwis.BaseApp):
             experimentInfo: The experiment information.
         """
         for argName, (argInfo, *_) in experimentInfo.arginfo.items():
+            # TODO(BECATRUE): The other types such as 'Scannable'
+            # will be implemented in Basic Runner project.
             entryCls = {
                 "BooleanValue": _BooleanEntry,
                 "StringValue": _StringEntry,

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -116,40 +116,35 @@ class _NumberEntry(_BaseEntry):
     def __init__(
         self,
         name: str,
-        unit: str,
-        scale: float,
-        step: float,
-        min: Optional[float],  # pylint: disable=redefined-builtin
-        max: Optional[float],  # pylint: disable=redefined-builtin
-        ndecimals: int,
-        type: str,  # pylint: disable=redefined-builtin
-        default: Optional[float] = None,
+        argInfo: Dict[str, Any],
         parent: Optional[QWidget] = None
-    ):  # pylint: disable=too-many-arguments
+    ):
         """Extended.
         
         Args:
-            unit: The unit of the value.
-            step: The step between values changed by the up and down button.
-            min: The minimum value. None for no minimum.
-            max: The maximum value. None for no maximum.
-            ndecimals: The number of displayed decimals.
-            default: The default value. If None, it is set to the min value.
-            scale, type: See the attributes section in _NumberEntry.
+            argInfo: The dictionary with the build arguments. Each key and its value are:
+                unit: The unit of the value.
+                step: The step between values changed by the up and down button.
+                min: The minimum value. (default=0.0)
+                max: The maximum value. (default=99.99)
+                ndecimals: The number of displayed decimals.
+                default: The default value. If None, it is set to the min value.
+                scale, type: See the attributes section in _NumberEntry.
         """
         super().__init__(name, parent=parent)
-        self.scale = scale
-        self.type = type
+        self.scale = argInfo["scale"]
+        self.type = argInfo["type"]
         # widgets
         self.spinBox = QDoubleSpinBox(self)
-        self.spinBox.setSuffix(unit)
-        self.spinBox.setSingleStep(step / scale)
-        if min is not None:
-            self.spinBox.setMinimum(min / scale)
-        if max is not None:
-            self.spinBox.setMaximum(max / scale)
-        self.spinBox.setDecimals(ndecimals)
-        self.spinBox.setValue((min if default is None else default) / scale)
+        self.spinBox.setSuffix(argInfo["unit"])
+        self.spinBox.setSingleStep(argInfo["step"] / self.scale)
+        if argInfo["min"] is not None:
+            self.spinBox.setMinimum(argInfo["min"] / self.scale)
+        if argInfo["max"] is not None:
+            self.spinBox.setMaximum(argInfo["max"] / self.scale)
+        self.spinBox.setDecimals(argInfo["ndecimals"])
+        self.spinBox.setValue((argInfo["min"] if argInfo["default"] is None \
+                               else argInfo["default"]) / self.scale)
         # layout
         self.layout.addWidget(self.spinBox)
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -1,6 +1,7 @@
 """App module for editting the build arguments and submitting the experiment."""
 
 import json
+from abc import ABCMeta, abstractmethod
 from typing import Any, Callable, Dict, Optional, Tuple
 
 import requests
@@ -11,6 +12,28 @@ from PyQt5.QtWidgets import (
 
 import qiwis
 from iquip.protocols import ExperimentInfo
+
+class _Entry(metaclass=ABCMeta):
+    """Abstract class for an argument entry.
+
+    In each subclass, value() must be implemented to return the selected value.
+
+    Attributes:
+        name: The argument name.
+    """
+
+    def __init__(self, name: str):
+        """Extended.
+        
+        Args:
+            name: See the attributes section in _Entry.
+        """
+        self.name = name
+
+    @abstractmethod
+    def value(self):
+        pass
+
 
 class BuilderFrame(QWidget):
     """Frame for showing the build arguments and requesting to submit it.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -31,7 +31,7 @@ class _Entry(metaclass=ABCMeta):
         self.name = name
 
     @abstractmethod
-    def value(self):
+    def value(self) -> Any:
         pass
 
 
@@ -59,6 +59,10 @@ class _BooleanEntry(_Entry, QCheckBox):
             default: The default value.
         """
         self.setCheckState(default)
+
+    def value(self) -> bool:
+        """Overridden."""
+        return self.checkState()
 
 
 class BuilderFrame(QWidget):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, Optional, Tuple
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
-    QCheckBox, QPushButton, QVBoxLayout, QWidget
+    QCheckBox, QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QWidget
 )
 
 import qiwis
@@ -42,11 +42,7 @@ class _BooleanEntry(_Entry, QCheckBox):
     """
 
     def __init__(self, name: str, parent: Optional[QWidget] = None, **kwargs: Any):
-        """Extended.
-
-        Args:
-            name: See the attributes section in _Entry.
-        """
+        """Extended."""
         _Entry.__init__(name=name)
         QCheckBox.__init__(parent=parent)
         default = kwargs["default", False]
@@ -76,9 +72,11 @@ class BuilderFrame(QWidget):
         """Extended."""
         super().__init__(parent=parent)
         # widgets
+        self.argsListWidget = QListWidget(self)
         self.submitButton = QPushButton("Submit", self)
         # layout
         layout = QVBoxLayout(self)
+        layout.addWidget(self.argsListWidget)
         layout.addWidget(self.submitButton)
 
 
@@ -147,6 +145,8 @@ class BuilderApp(qiwis.BaseApp):
     
     Attributes:
         builderFrame: The frame that shows the build arguments and requests to submit it.
+        experimentPath: The path of the experiment file.
+        experimentClsName: The class name of the experiment.
     """
 
     def __init__(
@@ -160,17 +160,23 @@ class BuilderApp(qiwis.BaseApp):
         """Extended.
         
         Args:
-            experimentPath: The path of the experiment file.
-            experimentClsName: The class name of the experiment.
+            experimentPath, experimentClsName: See the attributes section in BuilderApp.
             experimentInfo: The experiment information, a dictionary of protocols.ExperimentInfo.
         """
         super().__init__(name, parent=parent)
         self.experimentPath = experimentPath
         self.experimentClsName = experimentClsName
-        self.experimentInfo = ExperimentInfo(**experimentInfo)
         self.builderFrame = BuilderFrame()
+        self.initArgsEntry(ExperimentInfo(**experimentInfo))
         # connect signals to slots
         self.builderFrame.submitButton.clicked.connect(self.submit)
+
+    def initArgsEntry(self, experimentInfo: ExperimentInfo):
+        """Initialize the build arguments entry.
+        
+        Args:
+            experimentInfo: The experiment information.
+        """
 
     @pyqtSlot()
     def submit(self):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -1,7 +1,7 @@
 """App module for editting the build arguments and submitting the experiment."""
 
 import json
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
@@ -99,7 +99,7 @@ class _EnumerationEntry(_BaseEntry):
             self.comboBox.addItem(choice)
         if self.argInfo["choices"]:
             self.comboBox.setCurrentText(
-                self.argInfo["choices"][0] if self.argInfo["default"] is None 
+                self.argInfo["choices"][0] if self.argInfo["default"] is None
                 else self.argInfo["default"]
             )
         # layout

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -54,7 +54,8 @@ class _BooleanEntry(_BaseEntry):
     
     Attributes:
         argInfo: Each key and its value are:
-            default: The default value.
+            (optional) default: The boolean value. 
+              If not exist, the checkBox is set to False.
         checkBox: The checkbox showing the boolean value.
     """
 
@@ -63,7 +64,7 @@ class _BooleanEntry(_BaseEntry):
         super().__init__(name, argInfo, parent=parent)
         # widgets
         self.checkBox = QCheckBox(self)
-        self.checkBox.setChecked(self.argInfo["default"])
+        self.checkBox.setChecked(self.argInfo.get("default", False))
         # layout
         self.layout.addWidget(self.checkBox)
 
@@ -81,22 +82,22 @@ class _EnumerationEntry(_BaseEntry):
     Attributes:
         argInfo: Each key and its value are:
             choices: The pre-defined candidates.
-            default: The default value. If it does not exist, it is set to the first candidate.
+            (optional) default: The string value.
+              If not exist, the comboBox is set to the first candidate.
         comboBox: The combobox showing the enumeration value.
     """
 
     def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(name, argInfo, parent=parent)
+        choices = self.argInfo["choices"]
+        # TODO(BECATRUE): Handling an empty choices will be implemented in the issue #55.
+        if not choices:
+            pass
         # widgets
         self.comboBox = QComboBox(self)
-        for choice in self.argInfo["choices"]:
-            self.comboBox.addItem(choice)
-        if self.argInfo["choices"]:
-            self.comboBox.setCurrentText(
-                self.argInfo["choices"][0] if self.argInfo["default"] is None
-                else self.argInfo["default"]
-            )
+        self.comboBox.addItems(choices)
+        self.comboBox.setCurrentText(self.argInfo.get("default", choices[0]))
         # layout
         self.layout.addWidget(self.comboBox)
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -85,12 +85,7 @@ class _EnumerationEntry(_BaseEntry):
         comboBox: The combobox showing the enumeration value.
     """
 
-    def __init__(
-        self,
-        name: str,
-        argInfo: Dict[str, Any],
-        parent: Optional[QWidget] = None
-    ):
+    def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(name, argInfo, parent=parent)
         # widgets
@@ -131,12 +126,7 @@ class _NumberEntry(_BaseEntry):
     TODO(BECATRUE): The operations of unit and scale will be concretized in Basic Runner project.
     """
 
-    def __init__(
-        self,
-        name: str,
-        argInfo: Dict[str, Any],
-        parent: Optional[QWidget] = None
-    ):
+    def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(name, argInfo, parent=parent)
         # widgets

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -163,7 +163,8 @@ class _StringEntry(_BaseEntry):
     
     Attributes:
         argInfo: Each key and its value are:
-            default: The default value. If it does not exist, it is set to an empty string.
+            default: The string value.
+              If not exist, the lineEdit is set to an empty string.
         lineEdit: The lineedit showing the string value.
     """
 
@@ -172,7 +173,7 @@ class _StringEntry(_BaseEntry):
         super().__init__(name, argInfo, parent=parent)
         # widgets
         self.lineEdit = QLineEdit(self)
-        self.lineEdit.setText(self.argInfo["default"])
+        self.lineEdit.setText(self.argInfo.get("default", ""))
         # layout
         self.layout.addWidget(self.lineEdit)
 
@@ -202,7 +203,6 @@ class BuilderFrame(QWidget):
         layout = QVBoxLayout(self)
         layout.addWidget(self.argsListWidget)
         layout.addWidget(self.submitButton)
-        self.setLayout(layout)
 
 
 class ExperimentSubmitThread(QThread):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -114,33 +114,38 @@ class _NumberEntry(_BaseEntry):
     
     Attributes:
         argInfo: Each key and its value are:
-            default: The default value. If None, it is set to the min value.
+            (optional) default: The number value.
+              If not exist, the spinBox is set to the min value.
             unit: The unit of the value.
             scale: The scale factor that is multiplied to the number value.
             step: The step between values changed by the up and down button.
             min: The minimum value. (default=0.0)
             max: The maximum value. (default=99.99)
             ndecimals: The number of displayed decimals.
-            type: The type of the value. If "int", value() returns an integer value.
+            type: The type of the value.
+              If "int", value() returns an integer value.
+              Otherwise, it is regarded as a float value.
         spinBox: The spinbox showing the number value.
     
     TODO(BECATRUE): The operations of unit and scale will be concretized in Basic Runner project.
+    TODO(BECATRUE): Handling the case where the default doesn't exist and the min is None
+      will be implemented in Basic Runner project.
     """
 
     def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(name, argInfo, parent=parent)
+        scale, minValue, maxValue = map(self.argInfo.get, ("scale", "min", "max"))
         # widgets
         self.spinBox = QDoubleSpinBox(self)
         self.spinBox.setSuffix(self.argInfo["unit"])
-        self.spinBox.setSingleStep(self.argInfo["step"] / self.argInfo["scale"])
-        if self.argInfo["min"] is not None:
-            self.spinBox.setMinimum(self.argInfo["min"] / self.argInfo["scale"])
-        if self.argInfo["max"] is not None:
-            self.spinBox.setMaximum(self.argInfo["max"] / self.argInfo["scale"])
+        self.spinBox.setSingleStep(self.argInfo["step"] / scale)
+        if minValue is not None:
+            self.spinBox.setMinimum(minValue / scale)
+        if maxValue is not None:
+            self.spinBox.setMaximum(maxValue / scale)
         self.spinBox.setDecimals(self.argInfo["ndecimals"])
-        self.spinBox.setValue((self.argInfo["min"] if self.argInfo["default"] is None \
-                               else self.argInfo["default"]) / self.argInfo["scale"])
+        self.spinBox.setValue(self.argInfo.get("default", minValue) / scale)
         # layout
         self.layout.addWidget(self.spinBox)
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -157,18 +157,19 @@ class _NumberEntry(_BaseEntry):
 
 
 class _StringEntry(_BaseEntry):
-    """Entry class for a string value."""
-
-    def __init__(self, name: str, default: str = "", parent: Optional[QWidget] = None):
-        """Extended.
-        
-        Args:
+    """Entry class for a string value.
+    
+    Attributes:
+        argInfo: Each key and its value are:
             default: The default value. If it does not exist, it is set to an empty string.
-        """
-        super().__init__(name, parent=parent)
+    """
+
+    def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
+        """Extended."""
+        super().__init__(name, argInfo, parent=parent)
         # widgets
         self.lineEdit = QLineEdit(self)
-        self.lineEdit.setText(default)
+        self.lineEdit.setText(self.argInfo["default"])
         # layout
         self.layout.addWidget(self.lineEdit)
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -54,7 +54,7 @@ class _BooleanEntry(_BaseEntry):
         """Extended.
         
         Args:
-            default: The default value. If it does not exist, it is set to False.
+            default: The default value.
         """
         super().__init__(name, parent=parent)
         # widgets

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -6,7 +6,8 @@ from typing import Any, Callable, Dict, Optional, Tuple
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
-    QCheckBox, QHBoxLayout, QLabel, QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QWidget
+    QCheckBox, QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem, QPushButton,
+    QVBoxLayout, QWidget
 )
 
 import qiwis
@@ -68,6 +69,30 @@ class _BooleanEntry(_BaseEntry):
         Returns the status of the checkBox.
         """
         return self.checkBox.checkState()
+
+
+class _StringEntry(_BaseEntry):
+    """Entry class for a string value."""
+
+    def __init__(self, name: str, default: str = "", parent: Optional[QWidget] = None):
+        """Extended.
+        
+        Args:
+            default: The default value. If it does not exist, it is set to an empty string.
+        """
+        super().__init__(name, parent=parent)
+        # widgets
+        self.lineEdit = QLineEdit(self)
+        self.lineEdit.setText(default)
+        # layout
+        self.layout.addWidget(self.lineEdit)
+
+    def value(self) -> str:
+        """Overridden.
+        
+        Returns the value of the lineEdit.
+        """
+        return self.lineEdit.text()
 
 
 class BuilderFrame(QWidget):
@@ -196,7 +221,8 @@ class BuilderApp(qiwis.BaseApp):
         for argName, _argInfo in experimentInfo.arginfo.items():
             argInfo = _argInfo[0]  # All the remaining elements are None.
             entryCls = {
-                "BooleanValue": _BooleanEntry
+                "BooleanValue": _BooleanEntry,
+                "StringValue": _StringEntry
             }[argInfo.pop("ty")]
             widget = entryCls(argName, **argInfo)
             item = QListWidgetItem(self.builderFrame.argsListWidget)

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -55,6 +55,7 @@ class _BooleanEntry(_BaseEntry):
     Attributes:
         argInfo: Each key and its value are:
             default: The default value.
+        checkBox: The checkbox showing the boolean value.
     """
 
     def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
@@ -81,6 +82,7 @@ class _EnumerationEntry(_BaseEntry):
         argInfo: Each key and its value are:
             choices: The pre-defined candidates.
             default: The default value. If it does not exist, it is set to the first candidate.
+        comboBox: The combobox showing the enumeration value.
     """
 
     def __init__(
@@ -124,6 +126,7 @@ class _NumberEntry(_BaseEntry):
             max: The maximum value. (default=99.99)
             ndecimals: The number of displayed decimals.
             type: The type of the value. If "int", value() returns an integer value.
+        spinBox: The spinbox showing the number value.
     """
 
     def __init__(
@@ -163,6 +166,7 @@ class _StringEntry(_BaseEntry):
     Attributes:
         argInfo: Each key and its value are:
             default: The default value. If it does not exist, it is set to an empty string.
+        lineEdit: The lineedit showing the string value.
     """
 
     def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -142,6 +142,12 @@ class ExperimentSubmitThread(QThread):
 
 class BuilderApp(qiwis.BaseApp):
     """App for editting the build arguments and submitting the experiment.
+
+    There are four types of build arguments.
+      BooleanValue: Set to True or False.
+      EnumerateValue: Set to one of the pre-defined candidates.
+      NumberValue: Set to a number with a specific unit and scale.
+      StringValue: Set to a string.
     
     Attributes:
         builderFrame: The frame that shows the build arguments and requests to submit it.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -6,8 +6,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
-    QCheckBox, QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem, QPushButton,
-    QVBoxLayout, QWidget
+    QCheckBox, QComboBox, QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem,
+    QPushButton, QVBoxLayout, QWidget
 )
 
 import qiwis
@@ -78,27 +78,31 @@ class _EnumerationEntry(_BaseEntry):
         self,
         name: str,
         choices: List[str],
-        default: str = "",
+        default: Optional[str] = None,
         parent: Optional[QWidget] = None
     ):
         """Extended.
         
         Args:
-            default: The default value. If it does not exist, it is set to an empty string.
+            choices: The pre-defined candidates.
+            default: The default value. If it does not exist, it is set to None.
         """
         super().__init__(name, parent=parent)
         # widgets
-        self.lineEdit = QLineEdit(self)
-        self.lineEdit.setText(default)
+        self.comboBox = QComboBox(self)
+        for choice in choices:
+            self.comboBox.addItem(choice)
+        if choices:
+            self.comboBox.setCurrentText(choices[0] if default is None else default)
         # layout
-        self.layout.addWidget(self.lineEdit)
+        self.layout.addWidget(self.comboBox)
 
     def value(self) -> str:
         """Overridden.
         
-        Returns the value of the lineEdit.
+        Returns the value of the comboBox.
         """
-        return self.lineEdit.text()
+        return self.comboBox.currentText()
 
 
 class _StringEntry(_BaseEntry):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -35,6 +35,7 @@ class ExplorerFrame(QWidget):
         layout.addWidget(self.reloadButton)
         layout.addWidget(self.fileTree)
         layout.addWidget(self.openButton)
+        self.setLayout(layout)
 
 
 class _FileFinderThread(QThread):


### PR DESCRIPTION
This PR will close #42.

First of all, please check and merge the PR #43.

I implmented the left parts of #42:
1. Create the build arguments entries.
2. Submit the experiment with the editted arguments.

### Create the build arguments entries
Each entry is an instance of `_BaseEntry` and has the `nameLabel` to show the argument name.
Each entry type is implemented as a subclass of `_BaseEntry` and it has an appropriate widget such as `QSpinBox`.

### Submit the experiment with the editted arguments
Now, we can submit it with the _actual_ arguments not the default values using `_BaseEntry.value()`.

### Result
<img width="50%" src="https://github.com/snu-quiqcl/iquip/assets/76851886/740880f2-5346-48e3-ba27-158cf963c53d">

If you want to test more various experiments, I can offer you some tips!