### PR TITLE
Initialize the code viewer GUI

### DIFF
--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -231,7 +231,11 @@ class ExplorerApp(qiwis.BaseApp):
                 module="iquip.apps.visualizer",
                 cls="VisualizerApp",
                 show=True,
-                pos="left"
+                pos="left",
+                args={
+                    "experimentPath": experimentPath,
+                    "experimentClsName": experimentClsName
+                }
             )
         )
 

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -39,6 +39,7 @@ class ExplorerFrame(QWidget):
         layout.addWidget(self.reloadButton)
         layout.addWidget(self.fileTree)
         layout.addWidget(self.openButton)
+        layout.addWidget(self.visualizeButton)
 
 
 class _FileFinderThread(QThread):
@@ -109,6 +110,7 @@ class ExplorerApp(qiwis.BaseApp):
         self.explorerFrame.fileTree.itemExpanded.connect(self.lazyLoadFile)
         self.explorerFrame.reloadButton.clicked.connect(self.loadFileTree)
         self.explorerFrame.openButton.clicked.connect(self.openExperiment)
+        self.explorerFrame.visualizeButton.clicked.connect(self.openExperiment)
 
     @pyqtSlot()
     def loadFileTree(self):
@@ -168,14 +170,16 @@ class ExplorerApp(qiwis.BaseApp):
 
     @pyqtSlot()
     def openExperiment(self):
-        """Opens the experiment builder of the selected experiment.
+        """Opens the experiment builder or visualizer of the selected experiment.
 
-        Once the openButton is clicked, this is called.
+        Once the openButton or openVisualizer is clicked, this is called.
         If the selected element is a directory, it will be ignored.
         """
         experimentFileItem = self.explorerFrame.fileTree.currentItem()
         experimentPath = self.fullPath(experimentFileItem)
-        self.thread = ExperimentInfoThread(experimentPath, self.openBuilder, self)
+        callback = self.openBuilder if self.sender() == self.explorerFrame.openButton \
+                   else self.openVisualizer
+        self.thread = ExperimentInfoThread(experimentPath, callback, self)
         self.thread.start()
 
     def openBuilder(
@@ -186,13 +190,11 @@ class ExplorerApp(qiwis.BaseApp):
     ):
         """Opens the experiment builder with its information.
         
-        This is the callback function of apps.builder.ExperimentInfoThread.
+        This is the callback function of iquip.apps.thread.ExperimentInfoThread.
         The experiment is guaranteed to be the correct experiment file.
 
         Args:
-            experimentPath: The path of the experiment file.
-            experimentClsName: The class name of the experiment.
-            experimentInfo: The experiment information. See protocols.ExperimentInfo.
+            See the signals section in iquip.apps.thread.ExperimentInfoThread.
         """
         self.qiwiscall.createApp(
             name=f"builder_{experimentPath}",
@@ -206,6 +208,30 @@ class ExplorerApp(qiwis.BaseApp):
                     "experimentClsName": experimentClsName,
                     "experimentInfo": experimentInfo
                 }
+            )
+        )
+
+    def openVisualizer(
+        self,
+        experimentPath: str,
+        experimentClsName: str,
+        _experimentInfo: ExperimentInfo
+    ):
+        """Opens the experiment visualizer with its information.
+        
+        This is the callback function of iquip.apps.thread.ExperimentInfoThread.
+        The experiment is guaranteed to be the correct experiment file.
+
+        Args:
+            See the signals section in iquip.apps.thread.ExperimentInfoThread.
+        """
+        self.qiwiscall.createApp(
+            name=f"visualizer_{experimentPath}",
+            info=qiwis.AppInfo(
+                module="iquip.apps.visualizer",
+                cls="VisualizerApp",
+                show=True,
+                pos="left"
             )
         )
 

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -20,6 +20,9 @@ class ExplorerFrame(QWidget):
         fileTree: The tree widget for showing the file structure.
         reloadButton: The button for reloading the fileTree.
         openButton: The button for opening the selected experiment file.
+        visualizeButton: The button for opening the code and sequence viewers.
+    
+    TODO(BECATRUE): The visualizeButton will be moved into the builder app after it is finished.
     """
 
     def __init__(self, parent: Optional[QWidget] = None):
@@ -30,6 +33,7 @@ class ExplorerFrame(QWidget):
         self.fileTree.header().setVisible(False)
         self.reloadButton = QPushButton("Reload", self)
         self.openButton = QPushButton("Open", self)
+        self.visualizeButton = QPushButton("Visualize", self)
         # layout
         layout = QVBoxLayout(self)
         layout.addWidget(self.reloadButton)

--- a/iquip/apps/thread.py
+++ b/iquip/apps/thread.py
@@ -13,6 +13,10 @@ class ExperimentInfoThread(QThread):
     Signals:
         fetched(experimentPath, experimentClsName, experimentInfo):
           The experiment infomation is fetched.
+          Its arguments are as follows:
+            experimentPath: The path of the experiment file.
+            experimentClsName: The class name of the experiment.
+            experimentInfo: The experiment information. See protocols.ExperimentInfo.
     
     Attributes:
         experimentPath: The path of the experiment file.

