### PR TITLE
Aijuh/76/logs to file

### DIFF
--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -158,8 +158,8 @@ class LoggerApp(qiwis.BaseApp):
                            logging.ERROR: "ERROR", logging.CRITICAL: "CRITICAL"}
         self.frameHandler = LoggingHandler(self.addLog)
         logFileName = os.path.join(path,
-                                   QDateTime.currentDateTime().toString("log_yyMMdd-HHmmss"))
-        self.fileHandler = handlers.TimedRotatingFileHandler(filename=logFileName+".log", when="midnight"
+                                   QDateTime.currentDateTime().toString("log_yyMMdd-HHmmss.log"))
+        self.fileHandler = handlers.TimedRotatingFileHandler(filename=logFileName, when="midnight"
                                                              ,encoding="utf-8")
         self.initLogger()
         # set loggerFrame's frameLevelBox

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -146,7 +146,7 @@ class LoggerApp(qiwis.BaseApp):
         """Extended.
         
         Args:
-            path: The path of the log record file.
+            logFilePath: The path of the log record file.
         """
         super().__init__(name, parent=parent)
         self.loggerFrame = LoggerFrame()
@@ -175,11 +175,7 @@ class LoggerApp(qiwis.BaseApp):
         fileLevelBox.setCurrentText(self.levelsDict[self.fileHandler.level])
 
     def initLogger(self):
