### PR TITLE
Implement the left unit tests for builder app (1/2)

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -30,5 +30,5 @@ jobs:
         pip install git+https://github.com/snu-quiqcl/qiwis.git@${{ env.QIWIS_VERSION }}
     - name: Run the unit tests and check coverage
       run: |
-        xvfb-run `which coverage` run -m unittest discover
-        xvfb-run `which coverage` report --include="iquip/*.py"
+        xvfb-run `which coverage` run --source=iquip/ -m unittest discover
+        xvfb-run `which coverage` report

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -228,6 +228,7 @@ class _DateTimeEntry(_BaseEntry):
             return self.dateTimeEdit.dateTime().toString(Qt.ISODate)
         return None
 
+
 class BuilderFrame(QWidget):
     """Frame for showing the build arguments and requesting to submit it.
     

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -5,10 +5,9 @@ import unittest
 from unittest import mock
 
 from PyQt5.QtCore import QObject
-from PyQt5.QtWidgets import QApplication, QListWidget, QWidget
+from PyQt5.QtWidgets import QApplication, QWidget
 
 from iquip.apps import builder
-from iquip import protocols
 
 EXPERIMENT_INFO = {
     "name": "name",

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -4,7 +4,6 @@ import copy
 import unittest
 from unittest import mock
 
-from PyQt5.QtCore import QObject
 from PyQt5.QtWidgets import QApplication, QWidget
 
 from iquip.apps import builder

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -79,7 +79,6 @@ class BuilderAppTest(unittest.TestCase):
             experimentPath="experimentPath",
             experimentClsName="experimentClsName",
             experimentInfo=copy.deepcopy(EXPERIMENT_INFO),
-            parent=QObject()
         )
         for argName, (argInfo, *_) in EXPERIMENT_INFO["arginfo"].items():
             self.mockedEntries[argInfo.pop("ty")].assert_any_call(argName, argInfo)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -52,17 +52,17 @@ class BuilderAppTest(unittest.TestCase):
 
     def setUp(self):
         self.qapp = QApplication([])
-        self.mockedEntries = {
+        self.mocked_entries = {
             f"{type_}Value": mock.MagicMock(return_value=QWidget())
             for type_ in ("Boolean", "String", "Enumeration", "Number")
         }
         experiment_submit_thread_patcher = mock.patch("iquip.apps.builder.ExperimentSubmitThread")
         entries_patcher = mock.patch.multiple(
             "iquip.apps.builder",
-            _BooleanEntry=self.mockedEntries["BooleanValue"],
-            _StringEntry=self.mockedEntries["StringValue"],
-            _EnumerationEntry=self.mockedEntries["EnumerationValue"],
-            _NumberEntry=self.mockedEntries["NumberValue"]
+            _BooleanEntry=self.mocked_entries["BooleanValue"],
+            _StringEntry=self.mocked_entries["StringValue"],
+            _EnumerationEntry=self.mocked_entries["EnumerationValue"],
+            _NumberEntry=self.mocked_entries["NumberValue"]
         )
         self.mocked_submit_thread_cls = experiment_submit_thread_patcher.start()
         entries_patcher.start()
@@ -80,7 +80,7 @@ class BuilderAppTest(unittest.TestCase):
             experimentInfo=copy.deepcopy(EXPERIMENT_INFO)
         )
         for argName, (argInfo, *_) in EXPERIMENT_INFO["arginfo"].items():
-            self.mockedEntries[argInfo.pop("ty")].assert_any_call(argName, argInfo)
+            self.mocked_entries[argInfo.pop("ty")].assert_any_call(argName, argInfo)
 
 
 if __name__ == "__main__":

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -66,7 +66,7 @@ class BuilderAppTest(unittest.TestCase):
             _NumberEntry=self.mockedEntries["NumberValue"]
         )
         self.mocked_submit_thread_cls = experiment_submit_thread_patcher.start()
-        self.mocked_entries = entries_patcher.start()
+        entries_patcher.start()
         self.addCleanup(experiment_submit_thread_patcher.stop)
         self.addCleanup(entries_patcher.stop)
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -54,10 +54,8 @@ class BuilderAppTest(unittest.TestCase):
     def setUp(self):
         self.qapp = QApplication([])
         self.mockedEntries = {
-            "BooleanValue": mock.MagicMock(return_value=QWidget()),
-            "StringValue": mock.MagicMock(return_value=QWidget()),
-            "EnumerationValue": mock.MagicMock(return_value=QWidget()),
-            "NumberValue": mock.MagicMock(return_value=QWidget())
+            f"{type_}Value": mock.MagicMock(return_value=QWidget())
+            for type_ in ("Boolean", "String", "Enumeration", "Number")
         }
         experiment_submit_thread_patcher = mock.patch("iquip.apps.builder.ExperimentSubmitThread")
         entries_patcher = mock.patch.multiple(

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -78,7 +78,7 @@ class BuilderAppTest(unittest.TestCase):
             name="name",
             experimentPath="experimentPath",
             experimentClsName="experimentClsName",
-            experimentInfo=copy.deepcopy(EXPERIMENT_INFO),
+            experimentInfo=copy.deepcopy(EXPERIMENT_INFO)
         )
         for argName, (argInfo, *_) in EXPERIMENT_INFO["arginfo"].items():
             self.mockedEntries[argInfo.pop("ty")].assert_any_call(argName, argInfo)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,37 @@
+"""Unit tests for builder module."""
+
+import unittest
+from unittest import mock
+
+from iquip.apps import builder
+
+class _BaseEntryTest(unittest.TestCase):
+    """Unit tests for _BaseEntry class."""
+
+
+class _BooleanEntryTest(unittest.TestCase):
+    """Unit tests for _BooleanEntry class."""
+
+
+class _EnumerationEntryTest(unittest.TestCase):
+    """Unit tests for _EnumerationEntry class."""
+
+
+class _NumberEntryTest(unittest.TestCase):
+    """Unit tests for _NumberEntry class."""
+
+
+class _StringEntryTest(unittest.TestCase):
+    """Unit tests for _StringEntry class."""
+
+
+class _DateTimeEntryTest(unittest.TestCase):
+    """Unit tests for _DateTimeEntry class."""
+
+
+class ExperimentSubmitThreadTest(unittest.TestCase):
+    """Unit tests for ExperimentSubmitThread class."""
+
+
+class BuilderAppTest(unittest.TestCase):
+    """Unit tests for BuilderApp class."""

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -3,6 +3,8 @@
 import unittest
 from unittest import mock
 
+from PyQt5.QtWidgets import QApplication
+
 from iquip.apps import builder
 
 class _BaseEntryTest(unittest.TestCase):
@@ -35,3 +37,12 @@ class ExperimentSubmitThreadTest(unittest.TestCase):
 
 class BuilderAppTest(unittest.TestCase):
     """Unit tests for BuilderApp class."""
+
+    def setUp(self):
+        self.qapp = QApplication([])
+        patcher = mock.patch("iquip.apps.builder.ExperimentSubmitThread")
+        self.mocked_file_finder_thread_cls = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def tearDown(self):
+        del self.qapp

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -31,9 +31,9 @@ class FileFinderThreadTest(unittest.TestCase):
         with mock.patch("iquip.apps.explorer._FileFinderThread.fetched") as mockedFetched:
             thread = explorer._FileFinderThread(path="path", widget=widget,
                                                 callback=callback, parent=parent)
-            self.assertEqual(thread.path, "path")
-            self.assertEqual(thread.widget, widget)
-            mockedFetched.connect.assert_called_once_with(callback, type=Qt.QueuedConnection)
+        self.assertEqual(thread.path, "path")
+        self.assertEqual(thread.widget, widget)
+        mockedFetched.connect.assert_called_once_with(callback, type=Qt.QueuedConnection)
 
     def test_run(self):
         self.mocked_response.json.return_value = ["path1", "path2"]
@@ -44,10 +44,10 @@ class FileFinderThreadTest(unittest.TestCase):
                                                 callback=mock.MagicMock(), parent=parent)
             thread.run()
             thread.wait()
-            self.mocked_get.assert_called_once_with("http://127.0.0.1:8000/ls/",
-                                                    params={"directory": "path"},
-                                                    timeout=10)
-            mockedFetched.emit.assert_called_once_with(["path1", "path2"], widget)
+        self.mocked_get.assert_called_once_with("http://127.0.0.1:8000/ls/",
+                                                params={"directory": "path"},
+                                                timeout=10)
+        mockedFetched.emit.assert_called_once_with(["path1", "path2"], widget)
 
     def test_run_exception(self):
         """Tests when a requests.exceptions.RequestException occurs."""
@@ -59,10 +59,10 @@ class FileFinderThreadTest(unittest.TestCase):
                                                 callback=mock.MagicMock(), parent=parent)
             thread.run()
             thread.wait()
-            self.mocked_get.assert_called_once_with("http://127.0.0.1:8000/ls/",
-                                                    params={"directory": "path"},
-                                                    timeout=10)
-            mockedFetched.emit.assert_not_called()
+        self.mocked_get.assert_called_once_with("http://127.0.0.1:8000/ls/",
+                                                params={"directory": "path"},
+                                                timeout=10)
+        mockedFetched.emit.assert_not_called()
 
 
 class ExplorerAppTest(unittest.TestCase):

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -12,7 +12,6 @@ from PyQt5.QtTest import QTest
 from iquip import protocols
 from iquip.apps import explorer
 
-
 class FileFinderThreadTest(unittest.TestCase):
     """Unit tests for _FileFinderThread class."""
 

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -128,7 +128,7 @@ class ExplorerAppTest(unittest.TestCase):
         self.assertEqual(fileItem.childCount(), 0)  # No child item for a file.
 
     @mock.patch("iquip.apps.explorer.ExperimentInfoThread")
-    def test_open_experiment(self, mockedExperimentInfoThread):
+    def test_open_experiment(self, mocked_experiment_info_thread_cls):
         app = explorer.ExplorerApp(name="name", parent=QObject())
         item = QTreeWidgetItem(app.explorerFrame.fileTree)
         app.explorerFrame.fileTree.setCurrentItem(item)
@@ -137,7 +137,7 @@ class ExplorerAppTest(unittest.TestCase):
         ) as mocked:
             app.openExperiment()
         mocked["fullPath"].assert_called_with(item)
-        mockedExperimentInfoThread.assert_called_with(
+        mocked_experiment_info_thread_cls.assert_called_with(
             mocked["fullPath"].return_value,
             mocked["openBuilder"],
             app
@@ -146,9 +146,9 @@ class ExplorerAppTest(unittest.TestCase):
     def test_open_builder(self):
         app = explorer.ExplorerApp(name="name", parent=QObject())
         experimentInfo = protocols.ExperimentInfo("name", {"arg0": "value0"})
-        with mock.patch.object(app, "qiwiscall") as mockedQiwiscall:
+        with mock.patch.object(app, "qiwiscall") as mocked_qiwiscall:
             app.openBuilder("experimentPath", "experimentClsName", experimentInfo)
-        mockedQiwiscall.createApp.assert_called_with(
+        mocked_qiwiscall.createApp.assert_called_with(
             name="builder_experimentPath",
             info=qiwis.AppInfo(
                 module="iquip.apps.builder",
@@ -190,26 +190,26 @@ class ExplorerFunctionalTest(unittest.TestCase):
         del self.qapp
 
     @mock.patch("iquip.apps.explorer.ExplorerApp.lazyLoadFile")
-    def test_file_tree_item_expanded(self, mockedLazyLoadFile):
+    def test_file_tree_item_expanded(self, mocked_lazy_load_file):
         app = explorer.ExplorerApp(name="name", parent=QObject())
         directoryItem = QTreeWidgetItem(app.explorerFrame.fileTree)
         directoryItem.setText(0, "directory")
         QTreeWidgetItem(directoryItem)  # Add an empty item to an unloaded directory.
         directoryItem.setExpanded(True)
-        mockedLazyLoadFile.assert_called_once()
+        mocked_lazy_load_file.assert_called_once()
 
     @mock.patch("iquip.apps.explorer.ExplorerApp.loadFileTree")
-    def test_reload_button_clicked(self, mockedLoadFileTree):
+    def test_reload_button_clicked(self, mocked_load_file_tree):
         app = explorer.ExplorerApp(name="name", parent=QObject())
         QTest.mouseClick(app.explorerFrame.reloadButton, Qt.LeftButton)
         # Once when the app is created, once explicitly.
-        self.assertEqual(mockedLoadFileTree.call_count, 2)
+        self.assertEqual(mocked_load_file_tree.call_count, 2)
 
     @mock.patch("iquip.apps.explorer.ExplorerApp.openExperiment")
-    def test_open_button_clicked(self, mockedOpenExperiment):
+    def test_open_button_clicked(self, mocked_open_experiment):
         app = explorer.ExplorerApp(name="name", parent=QObject())
         QTest.mouseClick(app.explorerFrame.openButton, Qt.LeftButton)
-        mockedOpenExperiment.assert_called_once()
+        mocked_open_experiment.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -126,13 +126,21 @@ class ExplorerAppTest(unittest.TestCase):
         self.assertEqual(fileItem.text(0), "experiment_file.py")
         self.assertEqual(fileItem.childCount(), 0)  # No child item for a file.
 
-    def test_open_experiment(self):
+    @mock.patch("iquip.apps.explorer.ExperimentInfoThread")
+    def test_open_experiment(self, mockedExperimentInfoThread):
         app = explorer.ExplorerApp(name="name", parent=QObject())
         item = QTreeWidgetItem(app.explorerFrame.fileTree)
         app.explorerFrame.fileTree.setCurrentItem(item)
-        with mock.patch.object(app, "fullPath") as mockedFullPath:
+        with mock.patch.multiple(
+            app, fullPath=mock.DEFAULT, openBuilder=mock.DEFAULT
+        ) as mocked:
             app.openExperiment()
-            mockedFullPath.assert_called_with(item)
+        mocked["fullPath"].assert_called_with(item)
+        mockedExperimentInfoThread.assert_called_with(
+            mocked["fullPath"].return_value,
+            mocked["openBuilder"],
+            app
+        )
 
     def test_full_path(self):
         app = explorer.ExplorerApp(name="name", parent=QObject())

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -29,18 +29,18 @@ class FileFinderThreadTest(unittest.TestCase):
         widget = QTreeWidgetItem()
         callback = mock.MagicMock()
         parent = QObject()
-        with mock.patch("iquip.apps.explorer._FileFinderThread.fetched") as mockedFetched:
+        with mock.patch("iquip.apps.explorer._FileFinderThread.fetched") as mocked_fetched:
             thread = explorer._FileFinderThread(path="path", widget=widget,
                                                 callback=callback, parent=parent)
         self.assertEqual(thread.path, "path")
         self.assertEqual(thread.widget, widget)
-        mockedFetched.connect.assert_called_once_with(callback, type=Qt.QueuedConnection)
+        mocked_fetched.connect.assert_called_once_with(callback, type=Qt.QueuedConnection)
 
     def test_run(self):
         self.mocked_response.json.return_value = ["path1", "path2"]
         widget = QTreeWidgetItem()
         parent = QObject()
-        with mock.patch("iquip.apps.explorer._FileFinderThread.fetched") as mockedFetched:
+        with mock.patch("iquip.apps.explorer._FileFinderThread.fetched") as mocked_fetched:
             thread = explorer._FileFinderThread(path="path", widget=widget,
                                                 callback=mock.MagicMock(), parent=parent)
             thread.run()
@@ -48,14 +48,14 @@ class FileFinderThreadTest(unittest.TestCase):
         self.mocked_get.assert_called_once_with("http://127.0.0.1:8000/ls/",
                                                 params={"directory": "path"},
                                                 timeout=10)
-        mockedFetched.emit.assert_called_once_with(["path1", "path2"], widget)
+        mocked_fetched.emit.assert_called_once_with(["path1", "path2"], widget)
 
     def test_run_exception(self):
         """Tests when a requests.exceptions.RequestException occurs."""
         self.mocked_response.raise_for_status.side_effect = requests.exceptions.RequestException()
         widget = QTreeWidgetItem()
         parent = QObject()
-        with mock.patch("iquip.apps.explorer._FileFinderThread.fetched") as mockedFetched:
+        with mock.patch("iquip.apps.explorer._FileFinderThread.fetched") as mocked_fetched:
             thread = explorer._FileFinderThread(path="path", widget=widget,
                                                 callback=mock.MagicMock(), parent=parent)
             thread.run()
@@ -63,7 +63,7 @@ class FileFinderThreadTest(unittest.TestCase):
         self.mocked_get.assert_called_once_with("http://127.0.0.1:8000/ls/",
                                                 params={"directory": "path"},
                                                 timeout=10)
-        mockedFetched.emit.assert_not_called()
+        mocked_fetched.emit.assert_not_called()
 
 
 class ExplorerAppTest(unittest.TestCase):

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -4,10 +4,12 @@ import unittest
 from unittest import mock
 
 import requests
+import qiwis
 from PyQt5.QtCore import QObject, Qt
 from PyQt5.QtWidgets import QApplication, QTreeWidgetItem
 from PyQt5.QtTest import QTest
 
+from iquip import protocols
 from iquip.apps import explorer
 
 
@@ -140,6 +142,26 @@ class ExplorerAppTest(unittest.TestCase):
             mocked["fullPath"].return_value,
             mocked["openBuilder"],
             app
+        )
+
+    def test_open_builder(self):
+        app = explorer.ExplorerApp(name="name", parent=QObject())
+        experimentInfo = protocols.ExperimentInfo("name", {"arg0": "value0"})
+        with mock.patch.object(app, "qiwiscall") as mockedQiwiscall:
+            app.openBuilder("experimentPath", "experimentClsName", experimentInfo)
+        mockedQiwiscall.createApp.assert_called_with(
+            name="builder_experimentPath",
+            info=qiwis.AppInfo(
+                module="iquip.apps.builder",
+                cls="BuilderApp",
+                show=True,
+                pos="right",
+                args={
+                    "experimentPath": "experimentPath",
+                    "experimentClsName": "experimentClsName",
+                    "experimentInfo": experimentInfo
+                }
+            )
         )
 
     def test_full_path(self):


### PR DESCRIPTION
This PR is related to #68.

I think it will be too long if I implement all the tests, so I submit only half of them first.

I have implemented two things.
1. In `test_explorer.py`, finish tests for opening a builder.
2. In `test_builder.py`, set up for tests about `BuilderApp` class.
Please focus on `BuilderAppTest.setUp()`.