### PR TITLE
Aijuh/76/save logs to file

### DIFF
--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -196,7 +196,7 @@ class LoggerApp(qiwis.BaseApp):
     Attributes:
         loggerFrame: A frame that shows the logs.
         confirmFrame: A frame that asks whether to clear logs.
-        handler: A handler for adding logs to the loggerFrame.
+        frameHandler: A handler for adding logs to the loggerFrame.
         fileHandler: A handler for saving logs to file.
     """
 
@@ -220,25 +220,23 @@ class LoggerApp(qiwis.BaseApp):
         with open(self.dirTempLogFile, mode = "w", encoding = "utf-8"):
             pass
         # initialize handlers
-        self.handler = LoggingHandler(self.addLog)
+        self.frameHandler = LoggingHandler(self.addLog)
         self.fileHandler = logging.FileHandler(self.dirTempLogFile)
         simpleFormat = "[%(name)s] %(message)s"
         complexFormat = "%(asctime)s %(levelname)s [%(name)s]"\
                         " [%(filename)s:%(lineno)d] %(message)s"
-        self.handler.setFormatter(logging.Formatter(simpleFormat))
+        self.frameHandler.setFormatter(logging.Formatter(simpleFormat))
         self.fileHandler.setFormatter(logging.Formatter(complexFormat))
-        self.handler.setLevel(logging.WARNING)
-        self.fileHandler.setLevel(logging.INFO)
         # set rootLogger
         rootLogger = logging.getLogger()
-        rootLogger.addHandler(self.handler)
+        rootLogger.addHandler(self.frameHandler)
         rootLogger.addHandler(self.fileHandler)
         self.setLevel("WARNING")
         # set loggerFrame's levelBox
         levels_dict = {10: "DEBUG", 20: "INFO", 30: "WARNING", 40: "ERROR", 50: "CRITICAL"}
         self.loggerFrame.levelBox.addItems(levels_dict.values())
         self.loggerFrame.levelBox.textActivated.connect(self.setLevel)
-        self.loggerFrame.levelBox.setCurrentText(levels_dict[self.handler.level])
+        self.loggerFrame.levelBox.setCurrentText(levels_dict[self.frameHandler.level])
 
     @pyqtSlot(str)
     def setLevel(self, levelText: str):
@@ -257,7 +255,7 @@ class LoggerApp(qiwis.BaseApp):
             "CRITICAL": logging.CRITICAL
         }
         if levelText in levels:
-            self.handler.setLevel(levels[levelText])
+            self.frameHandler.setLevel(levels[levelText])
             self.fileHandler.setLevel(levels[levelText])
             logging.getLogger().setLevel(levels[levelText])
 

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -83,7 +83,7 @@ class ConfirmClearingFrame(QWidget):
     Attributes:
         label: The label for displaying a confirmation message to clear logs in the LoggerFrame.
         buttonBox: The buttonBox with OK and Cancel button to check whether to clear logs.
-   
+
     Signals:
         confirmed: A pyqtSignal that emits signal when Ok button is clicked. 
     """

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Tuple, Callable
 
 from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal, QDateTime
 from PyQt5.QtWidgets import (
-    QWidget, QVBoxLayout, QPushButton, QTextEdit, QLabel, QDialogButtonBox, QComboBox
+    QWidget, QVBoxLayout, QPushButton, QTextEdit, QLabel, QDialogButtonBox, QComboBox, QGridLayout
 )
 
 import qiwis
@@ -59,7 +59,10 @@ class LoggerFrame(QWidget):
     Attributes:
         logEdit: A textEdit which shows all logs.
         clearButton: A button for clearing all logs.
+        levelBoxLabel: A label for describing levelBox.
         levelBox: A comboBox for setting the logger's level.
