### PR TITLE
Implement additional functions of the builder

### DIFF
--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -14,6 +14,18 @@ import qiwis
 from iquip.protocols import ExperimentInfo
 from iquip.apps.thread import ExperimentInfoThread
 
+def compute_unit(unit: str) -> Optional[float]:
+    """Computes the unit scale of the given unit string based on ARTIQ units.
+    
+    Args:
+        unit: The unit string e.g., "ns", "kHz".
+
+    Returns:
+        The scale of the given unit. For example, the scale of "ms" is 0.001.
+        If the unit is not defined in ARTIQ, it returns None.
+    """
+
+
 class _BaseEntry(QWidget):
     """Base class for all argument entries.
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -137,6 +137,7 @@ class _NumberEntry(_BaseEntry):
         scale, minValue, maxValue = map(self.argInfo.get, ("scale", "min", "max"))
         # widgets
         self.spinBox = QDoubleSpinBox(self)
+        self.spinBox.valueChanged.connect(self.updateToolTip)
         self.spinBox.setSuffix(self.argInfo["unit"])
         self.spinBox.setSingleStep(self.argInfo["step"] / scale)
         # TODO(BECATRUE): A WARNING log will be added after implementing the logger app.
@@ -166,6 +167,14 @@ class _NumberEntry(_BaseEntry):
         """
         typeCls = int if self.argInfo["type"] == "int" else float
         return typeCls(self.spinBox.value() * self.argInfo["scale"])
+
+    @pyqtSlot()
+    def updateToolTip(self):
+        """Updates the text in the tooltip.
+        
+        Once the value of the spinBox is changed, this is called.
+        """
+        self.setToolTip(str(self.value()))
 
 
 class _StringEntry(_BaseEntry):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -403,6 +403,8 @@ class BuilderApp(qiwis.BaseApp):
     Attributes:
         builderFrame: The frame that shows the build arguments and requests to submit it.
         experimentPath: The path of the experiment file.
+        experimentSubmitThread: The most recently executed ExperimentSubmitThread instance.
+        experimentInfoThread: The most recently executed ExperimentInfoThread instance.
     """
 
     def __init__(
@@ -422,6 +424,8 @@ class BuilderApp(qiwis.BaseApp):
         """
         super().__init__(name, parent=parent)
         self.experimentPath = experimentPath
+        self.experimentSubmitThread = None
+        self.experimentInfoThread = None
         self.builderFrame = BuilderFrame(experimentInfo["name"], experimentClsName)
         self.initArgsEntry(ExperimentInfo(**experimentInfo))
         self.initSchedOptsEntry()
@@ -484,8 +488,8 @@ class BuilderApp(qiwis.BaseApp):
         
         Once the reloadArgsButton is clicked, this is called.
         """
-        self.thread = ExperimentInfoThread(self.experimentPath, self.onReloaded, self)
-        self.thread.start()
+        self.experimentInfoThread = ExperimentInfoThread(self.experimentPath, self.onReloaded, self)
+        self.experimentInfoThread.start()
 
     def onReloaded(
         self,
@@ -532,14 +536,14 @@ class BuilderApp(qiwis.BaseApp):
         """
         experimentArgs = self.argumentsFromListWidget(self.builderFrame.argsListWidget)
         schedOpts = self.argumentsFromListWidget(self.builderFrame.schedOptsListWidget)
