### PR TITLE
Aijuh/74/implement-log-viewer

### DIFF
--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -1,6 +1,7 @@
 """App module for editting the build arguments and submitting the experiment."""
 
 import json
+import logging
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import requests
@@ -12,6 +13,9 @@ from PyQt5.QtWidgets import (
 
 import qiwis
 from iquip.protocols import ExperimentInfo
+
+logger = logging.getLogger(__name__)
+
 
 class _BaseEntry(QWidget):
     """Base class for all argument entries.
@@ -251,7 +255,7 @@ class ExperimentSubmitThread(QThread):
                 "args": json.dumps(self.experimentArgs)
             }
         except TypeError:
-            print("Failed to convert the build arguments to a JSON string.")
+            logger.exception("Failed to convert the build arguments to a JSON string.")
             return
         try:
             response = requests.get("http://127.0.0.1:8000/experiment/submit/",
@@ -260,7 +264,7 @@ class ExperimentSubmitThread(QThread):
             response.raise_for_status()
             rid = response.json()
         except requests.exceptions.RequestException as err:
-            print(err)
+            logger.exception(err)
             return
         self.submitted.emit(rid)
 
@@ -352,7 +356,7 @@ class BuilderApp(qiwis.BaseApp):
         
         TODO(BECATRUE): It will be developed in Log Viewer project.
         """
-        print(f"RID: {rid}")
+        logger.info("RID: %d", rid)
 
     def frames(self) -> Tuple[BuilderFrame]:
         """Overridden."""

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -263,8 +263,8 @@ class ExperimentSubmitThread(QThread):
                                     timeout=10)
             response.raise_for_status()
             rid = response.json()
-        except requests.exceptions.RequestException as err:
-            logger.exception(err)
+        except requests.exceptions.RequestException:
+            logger.exception("Failed to submit the experiment.")
             return
         self.submitted.emit(rid)
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -347,14 +347,12 @@ class BuilderApp(qiwis.BaseApp):
         self.thread.start()
 
     def onSubmitted(self, rid: int):
-        """Prints the rid after submitted.
+        """Sends the rid to the logger after submitted.
 
         This is the callback function of ExperimentSubmitThread.
 
         Args:
             rid: The run identifier of the submitted experiment.
-        
-        TODO(BECATRUE): It will be developed in Log Viewer project.
         """
         logger.info("RID: %d", rid)
 

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -1,6 +1,7 @@
 """App module for showing the experiment list and opening an experiment."""
 
 import posixpath
+import logging
 from typing import Callable, List, Optional, Tuple, Union
 
 import requests
@@ -12,6 +13,9 @@ from PyQt5.QtWidgets import (
 import qiwis
 from iquip.protocols import ExperimentInfo
 from iquip.apps.thread import ExperimentInfoThread
+
+logger = logging.getLogger(__name__)
+
 
 class ExplorerFrame(QWidget):
     """Frame for showing the experiment list and opening an experiment.
@@ -84,7 +88,7 @@ class _FileFinderThread(QThread):
             response.raise_for_status()
             experimentList = response.json()
         except requests.exceptions.RequestException as err:
-            print(err)
+            logger.exception(err)
             return
         self.fetched.emit(experimentList, self.widget)
 

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -87,8 +87,8 @@ class _FileFinderThread(QThread):
                                     timeout=10)
             response.raise_for_status()
             experimentList = response.json()
