### PR TITLE
Set the scheduler options in the builder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @kangz12345 @BECATRUE

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -403,7 +403,7 @@ class BuilderApp(qiwis.BaseApp):
             self.builderFrame.schedOptsListWidget.setItemWidget(item, widget)
 
     def argumentsFromListWidget(self, listWidget: QListWidget) -> Dict[str, Any]:
-        """Gets arguments from the given list widget and return them.
+        """Gets arguments from the given list widget and returns them.
         
         Args:
             listWidget: The QListWidget containing _BaseEntry instances.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -195,7 +195,7 @@ class _DateTimeEntry(_BaseEntry):
 
     def __init__(self, name: str, parent: Optional[QWidget] = None):
         """Extended."""
-        super().__init__(name, parent=parent)
+        super().__init__(name, {}, parent=parent)
         # widgets
         self.checkBox = QCheckBox(self)
         self.checkBox.setChecked(False)
@@ -380,9 +380,23 @@ class BuilderApp(qiwis.BaseApp):
         
         There are three options; pipeline, priority, and timed.
         """
+        pipelineInfo = {
+            "default": "main"
+        }
+        priorityInfo = {
+            "default": 1,
+            "unit": "",
+            "scale": 1,
+            "step": 1,
+            "min": 1,
+            "max": 10,
+            "ndecimals": 0,
+            "type": "int"
+        }
+        print(1)
         for widget in (
-            _StringEntry("pipeline", "main"),
-            _NumberEntry("priority", "", 1., 1., 0., 10., 0, "int", 0.),
+            _StringEntry("pipeline", pipelineInfo),
+            _NumberEntry("priority", priorityInfo),
             _DateTimeEntry("timed")
         ):
             item = QListWidgetItem(self.builderFrame.schedOptsListWidget)

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -198,10 +198,12 @@ class BuilderFrame(QWidget):
         super().__init__(parent=parent)
         # widgets
         self.argsListWidget = QListWidget(self)
+        self.schedOptsListWidget = QListWidget(self)
         self.submitButton = QPushButton("Submit", self)
         # layout
         layout = QVBoxLayout(self)
         layout.addWidget(self.argsListWidget)
+        layout.addWidget(self.schedOptsListWidget)
         layout.addWidget(self.submitButton)
 
 
@@ -299,6 +301,7 @@ class BuilderApp(qiwis.BaseApp):
         self.experimentClsName = experimentClsName
         self.builderFrame = BuilderFrame()
         self.initArgsEntry(ExperimentInfo(**experimentInfo))
+        self.initSchedOptsEntry()
         # connect signals to slots
         self.builderFrame.submitButton.clicked.connect(self.submit)
 
@@ -322,6 +325,12 @@ class BuilderApp(qiwis.BaseApp):
             item.setSizeHint(widget.sizeHint())
             self.builderFrame.argsListWidget.addItem(item)
             self.builderFrame.argsListWidget.setItemWidget(item, widget)
+
+    def initSchedOptsEntry(self):
+        """Initializes the scheduler options entry.
+        
+        There are three options; pipeline, priority, and timed.
+        """
 
     @pyqtSlot()
     def submit(self):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -302,8 +302,7 @@ class ExperimentSubmitThread(QThread):
         except TypeError:
             print("Failed to convert the build arguments to a JSON string.")
             return
-        for schedOptName, schedOptValue in self.schedOpts.items():
-            params[schedOptName] = schedOptValue
+        params.update(self.schedOpts)
         try:
             response = requests.get("http://127.0.0.1:8000/experiment/submit/",
                                     params=params,

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -393,7 +393,6 @@ class BuilderApp(qiwis.BaseApp):
             "ndecimals": 0,
             "type": "int"
         }
-        print(1)
         for widget in (
             _StringEntry("pipeline", pipelineInfo),
             _NumberEntry("priority", priorityInfo),

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -4,10 +4,10 @@ import json
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import requests
-from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import QDateTime, QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
-    QCheckBox, QComboBox, QDoubleSpinBox, QHBoxLayout, QLabel, QLineEdit, QListWidget,
-    QListWidgetItem, QPushButton, QVBoxLayout, QWidget
+    QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QHBoxLayout, QLabel, QLineEdit,
+    QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QWidget
 )
 
 import qiwis
@@ -185,6 +185,29 @@ class _StringEntry(_BaseEntry):
         return self.lineEdit.text()
 
 
+class _DateTimeEntry(_BaseEntry):
+    """Entry class for a date and time value."""
+
+    def __init__(self, name: str, parent: Optional[QWidget] = None):
+        """Extended."""
+        super().__init__(name, parent=parent)
+        # widgets
+        currentDateTime = QDateTime.currentDateTime()
+        self.dateTimeEdit = QDateTimeEdit(currentDateTime, self)
+        self.dateTimeEdit.setCalendarPopup(True)
+        self.dateTimeEdit.setDisplayFormat("yyyy-MM-dd HH:mm:ss")
+        self.dateTimeEdit.setMinimumDateTime(currentDateTime)
+        # layout
+        self.layout.addWidget(self.dateTimeEdit)
+
+    def value(self) -> str:
+        """Overridden.
+        
+        Returns the value of the dateTimeEdit in ISO format.
+        """
+        return self.dateTimeEdit.dateTime().toString(Qt.ISODate)
+
+
 class BuilderFrame(QWidget):
     """Frame for showing the build arguments and requesting to submit it.
     
