### PR TITLE
Implement the left unit tests for builder app

### DIFF
--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -523,9 +523,7 @@ class BuilderApp(qiwis.BaseApp):
         for row in range(listWidget.count()):
             item = listWidget.item(row)
             widget = listWidget.itemWidget(item)
-            value = widget.value()
-            if value is not None:
-                args[widget.name] = value
+            args[widget.name] = widget.value()
         return args
 
     @pyqtSlot()

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -9,6 +9,5 @@ variable-rgx=_?_?(?:(?:[a-z0-9]+(?:_[a-z0-9]+)*_?_?)|(?:[a-z0-9]+(?:[A-Z][a-z0-9
 
 [MESSAGES CONTROL]
 disable=
-    duplicate-code,
     missing-docstring,
     protected-access,

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -9,5 +9,6 @@ variable-rgx=_?_?(?:(?:[a-z0-9]+(?:_[a-z0-9]+)*_?_?)|(?:[a-z0-9]+(?:[A-Z][a-z0-9
 
 [MESSAGES CONTROL]
 disable=
+    duplicate-code,
     missing-docstring,
     protected-access,

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -58,6 +58,7 @@ class BaseEntryTest(unittest.TestCase):
 class ExperimentSubmitThreadTest(unittest.TestCase):
     """Unit tests for ExperimentSubmitThread class."""
 
+    # pylint: disable=duplicate-code
     def setUp(self):
         self.qapp = QApplication([])
         patcher = mock.patch("requests.get")

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -53,6 +53,16 @@ class _DateTimeEntryTest(unittest.TestCase):
 class _ExperimentSubmitThreadTest(unittest.TestCase):
     """Unit tests for _ExperimentSubmitThread class."""
 
+    def setUp(self):
+        self.qapp = QApplication([])
+        patcher = mock.patch("requests.get")
+        self.mocked_get = patcher.start()
+        self.mocked_response = self.mocked_get.return_value
+        self.addCleanup(patcher.stop)
+
+    def tearDown(self):
+        del self.qapp
+
 
 class BuilderAppTest(unittest.TestCase):
     """Unit tests for BuilderApp class."""

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -130,7 +130,7 @@ class ExperimentSubmitThreadTest(unittest.TestCase):
 
 def get_thread(
         callback: Callable[[int], None],
-        parent: QObject,
+        parent: Optional[QObject] = None,
         experimentArgs: Optional[Dict[str, str]] = None
     ) -> builder.ExperimentSubmitThread:
     """Returns an ExperimentSubmitThread instance.

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -33,7 +33,7 @@ EXPERIMENT_ARGS = {"arg1": "arg_value1", "arg2": "arg_value2"}
 
 SCHED_OPTS = {"opt1": "opt_value1", "opt2": "opt_value2"}
 
-class _BaseEntryTest(unittest.TestCase):
+class BaseEntryTest(unittest.TestCase):
     """Unit tests for _BaseEntry class."""
 
     def setUp(self):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -56,7 +56,7 @@ class BaseEntryTest(unittest.TestCase):
 
 
 class ExperimentSubmitThreadTest(unittest.TestCase):
-    """Unit tests for ExperimentSubmitThread class."""
+    """Unit tests for _ExperimentSubmitThread class."""
 
     # pylint: disable=duplicate-code
     def setUp(self):
@@ -72,7 +72,7 @@ class ExperimentSubmitThreadTest(unittest.TestCase):
     def test_init(self):
         callback = mock.MagicMock()
         parent = QObject()
-        with mock.patch("iquip.apps.builder.ExperimentSubmitThread.submitted") as mocked_submitted:
+        with mock.patch("iquip.apps.builder._ExperimentSubmitThread.submitted") as mocked_submitted:
             thread = get_thread(callback, parent)
         self.assertEqual(thread.experimentPath, EXPERIMENT_PATH)
         self.assertEqual(thread.experimentArgs, EXPERIMENT_ARGS)
@@ -83,7 +83,7 @@ class ExperimentSubmitThreadTest(unittest.TestCase):
         self.mocked_response.json.return_value = 100
         callback = mock.MagicMock()
         parent = QObject()
-        with mock.patch("iquip.apps.builder.ExperimentSubmitThread.submitted") as mocked_submitted:
+        with mock.patch("iquip.apps.builder._ExperimentSubmitThread.submitted") as mocked_submitted:
             thread = get_thread(callback, parent)
             thread.run()
             thread.wait()
@@ -102,7 +102,7 @@ class ExperimentSubmitThreadTest(unittest.TestCase):
         self.mocked_response.raise_for_status.side_effect = requests.exceptions.RequestException()
         callback = mock.MagicMock()
         parent = QObject()
-        with mock.patch("iquip.apps.builder.ExperimentSubmitThread.submitted") as mocked_submitted:
+        with mock.patch("iquip.apps.builder._ExperimentSubmitThread.submitted") as mocked_submitted:
             thread = get_thread(callback, parent)
             thread.run()
             thread.wait()
@@ -120,7 +120,7 @@ class ExperimentSubmitThreadTest(unittest.TestCase):
         """Tests when a TypeError occurs."""
         callback = mock.MagicMock()
         parent = QObject()
-        with mock.patch("iquip.apps.builder.ExperimentSubmitThread.submitted") as mocked_submitted:
+        with mock.patch("iquip.apps.builder._ExperimentSubmitThread.submitted") as mocked_submitted:
             experimentArgs = {"arg1": lambda: None}  # Not JSONifiable.
             thread = get_thread(callback, parent, experimentArgs)
             thread.run()
@@ -134,7 +134,7 @@ def get_thread(
         parent: Optional[QObject] = None,
         experimentArgs: Optional[Dict[str, str]] = None
     ) -> builder._ExperimentSubmitThread:
-    """Returns an ExperimentSubmitThread instance.
+    """Returns an _ExperimentSubmitThread instance.
     
     Args:
         callback: The function called after the thread is done.
@@ -161,7 +161,6 @@ class BuilderAppTest(unittest.TestCase):
             f"{type_}Value": mock.MagicMock(return_value=QWidget())
             for type_ in ("Boolean", "String", "Enumeration", "Number", "DateTime")
         }
-        experiment_submit_thread_patcher = mock.patch("iquip.apps.builder._ExperimentSubmitThread")
         entries_patcher = mock.patch.multiple(
             "iquip.apps.builder",
             _BooleanEntry=self.mocked_entries["BooleanValue"],
@@ -232,7 +231,7 @@ class BuilderAppTest(unittest.TestCase):
         self.assertEqual(args["name1"], "value1")
         self.assertEqual(args["name2"], None)
 
-    @mock.patch("iquip.apps.builder.ExperimentSubmitThread")
+    @mock.patch("iquip.apps.builder._ExperimentSubmitThread")
     def test_submit(self, mocked_experiment_submit_thread_cls):
         app = builder.BuilderApp(
             name="name",

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -134,6 +134,35 @@ class BuilderAppTest(unittest.TestCase):
         self.assertEqual(args["name1"], "value1")
         self.assertNotIn("name2", args)
 
+    @mock.patch("iquip.apps.builder.ExperimentSubmitThread")
+    def test_submit(self, mocked_experiment_submit_thread_cls):
+        app = builder.BuilderApp(
+            name="name",
+            experimentPath="experimentPath",
+            experimentClsName="experimentClsName",
+            experimentInfo=copy.deepcopy(EMPTY_EXPERIMENT_INFO)
+        )
+        experimentArgs = {"key1": "value1"}
+        schedOpts = {"key2": "value2"}
+        with mock.patch.multiple(
+            app,
+            argumentsFromListWidget=mock.DEFAULT,
+            onSubmitted=mock.DEFAULT
+        ) as mocked:
+            mocked_arguments_from_list_widget = mocked["argumentsFromListWidget"]
+            mocked_on_submitted = mocked["onSubmitted"]
+            mocked_arguments_from_list_widget.side_effect=[experimentArgs, schedOpts]
+            app.submit()
+        mocked_arguments_from_list_widget.assert_any_call(app.builderFrame.argsListWidget)
+        mocked_arguments_from_list_widget.assert_any_call(app.builderFrame.schedOptsListWidget)
+        mocked_experiment_submit_thread_cls.assert_called_once_with(
+            "experimentPath",
+            experimentArgs,
+            schedOpts,
+            mocked_on_submitted,
+            app
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -211,10 +211,7 @@ class BuilderAppTest(unittest.TestCase):
 
     def test_arguments_from_list_widget(self):
         listWidget = QListWidget()
-        for name, value in (
-            ("name1", "value1"),
-            ("name2", None),
-        ):
+        for name, value in (("name1", "value1"), ("name2", None)):
             widget = QWidget()
             widget.name = name
             widget.value = mock.MagicMock(return_value=value)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -133,7 +133,7 @@ def get_thread(
         callback: Callable[[int], None],
         parent: Optional[QObject] = None,
         experimentArgs: Optional[Dict[str, str]] = None
-    ) -> builder.ExperimentSubmitThread:
+    ) -> builder._ExperimentSubmitThread:
     """Returns an ExperimentSubmitThread instance.
     
     Args:
@@ -143,7 +143,7 @@ def get_thread(
     """
     if experimentArgs is None:
         experimentArgs = copy.deepcopy(EXPERIMENT_ARGS)
-    return builder.ExperimentSubmitThread(
+    return builder._ExperimentSubmitThread(
         experimentPath=EXPERIMENT_PATH,
         experimentArgs=experimentArgs,
         schedOpts=SCHED_OPTS,

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,10 +1,11 @@
 """Unit tests for builder module."""
 
 import copy
+import functools
 import unittest
 from unittest import mock
 
-from PyQt5.QtWidgets import QApplication, QWidget
+from PyQt5.QtWidgets import QApplication, QListWidget, QListWidgetItem, QWidget
 
 from iquip.apps import builder
 
@@ -112,6 +113,28 @@ class BuilderAppTest(unittest.TestCase):
         self.mocked_entries["StringValue"].assert_any_call("pipeline", pipelineInfo)
         self.mocked_entries["NumberValue"].assert_any_call("priority", priorityInfo)
         self.mocked_entries["DateTimeValue"].assert_any_call("timed")
+
+    def test_arguments_from_list_widget(self):
+        listWidget = QListWidget()
+        for name, value in (
+            ("name1", "value1"),
+            ("name2", None),
+        ):
+            widget = QWidget()
+            widget.name = name
+            widget.value = mock.MagicMock(return_value=value)
+            item = QListWidgetItem(listWidget)
+            listWidget.addItem(item)
+            listWidget.setItemWidget(item, widget)
+        app = builder.BuilderApp(
+            name="name",
+            experimentPath="experimentPath",
+            experimentClsName="experimentClsName",
+            experimentInfo=copy.deepcopy(EMPTY_EXPERIMENT_INFO)
+        )
+        args = app.argumentsFromListWidget(listWidget)
+        self.assertEqual(args["name1"], "value1")
+        self.assertNotIn("name2", args)
 
 
 if __name__ == "__main__":

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -124,11 +124,6 @@ class ExperimentSubmitThreadTest(unittest.TestCase):
             thread = get_thread(callback, parent, experimentArgs)
             thread.run()
             thread.wait()
-        params = {
-            "file": EXPERIMENT_PATH,
-            "args": json.dumps(EXPERIMENT_ARGS),
-            **SCHED_OPTS
-        }
         self.mocked_get.assert_not_called()
         mocked_submitted.emit.assert_not_called()
 
@@ -136,7 +131,7 @@ class ExperimentSubmitThreadTest(unittest.TestCase):
 def get_thread(
         callback: Callable[[int], None],
         parent: QObject,
-        experimentArgs: Optional[Dict[str, str]] = EXPERIMENT_ARGS
+        experimentArgs: Optional[Dict[str, str]] = None
     ) -> builder.ExperimentSubmitThread:
     """Returns an ExperimentSubmitThread instance.
     
@@ -145,6 +140,8 @@ def get_thread(
         parent: The parent object.
         experimentArgs: The arguments of the experiment.
     """
+    if experimentArgs is None:
+        experimentArgs = copy.deepcopy(EXPERIMENT_ARGS)
     return builder.ExperimentSubmitThread(
         experimentPath=EXPERIMENT_PATH,
         experimentArgs=experimentArgs,

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -58,7 +58,7 @@ class _BaseEntryTest(unittest.TestCase):
 class ExperimentSubmitThreadTest(unittest.TestCase):
     """Unit tests for ExperimentSubmitThread class."""
 
-    def setUp(self):  # pylint: disable=duplicate-code
+    def setUp(self):
         self.qapp = QApplication([])
         patcher = mock.patch("requests.get")
         self.mocked_get = patcher.start()

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -58,7 +58,7 @@ class _BaseEntryTest(unittest.TestCase):
 class ExperimentSubmitThreadTest(unittest.TestCase):
     """Unit tests for ExperimentSubmitThread class."""
 
-    def setUp(self):
+    def setUp(self):  # pylint: disable=duplicate-code
         self.qapp = QApplication([])
         patcher = mock.patch("requests.get")
         self.mocked_get = patcher.start()

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -36,6 +36,24 @@ SCHED_OPTS = {"opt1": "opt_value1", "opt2": "opt_value2"}
 class _BaseEntryTest(unittest.TestCase):
     """Unit tests for _BaseEntry class."""
 
+    def setUp(self):
+        self.qapp = QApplication([])
+
+    def tearDown(self):
+        del self.qapp
+
+    def test_init(self):
+        for argName, (argInfo, *_) in EXPERIMENT_INFO["arginfo"].items():
+            entry = builder._BaseEntry(argName, argInfo)
+            self.assertEqual(entry.name, argName)
+            self.assertEqual(entry.argInfo, argInfo)
+
+    def test_value(self):
+        for argName, (argInfo, *_) in EXPERIMENT_INFO["arginfo"].items():
+            entry = builder._BaseEntry(argName, argInfo)
+            with self.assertRaises(NotImplementedError):
+                entry.value()
+
 
 class _BooleanEntryTest(unittest.TestCase):
     """Unit tests for _BooleanEntry class."""
@@ -70,7 +88,7 @@ class _ExperimentSubmitThreadTest(unittest.TestCase):
     def tearDown(self):
         del self.qapp
 
-    def test_init_thread(self):
+    def test_init(self):
         callback = mock.MagicMock()
         parent = QObject()
         with mock.patch("iquip.apps.builder.ExperimentSubmitThread.submitted") as mocked_submitted:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -230,7 +230,7 @@ class BuilderAppTest(unittest.TestCase):
         )
         args = app.argumentsFromListWidget(listWidget)
         self.assertEqual(args["name1"], "value1")
-        self.assertNotIn("name2", args)
+        self.assertEqual(args["name2"], None)
 
     @mock.patch("iquip.apps.builder.ExperimentSubmitThread")
     def test_submit(self, mocked_experiment_submit_thread_cls):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -5,6 +5,7 @@ import functools
 import unittest
 from unittest import mock
 
+from PyQt5.QtCore import QObject, Qt
 from PyQt5.QtWidgets import QApplication, QListWidget, QListWidgetItem, QWidget
 
 from iquip.apps import builder
@@ -62,6 +63,24 @@ class _ExperimentSubmitThreadTest(unittest.TestCase):
 
     def tearDown(self):
         del self.qapp
+
+    def test_init_thread(self):
+        experimentArgs = {"arg1": "value1", "arg2": "value2"}
+        schedOpts = {"opt1": "value1", "opt2": "value2"}
+        callback = mock.MagicMock()
+        parent = QObject()
+        with mock.patch("iquip.apps.builder.ExperimentSubmitThread.submitted") as mocked_submitted:
+            thread = builder.ExperimentSubmitThread(
+                experimentPath="experiment_path",
+                experimentArgs=experimentArgs,
+                schedOpts=schedOpts,
+                callback=callback,
+                parent=parent
+            )
+        self.assertEqual(thread.experimentPath, "experiment_path")
+        self.assertEqual(thread.experimentArgs, experimentArgs)
+        self.assertEqual(thread.schedOpts, schedOpts)
+        mocked_submitted.connect.assert_called_once_with(callback, type=Qt.QueuedConnection)
 
 
 class BuilderAppTest(unittest.TestCase):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -3,7 +3,7 @@
 import copy
 import json
 import unittest
-from typing import Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 from unittest import mock
 
 import requests
@@ -132,7 +132,7 @@ class ExperimentSubmitThreadTest(unittest.TestCase):
 def get_thread(
         callback: Callable[[int], None],
         parent: Optional[QObject] = None,
-        experimentArgs: Optional[Dict[str, str]] = None
+        experimentArgs: Optional[Dict[str, Any]] = None
     ) -> builder._ExperimentSubmitThread:
     """Returns an _ExperimentSubmitThread instance.
     

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -248,7 +248,7 @@ class BuilderAppTest(unittest.TestCase):
         ) as mocked:
             mocked_arguments_from_list_widget = mocked["argumentsFromListWidget"]
             mocked_on_submitted = mocked["onSubmitted"]
-            mocked_arguments_from_list_widget.side_effect=[experimentArgs, schedOpts]
+            mocked_arguments_from_list_widget.side_effect = [experimentArgs, schedOpts]
             app.submit()
         mocked_arguments_from_list_widget.assert_any_call(app.builderFrame.argsListWidget)
         mocked_arguments_from_list_widget.assert_any_call(app.builderFrame.schedOptsListWidget)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -72,9 +72,7 @@ class BuilderAppTest(unittest.TestCase):
             _NumberEntry=self.mocked_entries["NumberValue"],
             _DateTimeEntry=self.mocked_entries["DateTimeValue"]
         )
-        self.mocked_submit_thread_cls = experiment_submit_thread_patcher.start()
         entries_patcher.start()
-        self.addCleanup(experiment_submit_thread_patcher.stop)
         self.addCleanup(entries_patcher.stop)
 
     def tearDown(self):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -163,6 +163,15 @@ class BuilderAppTest(unittest.TestCase):
             app
         )
 
+    def test_frames(self):
+        app = builder.BuilderApp(
+            name="name",
+            experimentPath="experimentPath",
+            experimentClsName="experimentClsName",
+            experimentInfo=copy.deepcopy(EMPTY_EXPERIMENT_INFO)
+        )
+        self.assertEqual(app.frames(), (app.builderFrame,))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -15,7 +15,7 @@ from iquip.apps import explorer
 class FileFinderThreadTest(unittest.TestCase):
     """Unit tests for _FileFinderThread class."""
 
-    def setUp(self):
+    def setUp(self):  # pylint: disable=duplicate-code
         self.qapp = QApplication([])
         patcher = mock.patch("requests.get")
         self.mocked_get = patcher.start()

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -15,7 +15,7 @@ from iquip.apps import explorer
 class FileFinderThreadTest(unittest.TestCase):
     """Unit tests for _FileFinderThread class."""
 
-    def setUp(self):  # pylint: disable=duplicate-code
+    def setUp(self):
         self.qapp = QApplication([])
         patcher = mock.patch("requests.get")
         self.mocked_get = patcher.start()

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -15,6 +15,7 @@ from iquip.apps import explorer
 class FileFinderThreadTest(unittest.TestCase):
     """Unit tests for _FileFinderThread class."""
 
+    # pylint: disable=duplicate-code
     def setUp(self):
         self.qapp = QApplication([])
         patcher = mock.patch("requests.get")


### PR DESCRIPTION
This PR will close #68.

I implemented the left __unit__ tests for builder app, not functional tests.

So I __DID NOT__ implement tests about the followings.
- All entry classes except for `BaseEntry`
- `BuilderApp.onSubmitted()`

Also, all `print()` statements will be converted to logging, so we can test it using [`assertLogs()`](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertLogs) later.

### Results
![image](https://github.com/snu-quiqcl/iquip/assets/76851886/7cc8cb4f-cc2d-4cf0-9db5-f6e46c0df961)