-        except requests.exceptions.RequestException as err:
-            logger.exception(err)
+        except requests.exceptions.RequestException:
+            logger.exception("Failed to fetch the file list.")
             return
         self.fetched.emit(experimentList, self.widget)
 

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -1,0 +1,201 @@
+"""Module for log viewer in apps."""
+
+import time
+import logging
+from typing import Any, Optional, Tuple, Callable
+
+from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QPushButton, QTextEdit, QLabel, QDialogButtonBox, QComboBox
+)
+
+import qiwis
+
+class _Signaller(QObject):
+    """Signal only for LoggingHandler.
+
+    Signals:
+        signal(log): A formatted log message is emitted. 
+    """
+
+    signal = pyqtSignal(str)
+
+
+class LoggingHandler(logging.Handler):
+    """Handler for logger.
+
+    Sends a log message to connected function using emit.   
+    """
+
+    def __init__(self, slotfunc: Callable[[str], Any]):
+        """Extended.
+
+        Connects the slotfunc to the signal.
+
+        Args:
+            slotfunc: A slot function which is called when a log record is emitted.
+        """
+        super().__init__()
+        self.signaller = _Signaller()
+        self.signaller.signal.connect(slotfunc)
+
+    def emit(self, record: logging.LogRecord):
+        """Overridden.
+        
+        Emits input signal to the connected function.
+        """
+        s = self.format(record)
+        self.signaller.signal.emit(s)
+
+
+class LoggerFrame(QWidget):
+    """Frame for logging.
+
+    Attributes:
+        logEdit: A textEdit which shows all logs.
+        clearButton: A button for clearing all logs.
+        levelBox: A comboBox for setting the logger's level.
+    """
+
+    def __init__(self, parent: Optional[QObject] = None):
+        """Extended."""
+        super().__init__(parent=parent)
+        # widgets
+        self.logEdit = QTextEdit(self)
+        self.logEdit.setReadOnly(True)
+        self.clearButton = QPushButton("Clear")
+        self.levelBox = QComboBox(self)
+        # layout
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.logEdit)
+        layout.addWidget(self.clearButton)
+        layout.addWidget(self.levelBox)
+
+
+class ConfirmClearingFrame(QWidget):
+    """
+    A confirmation frame for log clearing.
+    """
+    confirmed = pyqtSignal()
+
+    def __init__(self, parent: Optional[QObject] = None):
+        """
+        Extended.
+        """
+        super().__init__(parent=parent)
+        # widgets
+        self.label = QLabel("Are you sure to clear?")
+        self.buttonBox = QDialogButtonBox()
+        self.buttonBox.addButton("OK", QDialogButtonBox.AcceptRole)
+        self.buttonBox.addButton("Cancel", QDialogButtonBox.RejectRole)
+        # connect signals
+        self.buttonBox.accepted.connect(self.buttonOKClicked)
+        self.buttonBox.rejected.connect(self.buttonCancelClicked)
+        # layouts
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+        layout.addWidget(self.label)
+        layout.addWidget(self.buttonBox)
+
+    def buttonOKClicked(self):
+        """Clicks OK to clear log."""
+        self.confirmed.emit()
+        self.close()
+
+    def buttonCancelClicked(self):
+        """Clicks Cancel not to clear log."""
+        self.close()
+
+
+class LoggerApp(qiwis.BaseApp):
+    """App for logging.
+
+    Manages a logger frame.
+
+    Attributes:
+        loggerFrame: A frame that shows the logs.
+    """
+
+    def __init__(self, name: str, parent: Optional[QObject] = None):
+        """Extended.
+
+        Args:
+            name: Name of the App
+        """
+        super().__init__(name, parent=parent)
+        self.loggerFrame = LoggerFrame()
+        # connect signals to slots
+        self.loggerFrame.clearButton.clicked.connect(self.checkToClear)
+        self.confirmFrame = ConfirmClearingFrame()
+        self.confirmFrame.confirmed.connect(self.clearLog)
+        self.handler = LoggingHandler(self.addLog)
+        # TODO(aijuh): Change the log format when it is determined.
+        fs ="%(name)s %(message)s"
+        formatter = logging.Formatter(fs)
+        self.handler.setFormatter(formatter)
+        logger = logging.getLogger()
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(self.handler)
+        self.loggerFrame.levelBox.addItems(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
+        self.loggerFrame.levelBox.textActivated.connect(self.setLevel)
+
+    @pyqtSlot(str)
+    def setLevel(self, text: str):
+        """Responds to the setLevelBox widget and changes the handler's level.
+
+        Args:
+            text: Selected level in the level select box.
+                  It should be one of "DEBUG", "INFO", "WARNING", "ERROR" and "CRITICAL".
+                  It should be case-sensitive and any other input is ignored.
+        """
+        level = {
+            "DEBUG": logging.DEBUG,
+            "INFO": logging.INFO,
+            "WARNING": logging.WARNING,
+            "ERROR": logging.ERROR,
+            "CRITICAL": logging.CRITICAL
+        }
+        if text in level:
+            self.handler.setLevel(level[text])
+
+    def frames(self) -> Tuple[LoggerFrame]:
+        """Overridden."""
+        return (self.loggerFrame,)
+
+    @pyqtSlot(str)
+    def addLog(self, content: str):
+        """Adds a channel name and log message.
+
+        Args:
+            content: Received log message.
+        """
+        timeString = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(time.time()))
+        self.loggerFrame.logEdit.insertPlainText(f"{timeString}: {content}\n")
+
+    def receivedSlot(self, channelName: str, content: Any):
+        """Overridden.
+
+        Possible channels are as follows.
+
+        "log": Log channel.
+            See self.addLog().
+        """
+        if channelName == "log":
+            if isinstance(content, str):
+                self.addLog(content)
+            else:
+                (logging.getLogger(__name__)).error("The message for the channel log should be a string.")
+        else:
+            (logging.getLogger(__name__)).error("The message was ignored because "
+                             "the treatment for the channel %s is not implemented.", channelName)
+
+    @pyqtSlot()
+    def checkToClear(self):
+        """Shows a confirmation frame for log clearing."""
+        self.broadcast("log", "Clicked to clear logs")
+        self.confirmFrame.show()
+
+    @pyqtSlot()
+    def clearLog(self):
+        """Clears the log text edit."""
+        self.loggerFrame.logEdit.clear()

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -66,7 +66,7 @@ class LoggerFrame(QWidget):
         # widgets
         self.logEdit = QTextEdit(self)
         self.logEdit.setReadOnly(True)