-        """Initializes the root logger and handlers.
-        
-        Args:
-            path: The path of the log record file.    
-        """
+        """Initializes the root logger and handlers."""
         def namer(name):
             return name.replace(".log", "") + ".log"
         self.fileHandler.suffix = "(%Y%m%d)"

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -200,6 +200,7 @@ class LoggerApp(qiwis.BaseApp):
         fileHandler: A handler for saving logs to file.
     """
 
+    # pylint: disable=too-many-instance-attributes
     def __init__(self, name: str, parent: Optional[QObject] = None):
         """Extended."""
         super().__init__(name, parent=parent)
@@ -226,7 +227,7 @@ class LoggerApp(qiwis.BaseApp):
         self.loggerFrame.levelBox.addItems(levels_dict.values())
         self.loggerFrame.levelBox.textActivated.connect(self.setLevel)
         self.loggerFrame.levelBox.setCurrentText(levels_dict[self.frameHandler.level])
-    
+
     def initLogger(self):
         """Initializes the root logger and handlers for constructor."""
         # initialize handlers

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -154,32 +154,36 @@ class LoggerApp(qiwis.BaseApp):
         # connect signals to slots
         self.loggerFrame.clearButton.clicked.connect(self.checkToClear)
         self.confirmFrame.confirmed.connect(self.clearLog)
-        self.initLogger(path)
-        # set loggerFrame's frameLevelBox
-        frameLevelBox = self.loggerFrame.frameLevelBox
-        frameLevelBox.addItems(self.levelsDict.values())
-        frameLevelBox.textActivated.connect(functools.partial(self.setLevel, self.frameHandler))
-        frameLevelBox.setCurrentText(self.levelsDict[self.frameHandler.level])
-        # set loggerFrame's fileLevelBox
-        fileLevelBox = self.loggerFrame.fileLevelBox
-        fileLevelBox.addItems(self.levelsDict.values())
-        fileLevelBox.textActivated.connect(functools.partial(self.setLevel, self.fileHandler))
-        fileLevelBox.setCurrentText(self.levelsDict[self.fileHandler.level])
-
-    def initLogger(self, path: str):
-        """Initializes the root logger and handlers.
-        
-        Args:
-            path: The path of the log record file.    
-        """
         self.levelsDict = {logging.DEBUG: "DEBUG", logging.INFO: "INFO", logging.WARNING: "WARNING",
                            logging.ERROR: "ERROR", logging.CRITICAL: "CRITICAL"}
         self.frameHandler = LoggingHandler(self.addLog)
         logFileName = os.path.join(path,
                                    QDateTime.currentDateTime().toString("log_yyMMdd-HHmmss"))
-        self.fileHandler = handlers.TimedRotatingFileHandler(filename=logFileName, when="midnight",
-                                                             encoding="utf-8")
-        self.fileHandler.suffix = "(%Y%m%d).log"
+        self.fileHandler = handlers.TimedRotatingFileHandler(filename=logFileName+".log", when="M",
+                                                             interval = 1, encoding="utf-8")
+        self.initLogger()
+        # set loggerFrame's frameLevelBox
+        frameLevelBox = self.loggerFrame.frameLevelBox
+        frameLevelBox.addItems(self.levelsDict.values())
+        frameLevelBox.currentTextChanged.connect(functools.partial(self.setLevel,
+                                                                   self.frameHandler))
+        frameLevelBox.setCurrentText(self.levelsDict[self.frameHandler.level])
+        # set loggerFrame's fileLevelBox
+        fileLevelBox = self.loggerFrame.fileLevelBox
+        fileLevelBox.addItems(self.levelsDict.values())
+        fileLevelBox.currentTextChanged.connect(functools.partial(self.setLevel, self.fileHandler))
+        fileLevelBox.setCurrentText(self.levelsDict[self.fileHandler.level])
+
+    def initLogger(self):
+        """Initializes the root logger and handlers.
+        
+        Args:
+            path: The path of the log record file.    
+        """
+        def namer(name):
+            return name.replace(".log", "") + ".log"
+        self.fileHandler.suffix = "(%Y%m%d)"
+        self.fileHandler.namer = namer
         shortFormat = "[%(name)s] %(message)s"
         longFormat = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] %(message)s"
         self.frameHandler.setFormatter(logging.Formatter(shortFormat))

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -175,10 +175,11 @@ class LoggerApp(qiwis.BaseApp):
         self.levelsDict = {logging.DEBUG: "DEBUG", logging.INFO: "INFO", logging.WARNING: "WARNING",
                            logging.ERROR: "ERROR", logging.CRITICAL: "CRITICAL"}
         self.frameHandler = LoggingHandler(self.addLog)
-        logFileName = os.path.join(path, QDateTime.currentDateTime().toString("log_yyMMdd-HHmmss.log"))
+        logFileName = os.path.join(path, 
+                                   QDateTime.currentDateTime().toString("log_yyMMdd-HHmmss"))
         self.fileHandler = handlers.TimedRotatingFileHandler(filename=logFileName, when="midnight",
                                                              interval=1, encoding="utf-8")
-        self.fileHandler.suffix = "(%Y%m%d)"
+        self.fileHandler.suffix = "(%Y%m%d).log"
         shortFormat = "[%(name)s] %(message)s"
         longFormat = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] %(message)s"
         self.frameHandler.setFormatter(logging.Formatter(shortFormat))

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -219,6 +219,16 @@ class LoggerApp(qiwis.BaseApp):
         self.dirLogFIle = "log_record.txt"
         with open(self.dirTempLogFile, mode = "w", encoding = "utf-8"):
             pass
+        #initialize logger
+        self.initLogger()
+        # set loggerFrame's levelBox
+        levels_dict = {10: "DEBUG", 20: "INFO", 30: "WARNING", 40: "ERROR", 50: "CRITICAL"}
+        self.loggerFrame.levelBox.addItems(levels_dict.values())
+        self.loggerFrame.levelBox.textActivated.connect(self.setLevel)
+        self.loggerFrame.levelBox.setCurrentText(levels_dict[self.frameHandler.level])
+    
+    def initLogger(self):
+        """Initializes the root logger and handlers for constructor."""
         # initialize handlers
         self.frameHandler = LoggingHandler(self.addLog)
         self.fileHandler = logging.FileHandler(self.dirTempLogFile)
@@ -232,11 +242,6 @@ class LoggerApp(qiwis.BaseApp):
         rootLogger.addHandler(self.frameHandler)
         rootLogger.addHandler(self.fileHandler)
         self.setLevel("WARNING")
-        # set loggerFrame's levelBox
-        levels_dict = {10: "DEBUG", 20: "INFO", 30: "WARNING", 40: "ERROR", 50: "CRITICAL"}
-        self.loggerFrame.levelBox.addItems(levels_dict.values())
-        self.loggerFrame.levelBox.textActivated.connect(self.setLevel)
-        self.loggerFrame.levelBox.setCurrentText(levels_dict[self.frameHandler.level])
 
     @pyqtSlot(str)
     def setLevel(self, levelText: str):

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -178,7 +178,7 @@ class LoggerApp(qiwis.BaseApp):
         logFileName = os.path.join(path,
                                    QDateTime.currentDateTime().toString("log_yyMMdd-HHmmss"))
         self.fileHandler = handlers.TimedRotatingFileHandler(filename=logFileName, when="midnight",
-                                                             interval=1, encoding="utf-8")
+                                                             encoding="utf-8")
         self.fileHandler.suffix = "(%Y%m%d).log"
         shortFormat = "[%(name)s] %(message)s"
         longFormat = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] %(message)s"
@@ -197,7 +197,7 @@ class LoggerApp(qiwis.BaseApp):
 
     @pyqtSlot(logging.Handler, str)
     def setLevel(self, handler_: logging.Handler, levelText: str):
-        """Changes the handler's level and update root logger's level.
+        """Changes the handler's level and updates root logger's level.
 
         Args:
             handler_: A Handler for which the level should be set. 

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -1,10 +1,10 @@
 """App module for log viewer in apps."""
 
+import os
+import functools
 import logging
 from logging import handlers
 from typing import Any, Optional, Tuple, Callable
-from functools import partial
-import os
 
 from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal, QDateTime
 from PyQt5.QtWidgets import (
@@ -146,7 +146,6 @@ class LoggerApp(qiwis.BaseApp):
         """Extended.
         
         Args:
-            name: Specifies name of the LoggerApp.
             path: Desribes file directory of log record file.
         """
         super().__init__(name, parent=parent)
@@ -166,12 +165,12 @@ class LoggerApp(qiwis.BaseApp):
         # set loggerFrame's frameLevelBox
         frameLevelBox = self.loggerFrame.frameLevelBox
         frameLevelBox.addItems(self.levelsDict.values())
-        frameLevelBox.textActivated.connect(partial(self.setLevel, self.frameHandler))
+        frameLevelBox.textActivated.connect(functools.partial(self.setLevel, self.frameHandler))
         frameLevelBox.setCurrentText(self.levelsDict[self.frameHandler.level])
         # set loggerFrame's fileLevelBox
         fileLevelBox = self.loggerFrame.fileLevelBox
         fileLevelBox.addItems(self.levelsDict.values())
-        fileLevelBox.textActivated.connect(partial(self.setLevel, self.fileHandler))
+        fileLevelBox.textActivated.connect(functools.partial(self.setLevel, self.fileHandler))
         fileLevelBox.setCurrentText(self.levelsDict[self.fileHandler.level])
 
     def initLogger(self):
@@ -185,7 +184,7 @@ class LoggerApp(qiwis.BaseApp):
         rootLogger = logging.getLogger()
         rootLogger.addHandler(self.frameHandler)
         rootLogger.addHandler(self.fileHandler)
-        self.frameHandler.setLevel("WARNING")
+        self.setLevel(self.frameHandler, "WARNING")
         self.setLevel(self.fileHandler, "WARNING")
 
     def frames(self) -> Tuple[LoggerFrame]:
@@ -194,7 +193,7 @@ class LoggerApp(qiwis.BaseApp):
 
     @pyqtSlot(logging.Handler, str)
     def setLevel(self, handler_: logging.Handler, levelText: str):
-        """Responds to the loggerFrame's fileLevelBox widgets and changes the handler's level.
+        """Changes the handler's level and update root logger's level.
 
         Args:
             handler_: A Handler for which the level should be set. 
@@ -205,7 +204,7 @@ class LoggerApp(qiwis.BaseApp):
         if levelText in self.levelsDict.values():
             handler_.setLevel(levelText)
             lowerLevel = min(self.frameHandler.level, self.fileHandler.level)
-            logging.getLogger().setLevel(self.levelsDict[lowerLevel])
+            logging.getLogger().setLevel(lowerLevel)
 
     @pyqtSlot(str)
     def addLog(self, content: str):

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -159,8 +159,8 @@ class LoggerApp(qiwis.BaseApp):
         self.frameHandler = LoggingHandler(self.addLog)
         logFileName = os.path.join(path,
                                    QDateTime.currentDateTime().toString("log_yyMMdd-HHmmss"))
-        self.fileHandler = handlers.TimedRotatingFileHandler(filename=logFileName+".log", when="M",
-                                                             interval = 1, encoding="utf-8")
+        self.fileHandler = handlers.TimedRotatingFileHandler(filename=logFileName+".log", when="midnight"
+                                                             ,encoding="utf-8")
         self.initLogger()
         # set loggerFrame's frameLevelBox
         frameLevelBox = self.loggerFrame.frameLevelBox

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -75,9 +75,9 @@ class LoggerFrame(QWidget):
         self.logEdit = QTextEdit(self)
         self.logEdit.setReadOnly(True)
         self.clearButton = QPushButton("Clear", self)
-        self.frameLevelBoxLabel = QLabel("Select screen log's level:")
+        self.frameLevelBoxLabel = QLabel("Select screen log's level:", self)
         self.frameLevelBox = QComboBox(self)
-        self.fileLevelBoxLabel = QLabel("Select file log's level:")
+        self.fileLevelBoxLabel = QLabel("Select file log's level:", self)
         self.fileLevelBox = QComboBox(self)
         # layout
         layout = QGridLayout(self)
@@ -192,8 +192,9 @@ class LoggerApp(qiwis.BaseApp):
         rootLogger = logging.getLogger()
         rootLogger.addHandler(self.frameHandler)
         rootLogger.addHandler(self.fileHandler)
-        self.setLevel(self.frameHandler, "WARNING")
-        self.setLevel(self.fileHandler, "WARNING")
+        defaultLevel = "WARNING"
+        self.setLevel(self.frameHandler, defaultLevel)
+        self.setLevel(self.fileHandler, defaultLevel)
 
     def frames(self) -> Tuple[LoggerFrame]:
         """Overridden."""

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -158,13 +158,15 @@ class LoggerApp(qiwis.BaseApp):
                                                              interval=1, encoding="utf-8")
         self.initLogger()
         # set loggerFrame's frameLevelBox
-        self.loggerFrame.frameLevelBox.addItems(self.levelsDict.values())
-        self.loggerFrame.frameLevelBox.textActivated.connect(partial(self.setLevel, self.frameHandler))
-        self.loggerFrame.frameLevelBox.setCurrentText(self.levelsDict[self.frameHandler.level])
+        frameLevelBox = self.loggerFrame.frameLevelBox
+        frameLevelBox.addItems(self.levelsDict.values())
+        frameLevelBox.textActivated.connect(partial(self.setLevel, self.frameHandler))
+        frameLevelBox.setCurrentText(self.levelsDict[self.frameHandler.level])
         # set loggerFrame's fileLevelBox
-        self.loggerFrame.fileLevelBox.addItems(self.levelsDict.values())
-        self.loggerFrame.fileLevelBox.textActivated.connect(partial(self.setLevel, self.fileHandler))
-        self.loggerFrame.fileLevelBox.setCurrentText(self.levelsDict[self.fileHandler.level])
+        fileLevelBox = self.loggerFrame.fileLevelBox
+        fileLevelBox.addItems(self.levelsDict.values())
+        fileLevelBox.textActivated.connect(partial(self.setLevel, self.fileHandler))
+        fileLevelBox.setCurrentText(self.levelsDict[self.fileHandler.level])
 
     def initLogger(self):
         """Initializes the root logger and handlers for constructor."""

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -146,7 +146,7 @@ class LoggerApp(qiwis.BaseApp):
         """Extended.
         
         Args:
-            path: Desribes file directory of log record file.
+            path: The path of the log record file.
         """
         super().__init__(name, parent=parent)
         self.loggerFrame = LoggerFrame()
@@ -154,14 +154,7 @@ class LoggerApp(qiwis.BaseApp):
         # connect signals to slots
         self.loggerFrame.clearButton.clicked.connect(self.checkToClear)
         self.confirmFrame.confirmed.connect(self.clearLog)
-        # initialize handlers
-        self.levelsDict = {logging.DEBUG: "DEBUG", logging.INFO: "INFO", logging.WARNING: "WARNING",
-                           logging.ERROR: "ERROR", logging.CRITICAL: "CRITICAL"}
-        self.frameHandler = LoggingHandler(self.addLog)
-        logFileName = os.path.join(path, QDateTime.currentDateTime().toString("logyyMMdd-HHmmss"))
-        self.fileHandler = handlers.TimedRotatingFileHandler(filename=logFileName, when="midnight",
-                                                             interval=1, encoding="utf-8")
-        self.initLogger()
+        self.initLogger(path)
         # set loggerFrame's frameLevelBox
         frameLevelBox = self.loggerFrame.frameLevelBox
         frameLevelBox.addItems(self.levelsDict.values())
@@ -173,8 +166,18 @@ class LoggerApp(qiwis.BaseApp):
         fileLevelBox.textActivated.connect(functools.partial(self.setLevel, self.fileHandler))
         fileLevelBox.setCurrentText(self.levelsDict[self.fileHandler.level])
 
-    def initLogger(self):
-        """Initializes the root logger and handlers for constructor."""
+    def initLogger(self, path: str):
+        """Initializes the root logger and handlers.
+        
+        Args:
+            path: The path of the log record file.    
+        """
+        self.levelsDict = {logging.DEBUG: "DEBUG", logging.INFO: "INFO", logging.WARNING: "WARNING",
+                           logging.ERROR: "ERROR", logging.CRITICAL: "CRITICAL"}
+        self.frameHandler = LoggingHandler(self.addLog)
+        logFileName = os.path.join(path, QDateTime.currentDateTime().toString("log_yyMMdd-HHmmss.log"))
+        self.fileHandler = handlers.TimedRotatingFileHandler(filename=logFileName, when="midnight",
+                                                             interval=1, encoding="utf-8")
         self.fileHandler.suffix = "(%Y%m%d)"
         shortFormat = "[%(name)s] %(message)s"
         longFormat = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] %(message)s"

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -142,7 +142,7 @@ class LoggerApp(qiwis.BaseApp):
         fileHandler: A handler for saving logs to file.
     """
 