@@ -339,7 +362,8 @@ class BuilderApp(qiwis.BaseApp):
         """
         for widget in (
             _StringEntry("pipeline", "main"),
-            _NumberEntry("priority", "", 1., 1., 0., 10., 0, "int", 0.)
+            _NumberEntry("priority", "", 1., 1., 0., 10., 0, "int", 0.),
+            _DateTimeEntry("timed")
         ):
             item = QListWidgetItem(self.builderFrame.schedOptsListWidget)
             item.setSizeHint(widget.sizeHint())

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -339,6 +339,7 @@ class BuilderApp(qiwis.BaseApp):
         """
         for widget in (
             _StringEntry("pipeline", "main"),
+            _NumberEntry("priority", "", 1., 1., 0., 10., 0, "int", 0.)
         ):
             item = QListWidgetItem(self.builderFrame.schedOptsListWidget)
             item.setSizeHint(widget.sizeHint())

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -186,7 +186,12 @@ class _StringEntry(_BaseEntry):
 
 
 class _DateTimeEntry(_BaseEntry):
-    """Entry class for a date and time value."""
+    """Entry class for a date and time value.
+    
+    Attributes:
+        checkBox: The checkbox for the availability of the dateTimeEdit.
+        dateTimeEdit: The dateTimeEdit for the date and time value.
+    """
 
     def __init__(self, name: str, parent: Optional[QWidget] = None):
         """Extended."""
@@ -213,12 +218,14 @@ class _DateTimeEntry(_BaseEntry):
         """
         self.dateTimeEdit.setEnabled(self.checkBox.isChecked())
 
-    def value(self) -> str:
+    def value(self) -> Optional[str]:
         """Overridden.
         
-        Returns the value of the dateTimeEdit in ISO format.
+        Returns the value of the dateTimeEdit in ISO format if it is enabled.
+        Otherwise returns None.
         """
-        return self.dateTimeEdit.dateTime().toString(Qt.ISODate)
+        return self.dateTimeEdit.dateTime().toString(Qt.ISODate) if self.dateTimeEdit.isEnabled() \
+               else None
 
 
 class BuilderFrame(QWidget):
@@ -397,7 +404,9 @@ class BuilderApp(qiwis.BaseApp):
         for row in range(listWidget.count()):
             item = listWidget.item(row)
             widget = listWidget.itemWidget(item)
-            args[widget.name] = widget.value()
+            value = widget.value()
+            if value is not None:
+                args[widget.name] = value
         return args
 
     @pyqtSlot()

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -212,7 +212,7 @@ class _DateTimeEntry(_BaseEntry):
 
     @pyqtSlot()
     def updateDateTimeEditState(self):
-        """Enables or disables the dateTimeEdit in according to the state of the checkBox.
+        """Enables or disables the dateTimeEdit according to the state of the checkBox.
         
         Once the state of the checkBox is changed, this is called.
         """