-        self.clearButton = QPushButton("Clear")
+        self.clearButton = QPushButton("Clear", self)
         self.levelBox = QComboBox(self)
         # layout
         layout = QVBoxLayout(self)
@@ -76,18 +76,15 @@ class LoggerFrame(QWidget):
 
 
 class ConfirmClearingFrame(QWidget):
-    """
-    A confirmation frame for log clearing.
-    """
+    """A confirmation frame for log clearing."""
+
     confirmed = pyqtSignal()
 
     def __init__(self, parent: Optional[QObject] = None):
-        """
-        Extended.
-        """
+        """Extended."""
         super().__init__(parent=parent)
         # widgets
-        self.label = QLabel("Are you sure to clear?")
+        self.label = QLabel("Are you sure to clear?", self)
         self.buttonBox = QDialogButtonBox()
         self.buttonBox.addButton("OK", QDialogButtonBox.AcceptRole)
         self.buttonBox.addButton("Cancel", QDialogButtonBox.RejectRole)
@@ -101,12 +98,12 @@ class ConfirmClearingFrame(QWidget):
         layout.addWidget(self.buttonBox)
 
     def buttonOKClicked(self):
-        """Clicks OK to clear log."""
+        """Called when the OK button is clicked."""
         self.confirmed.emit()
         self.close()
 
     def buttonCancelClicked(self):
-        """Clicks Cancel not to clear log."""
+        """Clicked Cancel not to clear log."""
         self.close()
 
 
@@ -117,6 +114,8 @@ class LoggerApp(qiwis.BaseApp):
 
     Attributes:
         loggerFrame: A frame that shows the logs.
+        confirmFame: A frame that asks to whether clear logs.
+        handler: A handler for adding logs to GUI. 
     """
 
     def __init__(self, name: str, parent: Optional[QObject] = None):
@@ -150,8 +149,8 @@ class LoggerApp(qiwis.BaseApp):
 
         Args:
             text: Selected level in the level select box.
-                  It should be one of "DEBUG", "INFO", "WARNING", "ERROR" and "CRITICAL".
-                  It should be case-sensitive and any other input is ignored.
+              It should be one of "DEBUG", "INFO", "WARNING", "ERROR" and "CRITICAL".
+              It should be case-sensitive and any other input is ignored.
         """
         level = {
             "DEBUG": logging.DEBUG,
@@ -162,6 +161,7 @@ class LoggerApp(qiwis.BaseApp):
         }
         if text in level:
             self.handler.setLevel(level[text])
+            (logging.getLogger()).setLevel(level[text])  
 
     def frames(self) -> Tuple[LoggerFrame]:
         """Overridden."""