-    def __init__(self, name: str, path: str, parent: Optional[QObject] = None):
+    def __init__(self, name: str, logFilePath: str, parent: Optional[QObject] = None):
         """Extended.
         
         Args:
@@ -157,10 +157,10 @@ class LoggerApp(qiwis.BaseApp):
         self.levelsDict = {logging.DEBUG: "DEBUG", logging.INFO: "INFO", logging.WARNING: "WARNING",
                            logging.ERROR: "ERROR", logging.CRITICAL: "CRITICAL"}
         self.frameHandler = LoggingHandler(self.addLog)
-        logFileName = os.path.join(path,
+        logFileName = os.path.join(logFilePath,
                                    QDateTime.currentDateTime().toString("log_yyMMdd-HHmmss.log"))
-        self.fileHandler = handlers.TimedRotatingFileHandler(filename=logFileName, when="midnight"
-                                                             ,encoding="utf-8")
+        self.fileHandler = handlers.TimedRotatingFileHandler(filename=logFileName, when="midnight",
+                                                             encoding="utf-8")
         self.initLogger()
         # set loggerFrame's frameLevelBox
         frameLevelBox = self.loggerFrame.frameLevelBox

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -1,7 +1,7 @@
 """App module for log viewer in apps."""
 
 import logging
-import logging.handlers
+from logging import handlers
 from typing import Any, Optional, Tuple, Callable
 
 from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal, QDateTime
@@ -161,17 +161,10 @@ class LoggerApp(qiwis.BaseApp):
     def initLogger(self):
         """Initializes the root logger and handlers for constructor."""
         self.levels_dict = {10: "DEBUG", 20: "INFO", 30: "WARNING", 40: "ERROR", 50: "CRITICAL"}
-        self.levels = {
-            "DEBUG": logging.DEBUG,
-            "INFO": logging.INFO,
-            "WARNING": logging.WARNING,
-            "ERROR": logging.ERROR,
-            "CRITICAL": logging.CRITICAL
-        }
         # initialize handlers
         self.frameHandler = LoggingHandler(self.addLog)
-        self.fileHandler = logging.handlers.TimedRotatingFileHandler(filename = "log-record", 
-                                                                     when = "midnight", interval = 1, encoding = 'utf-8')
+        self.fileHandler = handlers.TimedRotatingFileHandler(filename = "log", when = "midnight",
+                                                             interval = 1, encoding = 'utf-8')
         self.fileHandler.suffix = '-%Y%m%d'
         simpleFormat = "[%(name)s] %(message)s"
         complexFormat = "%(asctime)s %(levelname)s [%(name)s]"\
@@ -185,7 +178,7 @@ class LoggerApp(qiwis.BaseApp):
         self.fileHandler.setLevel("WARNING")
         self.setFrameLevel("WARNING")
         self.setFileLevel("WARNING")
-        
+
 
     def frames(self) -> Tuple[LoggerFrame]:
         """Overridden."""
@@ -200,10 +193,10 @@ class LoggerApp(qiwis.BaseApp):
               It should be one of "DEBUG", "INFO", "WARNING", "ERROR" and "CRITICAL".
               It should be case-sensitive and any other input is ignored.
         """