@@ -404,7 +404,7 @@ class BuilderApp(qiwis.BaseApp):
             self.builderFrame.schedOptsListWidget.setItemWidget(item, widget)
 
     def argumentsFromListWidget(self, listWidget: QListWidget) -> Dict[str, Any]:
-        """Get arguments from the given list widget and return them.
+        """Gets arguments from the given list widget and return them.
         
         Args:
             listWidget: The QListWidget containing _BaseEntry instances.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -233,6 +233,7 @@ class BuilderFrame(QWidget):
     
     Attributes:
         argsListWidget: The list widget with the build arguments.
+        schedOptsListWidget: The list widget with the schedule options.
         submitButton: The button for submitting the experiment.
     """
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -224,8 +224,9 @@ class _DateTimeEntry(_BaseEntry):
         Returns the value of the dateTimeEdit in ISO format if the checkBox is enabled.
         Otherwise returns None.
         """
-        return (self.dateTimeEdit.dateTime().toString(Qt.ISODate) if self.checkBox.isChecked()
-                else None)
+        if self.checkBox.isChecked():
+            return self.dateTimeEdit.dateTime().toString(Qt.ISODate)
+        return None
 
 class BuilderFrame(QWidget):
     """Frame for showing the build arguments and requesting to submit it.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -221,10 +221,10 @@ class _DateTimeEntry(_BaseEntry):
     def value(self) -> Optional[str]:
         """Overridden.
         
-        Returns the value of the dateTimeEdit in ISO format if it is enabled.
+        Returns the value of the dateTimeEdit in ISO format if the checkBox is enabled.
         Otherwise returns None.
         """
-        return (self.dateTimeEdit.dateTime().toString(Qt.ISODate) if self.dateTimeEdit.isEnabled()
+        return (self.dateTimeEdit.dateTime().toString(Qt.ISODate) if self.checkBox.isChecked()
                 else None)
 
 class BuilderFrame(QWidget):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -192,13 +192,26 @@ class _DateTimeEntry(_BaseEntry):
         """Extended."""
         super().__init__(name, parent=parent)
         # widgets
+        self.checkBox = QCheckBox(self)
+        self.checkBox.setChecked(False)
+        self.checkBox.stateChanged.connect(self.updateDateTimeEditState)
         currentDateTime = QDateTime.currentDateTime()
         self.dateTimeEdit = QDateTimeEdit(currentDateTime, self)
         self.dateTimeEdit.setCalendarPopup(True)
         self.dateTimeEdit.setDisplayFormat("yyyy-MM-dd HH:mm:ss")
+        self.dateTimeEdit.setEnabled(False)
         self.dateTimeEdit.setMinimumDateTime(currentDateTime)
         # layout
+        self.layout.addWidget(self.checkBox)
         self.layout.addWidget(self.dateTimeEdit)
+
+    @pyqtSlot()
+    def updateDateTimeEditState(self):
+        """Enables or disables the dateTimeEdit in according to the state of the checkBox.
+        
+        Once the state of the checkBox is changed, this is called.
+        """
+        self.dateTimeEdit.setEnabled(self.checkBox.isChecked())
 
     def value(self) -> str:
         """Overridden.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -224,9 +224,8 @@ class _DateTimeEntry(_BaseEntry):
         Returns the value of the dateTimeEdit in ISO format if it is enabled.
         Otherwise returns None.
         """
-        return self.dateTimeEdit.dateTime().toString(Qt.ISODate) if self.dateTimeEdit.isEnabled() \
-               else None
-
+        return (self.dateTimeEdit.dateTime().toString(Qt.ISODate) if self.dateTimeEdit.isEnabled()
+                else None)
 
 class BuilderFrame(QWidget):
     """Frame for showing the build arguments and requesting to submit it.


### PR DESCRIPTION
I added the scheduler options in the builder app.

### Functions
There are three scheduler options.
- Pipeline: The pipeline to run the experiment in.
- Priority: Higher value means sooner scheduling.
- Timed: The due date for the experiment in ISO format. None for no due date.

I added these options using several `Entry` classes implemented in #47.

### Examples
![image](https://github.com/snu-quiqcl/iquip/assets/76851886/47ca0578-88c3-4457-bf48-d2883f28b363)
![image](https://github.com/snu-quiqcl/iquip/assets/76851886/028fa847-8237-418d-8015-9216a4a04a7b)