@@ -180,7 +180,7 @@ class LoggerApp(qiwis.BaseApp):
     @pyqtSlot()
     def checkToClear(self):
         """Shows a confirmation frame for log clearing."""
-        logger.info("Clicked to clear logs")
+        logger.info("Clear button is clicked to clear logs")
         self.confirmFrame.show()
 
     @pyqtSlot()

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -83,7 +83,9 @@ class ConfirmClearingFrame(QWidget):
     Attributes:
         label: The label for displaying a confirmation message to clear logs in the LoggerFrame.
         buttonBox: The buttonBox with OK and Cancel button to check whether to clear logs.
-        confirmed: A pyqtSignal that emits signal when Ok button clicked. 
+
+    Signals:
+        confirmed: A pyqtSignal that emits signal when Ok button is clicked. 
     """
 
     confirmed = pyqtSignal()
@@ -117,7 +119,7 @@ class ConfirmClearingFrame(QWidget):
 class LoggerApp(qiwis.BaseApp):
     """App for logging.
 
-    Sets a handler of root logger and manages loggerFrame to show log messages.
+    Sets a handler of the root logger and manages the loggerFrame to show log messages.
     Gives options to clear logs and select log level in the loggerFrame.
 
     Attributes:
@@ -136,7 +138,7 @@ class LoggerApp(qiwis.BaseApp):
         self.confirmFrame.confirmed.connect(self.clearLog)
         self.handler = LoggingHandler(self.addLog)
         # TODO(aijuh): Change the log format when it is determined.
-        fs ="%(levelname)s [%(name)s] [%(filename)s:%(lineno)d] %(message)s "
+        fs = "%(levelname)s [%(name)s] [%(filename)s:%(lineno)d] %(message)s"
         formatter = logging.Formatter(fs)
         self.handler.setFormatter(formatter)
         rootLogger = logging.getLogger()
@@ -172,21 +174,21 @@ class LoggerApp(qiwis.BaseApp):
 
     @pyqtSlot(str)
     def addLog(self, content: str):
-        """Adds a channel name and log message.
+        """Adds a received log message to the LoggerFrame.
 
         Args:
-            content: Received log message.
+            content: A received log message.
         """
         timeString = QDateTime.currentDateTime().toString("yyyy-MM-dd HH:mm:ss")
         self.loggerFrame.logEdit.insertPlainText(f"{timeString}: {content}\n")
 
     @pyqtSlot()
     def checkToClear(self):
-        """Shows a confirmation frame for clearing log."""
+        """Shows a confirmation frame for clearing logs."""
         logger.info("Tried to clear logs by clicking clear button")
         self.confirmFrame.show()
 
     @pyqtSlot()
     def clearLog(self):
-        """Clears the log text edit."""
+        """Clears the log texts in loggerFrame."""
         self.loggerFrame.logEdit.clear()

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -26,7 +26,10 @@ class _Signaller(QObject):
 class LoggingHandler(logging.Handler):
     """Handler for logger.
 
-    Sends a log message to the connected function through a signal.   
+    Sends a log message to the connected function through a signal. 
+
+    Attributes:
+        signaller: A _Signaller class contains signal for emitting log.
     """
 
     def __init__(self, slotfunc: Callable[[str], Any]):
@@ -78,8 +81,9 @@ class ConfirmClearingFrame(QWidget):
     """A confirmation frame for log clearing in the LoggerFrame.
     
     Attributes:
-        label: Displays a confirmation message to clear logs in the LoggerFrame.
-        buttonBox: Contains OK and Cancel button to check whether to clear logs.
+        label: The label for displaying a confirmation message to clear logs in the LoggerFrame.
+        buttonBox: The buttonBox with OK and Cancel button to check whether to clear logs.
+        confirmed: A pyqtSignal that emits signal when Ok button clicked. 
     """
 
     confirmed = pyqtSignal()

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -161,7 +161,7 @@ class LoggerApp(qiwis.BaseApp):
         }
         if text in level:
             self.handler.setLevel(level[text])
-            (logging.getLogger()).setLevel(level[text])  
+            (logging.getLogger()).setLevel(level[text])
 
     def frames(self) -> Tuple[LoggerFrame]:
         """Overridden."""

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -1,4 +1,4 @@
-"""Module for log viewer in apps."""
+"""App module for log viewer in apps."""
 
 import time
 import logging
@@ -47,8 +47,8 @@ class LoggingHandler(logging.Handler):
         
         Emits input signal to the connected function.
         """