-        if levelText in self.levels:
-            self.frameHandler.setLevel(self.levels[levelText])
+        if levelText in self.levels_dict.values():
+            self.frameHandler.setLevel(levelText)
             if self.frameHandler.level < self.fileHandler.level:
-                logging.getLogger().setLevel(self.levels[levelText])
+                logging.getLogger().setLevel(levelText)
             else:
                 logging.getLogger().setLevel(self.levels_dict[self.fileHandler.level])
 
@@ -216,10 +209,10 @@ class LoggerApp(qiwis.BaseApp):
               It should be one of "DEBUG", "INFO", "WARNING", "ERROR" and "CRITICAL".
               It should be case-sensitive and any other input is ignored.
         """
-        if levelText in self.levels:
-            self.fileHandler.setLevel(self.levels[levelText])
+        if levelText in self.levels_dict.values():
+            self.fileHandler.setLevel(levelText)
             if self.fileHandler.level < self.frameHandler.level:
-                logging.getLogger().setLevel(self.levels[levelText])
+                logging.getLogger().setLevel(levelText)
             else:
                 logging.getLogger().setLevel(self.levels_dict[self.frameHandler.level])
 

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -4,6 +4,7 @@ import logging
 from logging import handlers
 from typing import Any, Optional, Tuple, Callable
 from functools import partial
+import os
 
 from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal, QDateTime
 from PyQt5.QtWidgets import (
@@ -141,8 +142,13 @@ class LoggerApp(qiwis.BaseApp):
         fileHandler: A handler for saving logs to file.
     """
 
-    def __init__(self, name: str = "logger", path: str = "logs", parent: Optional[QObject] = None):
-        """Extended."""
+    def __init__(self, name: str, path: str, parent: Optional[QObject] = None):
+        """Extended.
+        
+        Args:
+            name: Specifies name of the LoggerApp.
+            path: Desribes file directory of log record file.
+        """
         super().__init__(name, parent=parent)
         self.loggerFrame = LoggerFrame()
         self.confirmFrame = ConfirmClearingFrame()
@@ -153,7 +159,7 @@ class LoggerApp(qiwis.BaseApp):
         self.levelsDict = {logging.DEBUG: "DEBUG", logging.INFO: "INFO", logging.WARNING: "WARNING",
                            logging.ERROR: "ERROR", logging.CRITICAL: "CRITICAL"}
         self.frameHandler = LoggingHandler(self.addLog)