-        self.thread = ExperimentSubmitThread(
+        self.experimentSubmitThread = ExperimentSubmitThread(
             self.experimentPath,
             experimentArgs,
             schedOpts,
             self.onSubmitted,
             self
         )
-        self.thread.start()
+        self.experimentSubmitThread.start()
 
     def onSubmitted(self, rid: int):
         """Prints the rid after submitted.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -140,6 +140,8 @@ class _NumberEntry(_BaseEntry):
         self.spinBox = QDoubleSpinBox(self)
         self.spinBox.setSuffix(self.argInfo["unit"])
         self.spinBox.setSingleStep(self.argInfo["step"] / scale)
+        if minValue is not None and maxValue is not None and minValue > maxValue:
+            minValue, maxValue = maxValue, minValue
         if minValue is not None:
             self.spinBox.setMinimum(minValue / scale)
         if maxValue is not None:

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -451,6 +451,9 @@ class BuilderApp(qiwis.BaseApp):
             experimentClsName: The class name of the experiment.
             experimentInfo: The experiment information. See protocols.ExperimentInfo.
         """
+        for _ in range(self.builderFrame.argsListWidget.count()):
+            item = self.builderFrame.argsListWidget.takeItem(0)
+            del item
 
     def argumentsFromListWidget(self, listWidget: QListWidget) -> Dict[str, Any]:
         """Gets arguments from the given list widget and returns them.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -206,7 +206,7 @@ class _NumberEntry(_BaseEntry):
 
     @pyqtSlot()
     def updateToolTip(self):
-        """Updates the text in the tooltip.
+        """Updates the tooltip to show the actual value.
         
         Once the value of the spinBox is changed, this is called.
         """

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -247,15 +247,29 @@ class BuilderFrame(QWidget):
         submitButton: The button for submitting the experiment.
     """
 
-    def __init__(self, parent: Optional[QWidget] = None):
-        """Extended."""
+    def __init__(
+        self,
+        experimentName: str,
+        experimentClsName: str,
+        parent: Optional[QWidget] = None
+    ):
+        """Extended.
+        
+        Args:
+            experimentName: The experiment name, the name field of protocols.ExperimentInfo.
+            experimentClsName: The class name of the experiment.
+        """
         super().__init__(parent=parent)
         # widgets
+        self.experimentNameLabel = QLabel(f"Name: {experimentName}", self)
+        self.experimentClsNameLabel = QLabel(f"Class: {experimentClsName}", self)
         self.argsListWidget = QListWidget(self)
         self.schedOptsListWidget = QListWidget(self)
         self.submitButton = QPushButton("Submit", self)
         # layout
         layout = QVBoxLayout(self)
+        layout.addWidget(self.experimentNameLabel)
+        layout.addWidget(self.experimentClsNameLabel)
         layout.addWidget(self.argsListWidget)
         layout.addWidget(self.schedOptsListWidget)
         layout.addWidget(self.submitButton)
@@ -338,7 +352,6 @@ class BuilderApp(qiwis.BaseApp):
     Attributes:
         builderFrame: The frame that shows the build arguments and requests to submit it.
         experimentPath: The path of the experiment file.
-        experimentClsName: The class name of the experiment.
     """
 
     def __init__(
@@ -352,13 +365,13 @@ class BuilderApp(qiwis.BaseApp):
         """Extended.
         
         Args:
-            experimentPath, experimentClsName: See the attributes section in BuilderApp.
+            experimentPath: See the attributes section in BuilderApp.
+            experimentClsName: The class name of the experiment.
             experimentInfo: The experiment information, a dictionary of protocols.ExperimentInfo.
         """
         super().__init__(name, parent=parent)
         self.experimentPath = experimentPath
-        self.experimentClsName = experimentClsName
-        self.builderFrame = BuilderFrame()
+        self.builderFrame = BuilderFrame(experimentInfo["name"], experimentClsName)
         self.initArgsEntry(ExperimentInfo(**experimentInfo))
         self.initSchedOptsEntry()
         # connect signals to slots

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -128,8 +128,6 @@ class _NumberEntry(_BaseEntry):
         spinBox: The spinbox showing the number value.
     
     TODO(BECATRUE): The operations of unit and scale will be concretized in Basic Runner project.
-    TODO(BECATRUE): Handling the case where the default doesn't exist and the min is None
-      will be implemented in Basic Runner project.
     """
 
     def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
@@ -140,6 +138,7 @@ class _NumberEntry(_BaseEntry):
         self.spinBox = QDoubleSpinBox(self)
         self.spinBox.setSuffix(self.argInfo["unit"])
         self.spinBox.setSingleStep(self.argInfo["step"] / scale)
+        # TODO(BECATRUE): A WARNING log will be added after implementing the logger app.
         if minValue is not None and maxValue is not None and minValue > maxValue:
             minValue, maxValue = maxValue, minValue
         if minValue is not None:
@@ -147,7 +146,15 @@ class _NumberEntry(_BaseEntry):
         if maxValue is not None:
             self.spinBox.setMaximum(maxValue / scale)
         self.spinBox.setDecimals(self.argInfo["ndecimals"])
-        self.spinBox.setValue(self.argInfo.get("default", minValue) / scale)
+        if "default" in self.argInfo:
+            value = self.argInfo["default"]
+        elif minValue is not None:
+            value = minValue
+        elif maxValue is not None:
+            value = maxValue
+        else:
+            value = 0
+        self.spinBox.setValue(value / scale)
         # layout
         self.layout.addWidget(self.spinBox)
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -161,18 +161,18 @@ class _NumberEntry(_BaseEntry):
               If "int", value() returns an integer value.
               Otherwise, it is regarded as a float value.
         spinBox: The spinbox showing the number value.
-    
-    TODO(BECATRUE): The operations of unit and scale will be concretized in Basic Runner project.
+        warningLabel: The label showing a warning.
+            If the given scale is not typical for the unit, it shows a warning.
     """
 
     def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(name, argInfo, parent=parent)
-        scale, minValue, maxValue = map(self.argInfo.get, ("scale", "min", "max"))
+        unit, scale, minValue, maxValue = map(self.argInfo.get, ("unit", "scale", "min", "max"))
         # widgets
         self.spinBox = QDoubleSpinBox(self)
         self.spinBox.valueChanged.connect(self.updateToolTip)
-        self.spinBox.setSuffix(self.argInfo["unit"])
+        self.spinBox.setSuffix(unit)
         self.spinBox.setSingleStep(self.argInfo["step"] / scale)
         # TODO(BECATRUE): A WARNING log will be added after implementing the logger app.
         if minValue is not None and maxValue is not None and minValue > maxValue:
@@ -191,8 +191,13 @@ class _NumberEntry(_BaseEntry):
         else:
             value = 0
         self.spinBox.setValue(value / scale)
+        self.warningLabel = QLabel(self)
+        scale_by_unit = compute_unit(unit)
+        if scale_by_unit is not None and scale != scale_by_unit:
+            self.warningLabel.setText("Not a typical scale for the unit.")
         # layout
         self.layout.addWidget(self.spinBox)
+        self.layout.addWidget(self.warningLabel)
 
     def value(self) -> Union[int, float]:
         """Overridden.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -288,7 +288,10 @@ class BuilderFrame(QWidget):
     """Frame for showing the build arguments and requesting to submit it.
     
     Attributes:
+        experimentNameLabel: The label for showing the experiment name.
+        experimentClsNameLabel: The label for showing the class name of the experiment.
         argsListWidget: The list widget with the build arguments.
+        reloadArgsButton: The button for reloading the build arguments.
         schedOptsListWidget: The list widget with the schedule options.
         submitButton: The button for submitting the experiment.
     """

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -326,7 +326,7 @@ class BuilderFrame(QWidget):
         layout.addWidget(self.submitButton)
 
 
-class ExperimentSubmitThread(QThread):
+class _ExperimentSubmitThread(QThread):
     """QThread for submitting the experiment with its build arguments.
     
     Signals:
@@ -352,7 +352,7 @@ class ExperimentSubmitThread(QThread):
         
         Args:
             experimentPath, experimentArgs, schedOpts:
-              See the attributes section in ExperimentSubmitThread.
+              See the attributes section in _ExperimentSubmitThread.
             callback: The callback method called after this thread is finished.
         """
         super().__init__(parent=parent)
@@ -403,7 +403,7 @@ class BuilderApp(qiwis.BaseApp):
     Attributes:
         builderFrame: The frame that shows the build arguments and requests to submit it.
         experimentPath: The path of the experiment file.
-        experimentSubmitThread: The most recently executed ExperimentSubmitThread instance.
+        experimentSubmitThread: The most recently executed _ExperimentSubmitThread instance.
         experimentInfoThread: The most recently executed ExperimentInfoThread instance.
     """
 
@@ -536,7 +536,7 @@ class BuilderApp(qiwis.BaseApp):
         """
         experimentArgs = self.argumentsFromListWidget(self.builderFrame.argsListWidget)
         schedOpts = self.argumentsFromListWidget(self.builderFrame.schedOptsListWidget)
-        self.experimentSubmitThread = ExperimentSubmitThread(
+        self.experimentSubmitThread = _ExperimentSubmitThread(
             self.experimentPath,
             experimentArgs,
             schedOpts,
@@ -548,7 +548,7 @@ class BuilderApp(qiwis.BaseApp):
     def onSubmitted(self, rid: int):
         """Prints the rid after submitted.
 
-        This is the callback function of ExperimentSubmitThread.
+        This is the callback function of _ExperimentSubmitThread.
 
         Args:
             rid: The run identifier of the submitted experiment.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -454,6 +454,8 @@ class BuilderApp(qiwis.BaseApp):
         for _ in range(self.builderFrame.argsListWidget.count()):
             item = self.builderFrame.argsListWidget.takeItem(0)
             del item
+        self.builderFrame.experimentClsNameLabel.setText(f"Class: {experimentClsName}")
+        self.initArgsEntry(experimentInfo)
 
     def argumentsFromListWidget(self, listWidget: QListWidget) -> Dict[str, Any]:
         """Gets arguments from the given list widget and returns them.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -14,8 +14,8 @@ import qiwis
 from iquip.protocols import ExperimentInfo
 from iquip.apps.thread import ExperimentInfoThread
 
-def compute_unit(unit: str) -> Optional[float]:
-    """Computes the unit scale of the given unit string based on ARTIQ units.
+def compute_scale(unit: str) -> Optional[float]:
+    """Computes the scale of the given unit string based on ARTIQ units.
     
     Args:
         unit: The unit string e.g., "ns", "kHz".
@@ -25,7 +25,9 @@ def compute_unit(unit: str) -> Optional[float]:
         If the unit is not defined in ARTIQ, it returns None.
     """
     base_prefixes = "pnum_kMG"
-    unit_specs = {  # Units in ARTIQ
+    # See details at
+    # https://github.com/m-labs/artiq/blob/master/artiq/language/units.py
+    unit_specs = {
         "s": "pnum",
         "Hz": "mkMG",
         "dB": "",
@@ -192,7 +194,7 @@ class _NumberEntry(_BaseEntry):
             value = 0
         self.spinBox.setValue(value / scale)
         self.warningLabel = QLabel(self)
-        scale_by_unit = compute_unit(unit)
+        scale_by_unit = compute_scale(unit)
         if scale_by_unit is not None and scale != scale_by_unit:
             self.warningLabel.setText("Not a typical scale for the unit.")
         # layout

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -424,8 +424,8 @@ class BuilderApp(qiwis.BaseApp):
         """
         super().__init__(name, parent=parent)
         self.experimentPath = experimentPath
-        self.experimentSubmitThread = None
-        self.experimentInfoThread = None
+        self.experimentSubmitThread: Optional[_ExperimentSubmitThread] = None
+        self.experimentInfoThread: Optional[ExperimentInfoThread] = None
         self.builderFrame = BuilderFrame(experimentInfo["name"], experimentClsName)
         self.initArgsEntry(ExperimentInfo(**experimentInfo))
         self.initSchedOptsEntry()

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -158,41 +158,36 @@ class _NumberEntry(_BaseEntry):
             step: The step between values changed by the up and down button.
             min: The minimum value. (default=0.0)
             max: The maximum value. (default=99.99)
+              If min > max, then they are swapped.
             ndecimals: The number of displayed decimals.
             type: The type of the value.
               If "int", value() returns an integer value.
               Otherwise, it is regarded as a float value.
         spinBox: The spinbox showing the number value.
         warningLabel: The label showing a warning.
-            If the given scale is not typical for the unit, it shows a warning.
+          If the given scale is not typical for the unit, it shows a warning.
     """
 
     def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(name, argInfo, parent=parent)
-        unit, scale, minValue, maxValue = map(self.argInfo.get, ("unit", "scale", "min", "max"))
+        unit, scale, minValue, maxValue = map(argInfo.get, ("unit", "scale", "min", "max"))
         # widgets
         self.spinBox = QDoubleSpinBox(self)
         self.spinBox.valueChanged.connect(self.updateToolTip)
         self.spinBox.setSuffix(unit)
-        self.spinBox.setSingleStep(self.argInfo["step"] / scale)
+        self.spinBox.setSingleStep(argInfo["step"] / scale)
+        if minValue is None:
+            minValue = 0.0
+        if maxValue is None:
+            maxValue = 99.99
         # TODO(BECATRUE): A WARNING log will be added after implementing the logger app.
         if minValue is not None and maxValue is not None and minValue > maxValue:
             minValue, maxValue = maxValue, minValue
-        if minValue is not None:
-            self.spinBox.setMinimum(minValue / scale)
-        if maxValue is not None:
-            self.spinBox.setMaximum(maxValue / scale)
-        self.spinBox.setDecimals(self.argInfo["ndecimals"])
-        if "default" in self.argInfo:
-            value = self.argInfo["default"]
-        elif minValue is not None:
-            value = minValue
-        elif maxValue is not None:
-            value = maxValue
-        else:
-            value = 0
-        self.spinBox.setValue(value / scale)
+        self.spinBox.setMinimum(minValue / scale)
+        self.spinBox.setMaximum(maxValue / scale)
+        self.spinBox.setDecimals(argInfo["ndecimals"])
+        self.spinBox.setValue(argInfo.get("default", minValue) / scale)
         self.warningLabel = QLabel(self)
         scale_by_unit = compute_scale(unit)
         if scale_by_unit is not None and scale != scale_by_unit:

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -24,6 +24,28 @@ def compute_unit(unit: str) -> Optional[float]:
         The scale of the given unit. For example, the scale of "ms" is 0.001.
         If the unit is not defined in ARTIQ, it returns None.
     """
+    base_prefixes = "pnum_kMG"
+    unit_specs = {  # Units in ARTIQ
+        "s": "pnum",
+        "Hz": "mkMG",
+        "dB": "",
+        "V": "umk",
+        "A": "um",
+        "W": "num"
+    }
+    if unit in unit_specs:
+        return 1
+    if unit == "":
+        return None
+    prefix, base_unit = unit[0], unit[1:]
+    if prefix not in base_prefixes or prefix == "_":
+        return None
+    if base_unit not in unit_specs:
+        return None
+    if prefix not in unit_specs[base_unit]:
+        return None
+    exponent = base_prefixes.index(prefix) - 4
+    return 1000. ** exponent
 
 
 class _BaseEntry(QWidget):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -94,7 +94,8 @@ class ExplorerApp(qiwis.BaseApp):
 
     Attributes:
         explorerFrame: The frame that shows the file tree.
-        thread: The _FileFinderThread object.
+        fileFinderThread: The most recently executed _FileFinderThread instance.
+        experimentInfoThread: The most recently executed ExperimentInfoThread instance.
     """
 
     def __init__(self, name: str, parent: Optional[QObject] = None):
@@ -111,13 +112,13 @@ class ExplorerApp(qiwis.BaseApp):
     def loadFileTree(self):
         """Loads the experiment file structure in self.explorerFrame.fileTree."""
         self.explorerFrame.fileTree.clear()
-        self.thread = _FileFinderThread(
+        self.fileFinderThread = _FileFinderThread(
             ".",
             self.explorerFrame.fileTree,
             self._addFile,
             self
         )
-        self.thread.start()
+        self.fileFinderThread.start()
 
     @pyqtSlot(QTreeWidgetItem)
     def lazyLoadFile(self, experimentFileItem: QTreeWidgetItem):
@@ -134,13 +135,13 @@ class ExplorerApp(qiwis.BaseApp):
         # Remove the empty item of an unloaded directory.
         experimentFileItem.takeChild(0)
         experimentPath = self.fullPath(experimentFileItem)
-        self.thread = _FileFinderThread(
+        self.fileFinderThread = _FileFinderThread(
             experimentPath,
             experimentFileItem,
             self._addFile,
             self
         )
-        self.thread.start()
+        self.fileFinderThread.start()
 
     def _addFile(self, experimentList: List[str], widget: Union[QTreeWidget, QTreeWidgetItem]):
         """Adds the files into the children of the widget.
@@ -172,8 +173,8 @@ class ExplorerApp(qiwis.BaseApp):
         """
         experimentFileItem = self.explorerFrame.fileTree.currentItem()
         experimentPath = self.fullPath(experimentFileItem)
-        self.thread = ExperimentInfoThread(experimentPath, self.openBuilder, self)
-        self.thread.start()
+        self.experimentInfoThread = ExperimentInfoThread(experimentPath, self.openBuilder, self)
+        self.experimentInfoThread.start()
 
     def openBuilder(
         self,

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -101,8 +101,8 @@ class ExplorerApp(qiwis.BaseApp):
     def __init__(self, name: str, parent: Optional[QObject] = None):
         """Extended."""
         super().__init__(name, parent=parent)
-        self.fileFinderThread = None
-        self.experimentInfoThread = None
+        self.fileFinderThread: Optional[_FileFinderThread] = None
+        self.experimentInfoThread: Optional[ExperimentInfoThread] = None
         self.explorerFrame = ExplorerFrame()
         self.loadFileTree()
         # connect signals to slots

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -101,6 +101,8 @@ class ExplorerApp(qiwis.BaseApp):
     def __init__(self, name: str, parent: Optional[QObject] = None):
         """Extended."""
         super().__init__(name, parent=parent)
+        self.fileFinderThread = None
+        self.experimentInfoThread = None
         self.explorerFrame = ExplorerFrame()
         self.loadFileTree()
         # connect signals to slots

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -43,8 +43,8 @@ class _DateTimeEntryTest(unittest.TestCase):
     """Unit tests for _DateTimeEntry class."""
 
 
-class ExperimentSubmitThreadTest(unittest.TestCase):
-    """Unit tests for ExperimentSubmitThread class."""
+class _ExperimentSubmitThreadTest(unittest.TestCase):
+    """Unit tests for _ExperimentSubmitThread class."""
 
 
 class BuilderAppTest(unittest.TestCase):
@@ -56,7 +56,7 @@ class BuilderAppTest(unittest.TestCase):
             f"{type_}Value": mock.MagicMock(return_value=QWidget())
             for type_ in ("Boolean", "String", "Enumeration", "Number")
         }
-        experiment_submit_thread_patcher = mock.patch("iquip.apps.builder.ExperimentSubmitThread")
+        experiment_submit_thread_patcher = mock.patch("iquip.apps.builder._ExperimentSubmitThread")
         entries_patcher = mock.patch.multiple(
             "iquip.apps.builder",
             _BooleanEntry=self.mocked_entries["BooleanValue"],


### PR DESCRIPTION
This PR will close #49.

As I wrote in #49, I implemented several additional functions in the builder.
- Show the experiment info such as the name and class name.
- Enable to reload the build arguments from the experiment file.
- Alert if a _NumberEntry uses an atypical scale factor.
- Show the actual value of a _NumberEntry through QToolTip.
- Handle when min is greater than max in a _NumberEntry.
In that case, just swap min and max each other.
- Handle when both min and default are not given.

#### Results
![image](https://github.com/snu-quiqcl/iquip/assets/76851886/5eb784d2-22ed-4acc-8537-2c1803c35e55)
In the `time` argument, the scale is set to 0.1 explicitly, so it causes an warning.