-        s = self.format(record)
-        self.signaller.signal.emit(s)
+        logMsg = self.format(record)
+        self.signaller.signal.emit(logMsg)
 
 
 class LoggerFrame(QWidget):
@@ -109,25 +109,22 @@ class ConfirmClearingFrame(QWidget):
 class LoggerApp(qiwis.BaseApp):
     """App for logging.
 
-    Manages a logger frame.
+    Set a handler of root logger and manages loggerFrame to show log messages.
+    Give options to clear logs and select log level in the loggerFrame.
 
     Attributes:
         loggerFrame: A frame that shows the logs.
-        confirmFame: A frame that asks whether to clear logs.
-        handler: A handler for adding logs to GUI. 
+        confirmFrame: A frame that asks whether to clear logs.
+        handler: A handler for adding logs to the loggerFrame. 
     """
 
     def __init__(self, name: str, parent: Optional[QObject] = None):
-        """Extended.
-
-        Args:
-            name: Name of the App
-        """
+        """Extended."""
         super().__init__(name, parent=parent)
         self.loggerFrame = LoggerFrame()
+        self.confirmFrame = ConfirmClearingFrame()
         # connect signals to slots
         self.loggerFrame.clearButton.clicked.connect(self.checkToClear)
-        self.confirmFrame = ConfirmClearingFrame()
         self.confirmFrame.confirmed.connect(self.clearLog)
         self.handler = LoggingHandler(self.addLog)
         # TODO(aijuh): Change the log format when it is determined.
@@ -135,15 +132,15 @@ class LoggerApp(qiwis.BaseApp):
         formatter = logging.Formatter(fs)
         self.handler.setFormatter(formatter)
         rootLogger = logging.getLogger()
-        rootLogger.setLevel(logging.DEBUG)
+        rootLogger.setLevel("DEBUG")
         rootLogger.addHandler(self.handler)
-        self.handler.setLevel(logging.WARNING)
+        self.handler.setLevel("WARNING")
         self.loggerFrame.levelBox.addItems(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
         self.loggerFrame.levelBox.textActivated.connect(self.setLevel)
         self.loggerFrame.levelBox.setCurrentText("WARNING")
 
     @pyqtSlot(str)
-    def setLevel(self, text: str):
+    def setLevel(self, levelText: str):
         """Responds to the setLevelBox widget and changes the handler's level.
 
         Args:
@@ -158,9 +155,9 @@ class LoggerApp(qiwis.BaseApp):
             "ERROR": logging.ERROR,
             "CRITICAL": logging.CRITICAL
         }
-        if text in level:
-            self.handler.setLevel(level[text])
-            logging.getLogger().setLevel(level[text])
+        if levelText in level:
+            self.handler.setLevel(level[levelText])
+            logging.getLogger().setLevel(level[levelText])
 
     def frames(self) -> Tuple[LoggerFrame]:
         """Overridden."""
@@ -178,8 +175,8 @@ class LoggerApp(qiwis.BaseApp):
 
     @pyqtSlot()
     def checkToClear(self):
-        """Shows a confirmation frame for log clearing."""
-        logger.info("Clear button is clicked to clear logs")
+        """Shows a confirmation frame for clearing log."""
+        logger.info("Tried to clear logs by clicking clear button")
         self.confirmFrame.show()
 
     @pyqtSlot()

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -131,7 +131,7 @@ class LoggerApp(qiwis.BaseApp):
         formatter = logging.Formatter(fs)
         self.handler.setFormatter(formatter)
         rootLogger = logging.getLogger()
-        rootLogger.setLevel("DEBUG")
+        rootLogger.setLevel("WARNING")
         rootLogger.addHandler(self.handler)
         self.handler.setLevel("WARNING")
         self.loggerFrame.levelBox.addItems(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -93,7 +93,6 @@ class ConfirmClearingFrame(QWidget):
         self.buttonBox.rejected.connect(self.buttonCancelClicked)
         # layouts
         layout = QVBoxLayout(self)
-        self.setLayout(layout)
         layout.addWidget(self.label)
         layout.addWidget(self.buttonBox)
 
@@ -114,7 +113,7 @@ class LoggerApp(qiwis.BaseApp):
 
     Attributes:
         loggerFrame: A frame that shows the logs.
-        confirmFame: A frame that asks to whether to clear logs.
+        confirmFame: A frame that asks whether to clear logs.
         handler: A handler for adding logs to GUI. 
     """
 
@@ -161,7 +160,7 @@ class LoggerApp(qiwis.BaseApp):
         }
         if text in level:
             self.handler.setLevel(level[text])