-        logFileName = path + QDateTime.currentDateTime().toString("yyMMdd-HHmmss")
+        logFileName = os.path.join(path, QDateTime.currentDateTime().toString("logyyMMdd-HHmmss"))
         self.fileHandler = handlers.TimedRotatingFileHandler(filename=logFileName, when="midnight",
                                                              interval=1, encoding="utf-8")
         self.initLogger()
@@ -170,7 +176,7 @@ class LoggerApp(qiwis.BaseApp):
 
     def initLogger(self):
         """Initializes the root logger and handlers for constructor."""
-        self.fileHandler.suffix = '-(%Y%m%d)'
+        self.fileHandler.suffix = "(%Y%m%d)"
         shortFormat = "[%(name)s] %(message)s"
         longFormat = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] %(message)s"
         self.frameHandler.setFormatter(logging.Formatter(shortFormat))
@@ -180,8 +186,7 @@ class LoggerApp(qiwis.BaseApp):
         rootLogger.addHandler(self.frameHandler)
         rootLogger.addHandler(self.fileHandler)
         self.frameHandler.setLevel("WARNING")
-        self.fileHandler.setLevel("WARNING")
-        rootLogger.setLevel("WARNING")
+        self.setLevel(self.fileHandler, "WARNING")
 
     def frames(self) -> Tuple[LoggerFrame]:
         """Overridden."""

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -175,7 +175,7 @@ class LoggerApp(qiwis.BaseApp):
         self.levelsDict = {logging.DEBUG: "DEBUG", logging.INFO: "INFO", logging.WARNING: "WARNING",
                            logging.ERROR: "ERROR", logging.CRITICAL: "CRITICAL"}
         self.frameHandler = LoggingHandler(self.addLog)
-        logFileName = os.path.join(path, 
+        logFileName = os.path.join(path,
                                    QDateTime.currentDateTime().toString("log_yyMMdd-HHmmss"))
         self.fileHandler = handlers.TimedRotatingFileHandler(filename=logFileName, when="midnight",
                                                              interval=1, encoding="utf-8")

--- a/setup.json
+++ b/setup.json
@@ -10,7 +10,10 @@
             "module": "iquip.apps.logger",
             "cls": "LoggerApp",
             "show": true,
-            "pos": "bottom"
+            "pos": "bottom",
+            "args": {
+                "path": ""
+            }
         }
     }
 }

--- a/setup.json
+++ b/setup.json
@@ -12,7 +12,7 @@
             "show": true,
             "pos": "bottom",
             "args": {
-                "path": ""
+                "logFilePath": ""
             }
         }
     }

--- a/setup.json
+++ b/setup.json
@@ -14,6 +14,12 @@
             "args": {
                 "logFilePath": ""
             }
+        },
+        "scheduler": {
+            "module": "iquip.apps.scheduler",
+            "cls": "SchedulerApp",
+            "show": true,
+            "pos": "bottom"
         }
     }
 }


### PR DESCRIPTION
### Added feature for saving logs to file.

This is same PR as [previous](https://github.com/snu-quiqcl/iquip/pull/84). @BECATRUE leaved some comments on it.

This PR closes https://github.com/snu-quiqcl/iquip/issues/76
Below are images of current loggerFrame and saved log format.

All logs are first saved at temp file by using file handler. I first think that level for fileHandler should be different for frameHandler. But since user chooses desired level, we can just save that level of logs to file.

When user presses Save log to file button, contents at temp file saved to log record file and temp file is cleared.
When user presses Clear log file button, only log record file cleared.

The time format of logs in loggerFrame and file is different because we specify format for loggerFrame but use %asctime of format in fileHandler.

All the details can be changed.

![image](https://github.com/snu-quiqcl/iquip/assets/43592775/d63cf02c-1806-421d-8b1f-12ce0b6c1dbc)
![image](https://github.com/snu-quiqcl/iquip/assets/43592775/1ad8b5ac-298f-4aa1-9cf7-95669e1a6f8c)