+        fileWriteButton: A button for wrtie logs to file.
+        fileClearButton: A button for clear logs in file.
     """
 
     def __init__(self, parent: Optional[QObject] = None):
@@ -69,12 +72,18 @@ class LoggerFrame(QWidget):
         self.logEdit = QTextEdit(self)
         self.logEdit.setReadOnly(True)
         self.clearButton = QPushButton("Clear", self)
+        self.levelBoxLabel = QLabel("Select log's level:")
         self.levelBox = QComboBox(self)
+        self.fileWriteButton = QPushButton("Save log to file")
+        self.fileClearButton = QPushButton("Clear log file")
         # layout
-        layout = QVBoxLayout(self)
-        layout.addWidget(self.logEdit)
-        layout.addWidget(self.clearButton)
-        layout.addWidget(self.levelBox)
+        layout = QGridLayout(self)
+        layout.addWidget(self.logEdit, 0, 0, 1, 6)
+        layout.addWidget(self.clearButton,1, 0, 1, 6)
+        layout.addWidget(self.levelBoxLabel, 2, 0, 1, 2)
+        layout.addWidget(self.levelBox, 2, 2, 1, 4)
+        layout.addWidget(self.fileWriteButton, 3, 0, 1, 3)
+        layout.addWidget(self.fileClearButton, 3, 3, 1, 3)
 
 
 class ConfirmClearingFrame(QWidget):

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -26,7 +26,7 @@ class _Signaller(QObject):
 class LoggingHandler(logging.Handler):
     """Handler for logger.
 
-    Sends a log message to the connected function through a signal. 
+    Sends a log message to the connected function through a signal.
 
     Attributes:
         signaller: A _Signaller class contains signal for emitting log.
@@ -94,7 +94,7 @@ class ConfirmClearingFrame(QWidget):
         buttonBox: The buttonBox with OK and Cancel button to check whether to clear logs.
 
     Signals:
-        confirmed: A pyqtSignal that emits signal when Ok button is clicked. 
+        confirmed: A pyqtSignal that emits signal when Ok button is clicked.
     """
 
     confirmed = pyqtSignal()
@@ -125,6 +125,68 @@ class ConfirmClearingFrame(QWidget):
         self.close()
 
 
+class ConfirmFileClearFrame(QWidget):
+    """A confirmation frame for clearing the log record file's log messages."""
+    confirmed = pyqtSignal()
+
+    def __init__(self, parent: Optional[QObject] = None):
+        """Extended."""
+        super().__init__(parent=parent)
+        # widgets
+        self.label = QLabel("Are you sure to clear log file?")
+        self.buttonBox = QDialogButtonBox()
+        self.buttonBox.addButton("OK", QDialogButtonBox.AcceptRole)
+        self.buttonBox.addButton("Cancel", QDialogButtonBox.RejectRole)
+        # connect signals
+        self.buttonBox.accepted.connect(self.buttonOKClicked)
+        self.buttonBox.rejected.connect(self.buttonCancelClicked)
+        # layouts
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+        layout.addWidget(self.label)
+        layout.addWidget(self.buttonBox)
+
+    def buttonOKClicked(self):
+        """Clicked OK button to clear the log record file."""
+        self.confirmed.emit()
+        self.close()
+
+    def buttonCancelClicked(self):
+        """Clicked Cancel button not to clear the log record file."""
+        self.close()
+
+
+class ConfirmFileWriteFrame(QWidget):
+    """A confirmation frame for writing log messages to the log record file."""
+    confirmed = pyqtSignal()
+
+    def __init__(self, parent: Optional[QObject] = None):
+        """Extended."""
+        super().__init__(parent=parent)
+        # widgets
+        self.label = QLabel("Are you sure to write log messages to log file?")
+        self.buttonBox = QDialogButtonBox()
+        self.buttonBox.addButton("OK", QDialogButtonBox.AcceptRole)
+        self.buttonBox.addButton("Cancel", QDialogButtonBox.RejectRole)
+        # connect signals
+        self.buttonBox.accepted.connect(self.buttonOKClicked)
+        self.buttonBox.rejected.connect(self.buttonCancelClicked)
+        # layouts
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+        layout.addWidget(self.label)
+        layout.addWidget(self.buttonBox)
+
+    def buttonOKClicked(self):
+        """Clicked OK button to wrtie log messages to the log record file."""
+        self.confirmed.emit()
+        self.close()
+
+    def buttonCancelClicked(self):
+        """Clicked Cancel button not to write log messages to the log record file."""
+        self.close()
+
+
 class LoggerApp(qiwis.BaseApp):
     """App for logging.
 
@@ -134,7 +196,8 @@ class LoggerApp(qiwis.BaseApp):
     Attributes:
         loggerFrame: A frame that shows the logs.
         confirmFrame: A frame that asks whether to clear logs.
-        handler: A handler for adding logs to the loggerFrame. 
+        handler: A handler for adding logs to the loggerFrame.
+        fileHandler: A handler for saving logs to file.
     """
 
     def __init__(self, name: str, parent: Optional[QObject] = None):