-            (logging.getLogger()).setLevel(level[text])
+            logging.getLogger().setLevel(level[text])
 
     def frames(self) -> Tuple[LoggerFrame]:
         """Overridden."""

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -26,7 +26,7 @@ class _Signaller(QObject):
 class LoggingHandler(logging.Handler):
     """Handler for logger.
 
-    Sends a log message to connected function using emit.   
+    Sends a log message to the connected function through a signal.   
     """
 
     def __init__(self, slotfunc: Callable[[str], Any]):
@@ -75,7 +75,12 @@ class LoggerFrame(QWidget):
 
 
 class ConfirmClearingFrame(QWidget):
-    """A confirmation frame for log clearing."""
+    """A confirmation frame for log clearing in the LoggerFrame.
+    
+    Attributes:
+        label: Displays a confirmation message to clear logs in the LoggerFrame.
+        buttonBox: Contains OK and Cancel button to check whether to clear logs.
+    """
 
     confirmed = pyqtSignal()
 
@@ -108,8 +113,8 @@ class ConfirmClearingFrame(QWidget):
 class LoggerApp(qiwis.BaseApp):
     """App for logging.
 
-    Set a handler of root logger and manages loggerFrame to show log messages.
-    Give options to clear logs and select log level in the loggerFrame.
+    Sets a handler of root logger and manages loggerFrame to show log messages.
+    Gives options to clear logs and select log level in the loggerFrame.
 
     Attributes:
         loggerFrame: A frame that shows the logs.
@@ -131,32 +136,31 @@ class LoggerApp(qiwis.BaseApp):
         formatter = logging.Formatter(fs)
         self.handler.setFormatter(formatter)
         rootLogger = logging.getLogger()
-        rootLogger.setLevel("WARNING")
         rootLogger.addHandler(self.handler)
-        self.handler.setLevel("WARNING")
+        self.setLevel("WARNING")
         self.loggerFrame.levelBox.addItems(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
         self.loggerFrame.levelBox.textActivated.connect(self.setLevel)
         self.loggerFrame.levelBox.setCurrentText("WARNING")
 
     @pyqtSlot(str)
     def setLevel(self, levelText: str):
-        """Responds to the setLevelBox widget and changes the handler's level.
+        """Responds to the loggerFrame's levelBox widget and changes the handler's level.
 
         Args:
-            text: Selected level in the level select box.
+            leveltext: Selected level in the level select box.
               It should be one of "DEBUG", "INFO", "WARNING", "ERROR" and "CRITICAL".
               It should be case-sensitive and any other input is ignored.
         """