--- a/iquip/apps/visualizer.py
+++ b/iquip/apps/visualizer.py
@@ -1,6 +1,7 @@
 """App module for visualizing the experiment code."""
 
-from typing import Callable, Optional, Tuple
+import ast
+from typing import Callable, List, Optional, Tuple
 
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
@@ -106,7 +107,28 @@ class VisualizerApp(qiwis.BaseApp):
         self.thread.start()
 
     def loadViewer(self, code: str):
-        pass
+        stmtList = self.findExperimentStmtList(code)
+
+    def findExperimentStmtList(self, code: str) -> List[ast.stmt]:
+        """Finds run() of the given experiment code and returns its statement list as ast types.
+
+        Args:
+            code: The experiment code.
+
+        Returns:
+            A list of all statements in run() of the given experiment code.
+            Each element is an instance of ast.stmt class.
+        """
+        fullStmtList = ast.parse(code).body
+        experimentClsStmtList = next(
+            stmt for stmt in fullStmtList
+            if isinstance(stmt, ast.ClassDef) and stmt.name == self.experimentClsName
+        ).body
+        runFunctionStmtList = next(
+            stmt for stmt in experimentClsStmtList
+            if isinstance(stmt, ast.FunctionDef) and stmt.name == "run"
+        ).body
+        return runFunctionStmtList
 
     def frames(self) -> Tuple[CodeViewerFrame]:
         """Overridden."""

--- a/iquip/apps/visualizer.py
+++ b/iquip/apps/visualizer.py
@@ -18,7 +18,7 @@ class CodeViewerFrame(QWidget):
 
 
 class VisualizerApp(qiwis.BaseApp):
-    """App for showing the code viewer and the sequence viewer."""
+    """App for showing the code and sequence viewers."""
 
     def __init__(self, name: str, parent: Optional[QObject] = None):
         """Extended."""

--- a/iquip/apps/visualizer.py
+++ b/iquip/apps/visualizer.py
@@ -3,7 +3,7 @@
 from typing import Optional, Tuple
 
 from PyQt5.QtCore import QObject
-from PyQt5.QtWidgets import QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QTreeWidget, QVBoxLayout, QWidget
 
 import qiwis
 
@@ -13,8 +13,11 @@ class CodeViewerFrame(QWidget):
     def __init__(self, parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(parent=parent)
+        # widgets
+        self.viewer = QTreeWidget(self)
         # layout
         layout = QVBoxLayout(self)
+        layout.addWidget(self.viewer)
 
 
 class VisualizerApp(qiwis.BaseApp):

--- a/iquip/apps/visualizer.py
+++ b/iquip/apps/visualizer.py
@@ -1,7 +1,7 @@
 """App module for visualizing the experiment code."""
 
 import ast
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Union
 
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
@@ -115,9 +115,7 @@ class VisualizerApp(qiwis.BaseApp):
             code: The experiment code.
         """
         stmtList = self.findExperimentStmtList(code)
-        for stmt in stmtList:
-            stmtText = ast.get_source_segment(code, stmt)
-            self.addCodeViewerItem(stmt.lineno, stmtText)
+        self._addCodeViewerItem(code, stmtList, self.codeViewerFrame.viewerTree)
 
     def findExperimentStmtList(self, code: str) -> List[ast.stmt]:
         """Finds run() of the given experiment code and returns its statement list as ast types.
@@ -140,16 +138,33 @@ class VisualizerApp(qiwis.BaseApp):
         ).body
         return runFunctionStmtList
 
-    def addCodeViewerItem(self, lineno: int, content: str):
-        """Adds the given information into self.codeViewerFrame.viewerTree.
+    def _addCodeViewerItem(
+        self,
+        code: str,
+        stmtList: List[ast.stmt],
+        widget: Union[QTreeWidget, QTreeWidgetItem]
+    ):
+        """Adds the statements into the chlidren of the widget.
         
         Args:
-            lineno: The code line number.
-            content: It will be set to a raw code text.
+            code: The experiment code.
+            stmtList: The list of statements.
+            widget: The statements will be added under this widget.
         """
-        stmtItem = QTreeWidgetItem(self.codeViewerFrame.viewerTree)
-        stmtItem.setText(0, str(lineno))
-        stmtItem.setText(1, content)
+        for stmt in stmtList:
+            stmtText = ast.get_source_segment(code, stmt)
+            self._setCodeViewerItemContent(QTreeWidgetItem(widget), stmt.lineno, stmtText)
+
+    def _setCodeViewerItemContent(self, item: QTreeWidgetItem, lineno: int, content: str):
+        """Sets the given information as contents of the item.
+        
+        Args:
+            item: The statement item to set contents.
+            lineno: The code line number.
+            content: The raw code text.
+        """
+        item.setText(0, str(lineno))
+        item.setText(1, content)
 
     def frames(self) -> Tuple[CodeViewerFrame]:
         """Overridden."""

--- a/iquip/apps/visualizer.py
+++ b/iquip/apps/visualizer.py
@@ -1,10 +1,21 @@
 """App module for visualizing the experiment code."""
 
-from typing import Optional
+from typing import Optional, Tuple
 
 from PyQt5.QtCore import QObject
+from PyQt5.QtWidgets import QVBoxLayout, QWidget
 
 import qiwis
+
+class CodeViewerFrame(QWidget):
+    """Frame for showing the code viewer."""
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        """Extended."""
+        super().__init__(parent=parent)
+        # layout
+        layout = QVBoxLayout(self)
+
 
 class VisualizerApp(qiwis.BaseApp):
     """App for showing the code viewer and the sequence viewer."""
@@ -12,3 +23,8 @@ class VisualizerApp(qiwis.BaseApp):
     def __init__(self, name: str, parent: Optional[QObject] = None):
         """Extended."""
         super().__init__(name, parent=parent)
+        self.codeViewerFrame = CodeViewerFrame()
+
+    def frames(self) -> Tuple[CodeViewerFrame]:
+        """Overridden."""
+        return (self.codeViewerFrame,)

--- a/iquip/apps/visualizer.py
+++ b/iquip/apps/visualizer.py
@@ -18,6 +18,7 @@ class CodeViewerFrame(QWidget):
         # widgets
         self.viewerTree = QTreeWidget(self)
         self.viewerTree.setColumnCount(2)
+        self.viewerTree.setHeaderLabels(["line", "code"])
         # layout
         layout = QVBoxLayout(self)
         layout.addWidget(self.viewerTree)

--- a/iquip/apps/visualizer.py
+++ b/iquip/apps/visualizer.py
@@ -1,8 +1,8 @@
 """App module for visualizing the experiment code."""
 
-from typing import Optional, Tuple
+from typing import Callable, Optional, Tuple
 
-from PyQt5.QtCore import QObject
+from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal
 from PyQt5.QtWidgets import QTreeWidget, QVBoxLayout, QWidget
 
 import qiwis
@@ -18,6 +18,31 @@ class CodeViewerFrame(QWidget):
         # layout
         layout = QVBoxLayout(self)
         layout.addWidget(self.viewer)
+
+
+class ExperimentCodeThread(QThread):
+    """QThread for obtaining the experiment code from the proxy server.
+    
+    Attributes:
+        experimentPath: The path of the experiment file.
+    """
+
+    fetched = pyqtSignal()
+
+    def __init__(
+        self,
+        experimentPath: str,
+        callback: Callable[..., None],
+        parent: Optional[QObject] = None
+    ):
+        """Extended.
+        
+        Args:
+            experimentPath: See the attributes section in ExperimentCodeThread.
+        """
+        super().__init__(parent=parent)
+        self.experimentPath = experimentPath
+        self.fetched.connect(callback, type=Qt.QueuedConnection)
 
 
 class VisualizerApp(qiwis.BaseApp):

--- a/iquip/apps/visualizer.py
+++ b/iquip/apps/visualizer.py
@@ -20,7 +20,13 @@ class CodeViewerFrame(QWidget):
 class VisualizerApp(qiwis.BaseApp):
     """App for showing the code and sequence viewers."""
 
-    def __init__(self, name: str, parent: Optional[QObject] = None):
+    def __init__(
+        self,
+        name: str,
+        experimentPath: str,
+        experimentClsName: str,
+        parent: Optional[QObject] = None
+    ):
         """Extended."""
         super().__init__(name, parent=parent)
         self.codeViewerFrame = CodeViewerFrame()

--- a/iquip/apps/visualizer.py
+++ b/iquip/apps/visualizer.py
@@ -1,0 +1,14 @@
+"""App module for visualizing the experiment code."""
+
+from typing import Optional
+
+from PyQt5.QtCore import QObject
+
+import qiwis
+
+class VisualizerApp(qiwis.BaseApp):
+    """App for showing the code viewer and the sequence viewer."""
+
+    def __init__(self, name: str, parent: Optional[QObject] = None):
+        """Extended."""
+        super().__init__(name, parent=parent)


### PR DESCRIPTION
This PR will close #52.

As I said in #52, I implemented two things.
1. Initialize the code viewer as a `QTreeWidget`.
2. Show all statements of run() just in series.

_NOT IMPLEMENTED_
- All control and loop statement such as `if` and `for`.
- Remove unnecessary statements.
- For control or loop statement, show only the first line, i.e. except for the body.

### Examples
#### Code
```python
from artiq.experiment import *

class VisualizeTest(EnvExperiment):
    """Visualize Test"""

    def build(self):
        self.setattr_device("core")
        self.setattr_device("a")
        self.setattr_device("b")

    @kernel
    def run(self):
        self.a.pulse(1*MHz, 1*us)
        with parallel:
            self.b.pulse(1*MHz, 1*us)
            self.a.pulse(1*MHz, 1*us)
```

#### GUI
<img width="60%" src="https://github.com/snu-quiqcl/iquip/assets/76851886/4e839396-4783-42df-bbb6-94332d20381a">