@@ -142,20 +205,40 @@ class LoggerApp(qiwis.BaseApp):
         super().__init__(name, parent=parent)
         self.loggerFrame = LoggerFrame()
         self.confirmFrame = ConfirmClearingFrame()
+        self.confirmFileClearFrame = ConfirmFileClearFrame()
+        self.confirmFileWriteFrame = ConfirmFileWriteFrame()
         # connect signals to slots
         self.loggerFrame.clearButton.clicked.connect(self.checkToClear)
+        self.loggerFrame.fileWriteButton.clicked.connect(self.checkToWriteFile)
+        self.loggerFrame.fileClearButton.clicked.connect(self.checkToClearFile)
         self.confirmFrame.confirmed.connect(self.clearLog)
+        self.confirmFileClearFrame.confirmed.connect(self.clearFile)
+        self.confirmFileWriteFrame.confirmed.connect(self.writeToFile)
+        # clear the log_temp file
+        self.dirTempLogFile = "log_temp.txt"
+        self.dirLogFIle = "log_record.txt"
+        with open(self.dirTempLogFile, mode = "w", encoding = "utf-8"):
+            pass
+        # initialize handlers
         self.handler = LoggingHandler(self.addLog)
-        # TODO(aijuh): Change the log format when it is determined.
-        fs = "%(levelname)s [%(name)s] [%(filename)s:%(lineno)d] %(message)s"
-        formatter = logging.Formatter(fs)
-        self.handler.setFormatter(formatter)
+        self.fileHandler = logging.FileHandler(self.dirTempLogFile)
+        simpleFormat = "[%(name)s] %(message)s"
+        complexFormat = "%(asctime)s %(levelname)s [%(name)s]"\
+                        " [%(filename)s:%(lineno)d] %(message)s"
+        self.handler.setFormatter(logging.Formatter(simpleFormat))
+        self.fileHandler.setFormatter(logging.Formatter(complexFormat))
+        self.handler.setLevel(logging.WARNING)
+        self.fileHandler.setLevel(logging.INFO)
+        # set rootLogger
         rootLogger = logging.getLogger()
         rootLogger.addHandler(self.handler)
+        rootLogger.addHandler(self.fileHandler)
         self.setLevel("WARNING")
-        self.loggerFrame.levelBox.addItems(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
+        # set loggerFrame's levelBox
+        levels_dict = {10: "DEBUG", 20: "INFO", 30: "WARNING", 40: "ERROR", 50: "CRITICAL"}
+        self.loggerFrame.levelBox.addItems(levels_dict.values())
         self.loggerFrame.levelBox.textActivated.connect(self.setLevel)
-        self.loggerFrame.levelBox.setCurrentText("WARNING")
+        self.loggerFrame.levelBox.setCurrentText(levels_dict[self.handler.level])
 
     @pyqtSlot(str)
     def setLevel(self, levelText: str):
@@ -175,6 +258,7 @@ class LoggerApp(qiwis.BaseApp):
         }
         if levelText in levels:
             self.handler.setLevel(levels[levelText])
+            self.fileHandler.setLevel(levels[levelText])
             logging.getLogger().setLevel(levels[levelText])
 
     def frames(self) -> Tuple[LoggerFrame]:
@@ -192,12 +276,43 @@ class LoggerApp(qiwis.BaseApp):
         self.loggerFrame.logEdit.insertPlainText(f"{timeString}: {content}\n")
 
     @pyqtSlot()