-        level = {
+        levels = {
             "DEBUG": logging.DEBUG,
             "INFO": logging.INFO,
             "WARNING": logging.WARNING,
             "ERROR": logging.ERROR,
             "CRITICAL": logging.CRITICAL
         }
-        if levelText in level:
-            self.handler.setLevel(level[levelText])
-            logging.getLogger().setLevel(level[levelText])
+        if levelText in levels:
+            self.handler.setLevel(levels[levelText])
+            logging.getLogger().setLevel(levels[levelText])
 
     def frames(self) -> Tuple[LoggerFrame]:
         """Overridden."""

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -85,14 +85,14 @@ class ConfirmClearingFrame(QWidget):
         super().__init__(parent=parent)
         # widgets
         self.label = QLabel("Are you sure to clear?", self)
-        self.buttonBox = QDialogButtonBox()
+        self.buttonBox = QDialogButtonBox(self)
         self.buttonBox.addButton("OK", QDialogButtonBox.AcceptRole)
         self.buttonBox.addButton("Cancel", QDialogButtonBox.RejectRole)
         # connect signals
         self.buttonBox.accepted.connect(self.buttonOKClicked)
         self.buttonBox.rejected.connect(self.buttonCancelClicked)
         # layouts
-        layout = QVBoxLayout()
+        layout = QVBoxLayout(self)
         self.setLayout(layout)
         layout.addWidget(self.label)
         layout.addWidget(self.buttonBox)
@@ -103,7 +103,7 @@ class ConfirmClearingFrame(QWidget):
         self.close()
 
     def buttonCancelClicked(self):
-        """Clicked Cancel not to clear log."""
+        """Called when the Cancel button is clicked."""
         self.close()
 
 
@@ -114,7 +114,7 @@ class LoggerApp(qiwis.BaseApp):
 
     Attributes:
         loggerFrame: A frame that shows the logs.
-        confirmFame: A frame that asks to whether clear logs.
+        confirmFame: A frame that asks to whether to clear logs.
         handler: A handler for adding logs to GUI. 
     """
 

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -136,8 +136,10 @@ class LoggerApp(qiwis.BaseApp):
         logger = logging.getLogger()
         logger.setLevel(logging.DEBUG)
         logger.addHandler(self.handler)
+        self.handler.setLevel(logging.WARNING)
         self.loggerFrame.levelBox.addItems(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
         self.loggerFrame.levelBox.textActivated.connect(self.setLevel)
+        self.loggerFrame.levelBox.setCurrentText("WARNING")
 
     @pyqtSlot(str)
     def setLevel(self, text: str):
@@ -171,24 +173,6 @@ class LoggerApp(qiwis.BaseApp):
         """
         timeString = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(time.time()))
         self.loggerFrame.logEdit.insertPlainText(f"{timeString}: {content}\n")
-
-    def receivedSlot(self, channelName: str, content: Any):
-        """Overridden.
-
-        Possible channels are as follows.
-
-        "log": Log channel.
-            See self.addLog().
-        """
-        if channelName == "log":
-            if isinstance(content, str):
-                self.addLog(content)
-            else:
-                logger = logging.getLogger(__name__)
-                logger.error("The message for the channel log should be a string.")
-        else:
-            (logging.getLogger(__name__)).error("The message was ignored because "
-                             "the treatment for the channel %s is not implemented.", channelName)
 
     @pyqtSlot()
     def checkToClear(self):

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -184,7 +184,8 @@ class LoggerApp(qiwis.BaseApp):
             if isinstance(content, str):
                 self.addLog(content)
             else:
-                (logging.getLogger(__name__)).error("The message for the channel log should be a string.")
+                logger = logging.getLogger(__name__)
+                logger.error("The message for the channel log should be a string.")
         else:
             (logging.getLogger(__name__)).error("The message was ignored because "
                              "the treatment for the channel %s is not implemented.", channelName)

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -1,10 +1,9 @@
 """App module for log viewer in apps."""
 
-import time
 import logging
 from typing import Any, Optional, Tuple, Callable
 
-from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal
+from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal, QDateTime
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QPushButton, QTextEdit, QLabel, QDialogButtonBox, QComboBox
 )
@@ -170,7 +169,7 @@ class LoggerApp(qiwis.BaseApp):
         Args:
             content: Received log message.
         """
-        timeString = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(time.time()))
+        timeString = QDateTime.currentDateTime().toString("yyyy-MM-dd HH:mm:ss")
         self.loggerFrame.logEdit.insertPlainText(f"{timeString}: {content}\n")
 
     @pyqtSlot()

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -51,29 +51,6 @@ class LoggingHandler(logging.Handler):
         self.signaller.signal.emit(s)
 
 
-class _ScreenFilter(logging.Filter):
-    """Filter only for Screen LoggingHandler.
-    
-    Attributes:
-        validLoggerName: A list of loggers' name whose logs are printed on the screen.
-    """
-
-    def __init__(self):
-        """Extended."""
-        super().__init__()
-        self.validLoggerName = ["iquip.apps.builder", "iquip.apps.explorer",
-                                "iquip.apps.logger", "iquip.apps.thread"]
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        """Return True only when logRecord's log name is in vaildLoggerName."""
-        return record.name in self.validLoggerName
-
-    def addName(self, name: str):
-        """Add a new name in vaildLoggerName."""
-        if name:
-            self.validLoggerName.append(name)
-
-
 class LoggerFrame(QWidget):
     """Frame for logging.
 
@@ -159,7 +136,6 @@ class LoggerApp(qiwis.BaseApp):
         fs ="%(levelname)s [%(name)s] [%(filename)s:%(lineno)d] %(message)s "
         formatter = logging.Formatter(fs)
         self.handler.setFormatter(formatter)
-        self.handler.addFilter(_ScreenFilter())
         rootLogger = logging.getLogger()
         rootLogger.setLevel(logging.DEBUG)
         rootLogger.addHandler(self.handler)

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -177,7 +177,7 @@ class LoggerApp(qiwis.BaseApp):
         """Adds a received log message to the LoggerFrame.
 
         Args:
-            content: A received log message.
+            content: Received log message.
         """
         timeString = QDateTime.currentDateTime().toString("yyyy-MM-dd HH:mm:ss")
         self.loggerFrame.logEdit.insertPlainText(f"{timeString}: {content}\n")

--- a/iquip/apps/thread.py
+++ b/iquip/apps/thread.py
@@ -69,4 +69,4 @@ class ExperimentInfoThread(QThread):
                 ExperimentInfo(**experimentInfo)
             )
         else:
-            logger.error("The selected item is not an experiment file.")
+            logger.info("The selected item is not an experiment file.")

--- a/iquip/apps/thread.py
+++ b/iquip/apps/thread.py
@@ -1,11 +1,15 @@
 """Module for common threads in apps."""
 
+import logging
 from typing import Callable, Optional
 
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal
 
 from iquip.protocols import ExperimentInfo
+
+logger = logging.getLogger(__name__)
+
 
 class ExperimentInfoThread(QThread):
     """QThread for obtaining the experiment information from the proxy server.
@@ -54,7 +58,7 @@ class ExperimentInfoThread(QThread):
             response.raise_for_status()
             data = response.json()
         except requests.exceptions.RequestException as err:
-            print(err)
+            logger.exception(err)
             return
         if data:
             experimentClsName = next(iter(data))
@@ -65,4 +69,4 @@ class ExperimentInfoThread(QThread):
                 ExperimentInfo(**experimentInfo)
             )
         else:
-            print("The selected item is a non-experiment file.")
+            logger.error("The selected item is a non-experiment file.")

--- a/iquip/apps/thread.py
+++ b/iquip/apps/thread.py
@@ -57,8 +57,8 @@ class ExperimentInfoThread(QThread):
                                     timeout=10)
             response.raise_for_status()
             data = response.json()
-        except requests.exceptions.RequestException as err:
-            logger.exception(err)
+        except requests.exceptions.RequestException:
+            logger.exception("Failed to fetch the experiment information.")
             return
         if data:
             experimentClsName = next(iter(data))
@@ -69,4 +69,4 @@ class ExperimentInfoThread(QThread):
                 ExperimentInfo(**experimentInfo)
             )
         else:
-            logger.error("The selected item is a non-experiment file.")
+            logger.error("The selected item is not an experiment file.")

--- a/setup.json
+++ b/setup.json
@@ -5,6 +5,12 @@
             "cls": "ExplorerApp",
             "show": true,
             "pos": "left"
+        },
+        "logger": {
+            "module": "iquip.apps.logger",
+            "cls": "LoggerApp",
+            "show": true,
+            "pos": "bottom"
         }
     }
 }


### PR DESCRIPTION
Implemented logger app by using same code as qiwis' logger.py.
An image below is implemented logger app. We can see RID value message from builder.py. Position and log format should be determined.

Unfortunately, other app also using logging so unwanted log message printed out since we are using root logger.
I think we can handle it by making naming convention inside iquip app. If other app running by iquip's app wants to print log message, we may read it  inside that specific iquip's app. 
I didn't think all the details but give option (ex. bool variable) to the Baseapp to read all log message or not. If it is supposed to take all the log message, read it using root logger and send to its own logger.
I may missed some points. I will wait for further comments.
 This closes issue #74

![image](https://github.com/snu-quiqcl/iquip/assets/43592775/c8490210-3a3e-458f-aa9d-63e89a383a86)