+    def checkToWriteFile(self):
+        """Shows a confirmation frame for writing to the log record file."""
+        logger.info("Clicked to write log messages to log file.")
+        self.confirmFileWriteFrame.show()
+
+    @pyqtSlot()
+    def writeToFile(self):
+        """Writes log messages in log_temp file to log record file."""
+        with open("log_record.txt", mode = "a", encoding = "utf-8") as logFile:
+            with open("log_temp.txt", mode = "r+", encoding = "utf-8") as tempFile:
+                while True:
+                    line = tempFile.readline()
+                    if not line:
+                        break
+                    logFile.write(line)
+                tempFile.seek(0, 0)
+                tempFile.truncate()
+
+    @pyqtSlot()
+    def checkToClearFile(self):
+        """Shows a confirmation frame for clearing the log record file."""
+        logger.info("Clicked to clear log messages in log file.")
+        self.confirmFileClearFrame.show()
+
+    @pyqtSlot()
+    def clearFile(self):
+        """Clears log messages in the log record file."""
+        with open("log_record.txt", mode = "w", encoding = "utf-8"):
+            pass
+
+    @pyqtSlot()
     def checkToClear(self):
-        """Shows a confirmation frame for clearing logs."""
+        """Shows a confirmation frame for clearing logs in the loggerFrame."""
         logger.info("Tried to clear logs by clicking clear button")
         self.confirmFrame.show()
 
     @pyqtSlot()
     def clearLog(self):
-        """Clears the log texts in loggerFrame."""
+        """Clears the log texts in the loggerFrame."""
         self.loggerFrame.logEdit.clear()

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Tuple, Callable
 
 from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal, QDateTime
 from PyQt5.QtWidgets import (
-    QWidget, QVBoxLayout, QPushButton, QTextEdit, QLabel, QDialogButtonBox, QComboBox, QGridLayout
+    QWidget, QVBoxLayout, QPushButton, QTextEdit, QLabel, QDialogButtonBox, QComboBox
 )
 
 import qiwis
@@ -59,10 +59,7 @@ class LoggerFrame(QWidget):
     Attributes:
         logEdit: A textEdit which shows all logs.
         clearButton: A button for clearing all logs.
-        levelBoxLabel: A label for describing levelBox.
         levelBox: A comboBox for setting the logger's level.
-        fileWriteButton: A button for wrtie logs to file.
-        fileClearButton: A button for clear logs in file.
     """
 
     def __init__(self, parent: Optional[QObject] = None):
@@ -72,19 +69,12 @@ class LoggerFrame(QWidget):
         self.logEdit = QTextEdit(self)
         self.logEdit.setReadOnly(True)
         self.clearButton = QPushButton("Clear", self)
-        self.levelBoxLabel = QLabel("Select log's level:")
         self.levelBox = QComboBox(self)
-        self.fileWriteButton = QPushButton("Save log to file")
-        self.fileClearButton = QPushButton("Clear log file")
         # layout
-        layout = QGridLayout(self)
-        layout.addWidget(self.logEdit, 0, 0, 1, 6)
-        layout.addWidget(self.clearButton,1, 0, 1, 6)
-        layout.addWidget(self.levelBoxLabel, 2, 0, 1, 2)
-        layout.addWidget(self.levelBox, 2, 2, 1, 4)
-        layout.addWidget(self.fileWriteButton, 3, 0, 1, 3)
-        layout.addWidget(self.fileClearButton, 3, 3, 1, 3)
-
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.logEdit)
+        layout.addWidget(self.clearButton)
+        layout.addWidget(self.levelBox)
 
 
 class ConfirmClearingFrame(QWidget):


### PR DESCRIPTION
### Added feature for saving logs to file. 
This PR closes issue #76 
Below are images of current loggerFrame and saved log format.

All logs are first saved at temp file by using file handler. I first think that level for fileHandler should be different for frameHandler. But since user chooses desired level, we can just save that level of logs to file. 

 When user presses `Save log to file` button, contents at temp file saved to log record file and temp file is cleared.
 When user presses `Clear log file` button, only log record file cleared.

The time format of logs in loggerFrame and file is different because we specify format for loggerFrame but use `%asctime` of format in fileHandler. 

All the details can be changed.  

![log_frame](https://github.com/snu-quiqcl/iquip/assets/43592775/520bf764-ce13-4a58-bc66-e70a31b7f8a1)
![file_log](https://github.com/snu-quiqcl/iquip/assets/43592775/15681d2b-ceb2-48db-9186-4e0662b57669)
