### PR TITLE
Unit test for scheduler

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -75,7 +75,7 @@ class SchedulerAppTest(unittest.TestCase):
             for info in data:
                 app.addExperiment(info)
                 mocked_queue.append.assert_called_with(info)
-                assert mocked_queue.sort.called
+            self.assertEqual(mocked_queue.sort.call_count, len(data))
 
     def test_run_experiment(self):
         app = scheduler.SchedulerApp(name="name")
@@ -96,8 +96,8 @@ class SchedulerFunctionalTest(unittest.TestCase):
 
     def test_add_experiment(self):
         app = scheduler.SchedulerApp(name="name", parent=QObject())
-        priorities = [1, 9, 3, 8, 7, 4, 2, 6, 5, 0] # "priority" value for each experiment
-        sorted_indices = [1, 3, 4, 7, 8, 5, 2, 6, 0, 9] # experiment number when sorted
+        priorities = [1, 9, 3, 8, 7, 4, 2, 6, 5, 0]
+        sorted_indices = [1, 3, 4, 7, 8, 5, 2, 6, 0, 9]
         data = [
             ExperimentInfo(str(i), {"rid": i, "priority": priorities[i]}) for i in range(10)
         ]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -19,16 +19,16 @@ class ExperimentModelTest(unittest.TestCase):
         del self.qapp
 
     def test_row_count(self):
-        data1 = (ExperimentInfo(str(i), {"rid": i, "priority": i}) for i in range(10))
-        data2 = (ExperimentInfo(str(i), {"rid": i, "priority": 0}) for i in range(10))
+        data1 = (ExperimentInfo(str(i), {"rid": i, "priority": i}) for i in range(10),)
+        data2 = (ExperimentInfo(str(i), {"rid": i, "priority": 0}) for i in range(10),)
         for data in (data1, data2):
             model = scheduler.ExperimentModel()
             model.experimentQueue.extend(data)
             self.assertEqual(model.rowCount(), len(data))
 
     def test_data(self):
-        data1 = (ExperimentInfo(str(i), {"rid": i, "priority": i}) for i in range(10))
-        data2 = (ExperimentInfo(str(i), {"rid": i, "priority": 0}) for i in range(10))
+        data1 = (ExperimentInfo(str(i), {"rid": i, "priority": i}) for i in range(10),)
+        data2 = (ExperimentInfo(str(i), {"rid": i, "priority": 0}) for i in range(10),)
         for data in (data1, data2):
             model = scheduler.ExperimentModel()
             model.experimentQueue.extend(data)
@@ -71,7 +71,7 @@ class SchedulerAppTest(unittest.TestCase):
     def test_add_experiment(self):
         app = scheduler.SchedulerApp(name="name")
         with mock.patch.object(app.schedulerFrame.model, "experimentQueue") as mocked_queue:
-            data = (ExperimentInfo(str(i), {"rid": i, "priority": 10 - i}) for i in range(10))
+            data = (ExperimentInfo(str(i), {"rid": i, "priority": 10 - i}) for i in range(10),)
             for info in data:
                 app.addExperiment(info)
                 mocked_queue.append.assert_called_with(info)
@@ -99,7 +99,7 @@ class SchedulerFunctionalTest(unittest.TestCase):
         priorities = [1, 9, 3, 8, 7, 4, 2, 6, 5, 0]
         sorted_indices = [1, 3, 4, 7, 8, 5, 2, 6, 0, 9]
         data = (
-            ExperimentInfo(str(i), {"rid": i, "priority": priorities[i]}) for i in range(10)
+            ExperimentInfo(str(i), {"rid": i, "priority": priorities[i]}) for i in range(10),
         )
         for info in data:
             app.addExperiment(info)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -19,16 +19,16 @@ class ExperimentModelTest(unittest.TestCase):
         del self.qapp
 
     def test_row_count(self):
-        data1 = (ExperimentInfo(str(i), {"rid": i, "priority": i}) for i in range(10),)
-        data2 = (ExperimentInfo(str(i), {"rid": i, "priority": 0}) for i in range(10),)
+        data1 = tuple(ExperimentInfo(str(i), {"rid": i, "priority": i}) for i in range(10))
+        data2 = tuple(ExperimentInfo(str(i), {"rid": i, "priority": 0}) for i in range(10))
         for data in (data1, data2):
             model = scheduler.ExperimentModel()
             model.experimentQueue.extend(data)
             self.assertEqual(model.rowCount(), len(data))
 
     def test_data(self):
-        data1 = (ExperimentInfo(str(i), {"rid": i, "priority": i}) for i in range(10),)
-        data2 = (ExperimentInfo(str(i), {"rid": i, "priority": 0}) for i in range(10),)
+        data1 = tuple(ExperimentInfo(str(i), {"rid": i, "priority": i}) for i in range(10))
+        data2 = tuple(ExperimentInfo(str(i), {"rid": i, "priority": 0}) for i in range(10))
         for data in (data1, data2):
             model = scheduler.ExperimentModel()
             model.experimentQueue.extend(data)
@@ -50,13 +50,13 @@ class ExperimentModelTest(unittest.TestCase):
         mime2 = QMimeData()
         mime2.setText("2")
         model.dropMimeData(mime0, Qt.MoveAction, 0, 0, model.index(0)) # exp1 above exp1
-        self.assertEqual(model.experimentQueue, data)
+        self.assertEqual(model.experimentQueue, list(data))
         model.dropMimeData(mime0, Qt.MoveAction, 2, 0, model.index(0)) # exp1 above exp3
-        self.assertEqual(model.experimentQueue, data)
+        self.assertEqual(model.experimentQueue, list(data))
         model.dropMimeData(mime1, Qt.MoveAction, 3, 0, model.index(0)) # exp2 below exp3
         self.assertEqual(model.experimentQueue, [data[0], data[2], data[1]])
         model.dropMimeData(mime2, Qt.MoveAction, 1, 0, model.index(0)) # exp2 above exp3
-        self.assertEqual(model.experimentQueue, data)
+        self.assertEqual(model.experimentQueue, list(data))
 
 
 class SchedulerAppTest(unittest.TestCase):
@@ -71,7 +71,7 @@ class SchedulerAppTest(unittest.TestCase):
     def test_add_experiment(self):
         app = scheduler.SchedulerApp(name="name")
         with mock.patch.object(app.schedulerFrame.model, "experimentQueue") as mocked_queue:
-            data = (ExperimentInfo(str(i), {"rid": i, "priority": 10 - i}) for i in range(10),)
+            data = tuple(ExperimentInfo(str(i), {"rid": i, "priority": 10 - i}) for i in range(10))
             for info in data:
                 app.addExperiment(info)
                 mocked_queue.append.assert_called_with(info)
@@ -98,8 +98,8 @@ class SchedulerFunctionalTest(unittest.TestCase):
         app = scheduler.SchedulerApp(name="name", parent=QObject())
         priorities = [1, 9, 3, 8, 7, 4, 2, 6, 5, 0]
         sorted_indices = [1, 3, 4, 7, 8, 5, 2, 6, 0, 9]
-        data = (
-            ExperimentInfo(str(i), {"rid": i, "priority": priorities[i]}) for i in range(10),
+        data = tuple(
+            ExperimentInfo(str(i), {"rid": i, "priority": priorities[i]}) for i in range(10)
         )
         for info in data:
             app.addExperiment(info)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,4 +1,4 @@
-"""Unit tests for monitor module."""
+"""Unit tests for scheduler module."""
 
 import unittest
 
@@ -6,9 +6,9 @@ from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import Qt, QObject,  QMimeData
 
 from iquip.apps import scheduler
-from iquip.protocols import ExperimentInfo as ExpInfo
+from iquip.protocols import ExperimentInfo
 
-class TestExperimentModel(unittest.TestCase):
+class ExperimentModelTest(unittest.TestCase):
     """Unit tests for ExperimentModel class."""
 
     def setUp(self):
@@ -20,10 +20,10 @@ class TestExperimentModel(unittest.TestCase):
     def test_model_index(self):
         data1 = []
         for i in range(10):
-            data1.append(ExpInfo("exp" + str(i), {"rid": i, "priority": i}))
+            data1.append(ExperimentInfo(str(i), {"rid": i, "priority": i}))
         data2 = []
         for i in range(100):
-            data1.append(ExpInfo("exp" + str(i), {"rid": i, "priority": 0}))
+            data1.append(ExperimentInfo(str(i), {"rid": i, "priority": 0}))
         for data in (data1, data2):
             mdl = scheduler.ExperimentModel()
             mdl.experimentQueue.extend(data)
@@ -33,9 +33,9 @@ class TestExperimentModel(unittest.TestCase):
 
     def test_drag_and_drop(self):
         mdl = scheduler.ExperimentModel()
-        data = [ExpInfo("exp1", {"rid": 1, "priority": 2}),
-                ExpInfo("exp2", {"rid": 2, "priority": 1}),
-                ExpInfo("exp3", {"rid": 3, "priority": 1})
+        data = [ExperimentInfo("1", {"rid": 1, "priority": 2}),
+                ExperimentInfo("2", {"rid": 2, "priority": 1}),
+                ExperimentInfo("3", {"rid": 3, "priority": 1})
                ]
         mdl.experimentQueue.extend(data)
         mime0 = QMimeData()
@@ -54,8 +54,8 @@ class TestExperimentModel(unittest.TestCase):
         self.assertEqual(mdl.experimentQueue, data)
 
 
-class TestSchedulerApp(unittest.TestCase):
-    """Unit tests for SchedulerApp class."""
+class SchedulerAppTest(unittest.TestCase):
+    """Functional tests for SchedulerApp class."""
 
     def setUp(self):
         self.qapp = QApplication([])
@@ -65,24 +65,24 @@ class TestSchedulerApp(unittest.TestCase):
 
     def test_add_experiment(self):
         app = scheduler.SchedulerApp(name="name", parent=QObject())
-        data = [ExpInfo("exp" + str(i), {"rid": i, "priority": 10-i}) for i in range(10)]
+        data = [ExperimentInfo(str(i), {"rid": i, "priority": 10 - i}) for i in range(10)]
         for info in data:
-            app.addExperiment(info=info)
+            app.addExperiment(info)
         self.assertEqual(app.schedulerFrame.model.experimentQueue, data)
         app.schedulerFrame.model.experimentQueue = []
         permutation = [1, 9, 3, 8, 7, 4, 2, 6, 5, 0]
         inv_permutation = [1, 3, 4, 7, 8, 5, 2, 6, 0, 9]
-        data = [ExpInfo("exp" + str(i), {"rid": i, "priority": permutation[i]}
+        data = [ExperimentInfo(str(i), {"rid": i, "priority": permutation[i]}
                        ) for i in range(10)]
         for info in data:
-            app.addExperiment(info=info)
+            app.addExperiment(info)
         self.assertEqual(app.schedulerFrame.model.experimentQueue,
                          [data[inv_permutation[i]] for i in range(10)])
 
     def test_run_experiment(self):
         app = scheduler.SchedulerApp(name="name", parent=QObject())
-        experiment_run = ExpInfo("exp1", {"rid": 1, "priority": 1})
-        experiment_queue = ExpInfo("exp2", {"rid": 2, "priority": 2})
+        experiment_run = ExperimentInfo("1", {"rid": 1, "priority": 1})
+        experiment_queue = ExperimentInfo("2", {"rid": 2, "priority": 2})
         app.schedulerFrame.model.experimentQueue.append(experiment_run)
         app.schedulerFrame.model.experimentQueue.append(experiment_queue)
         app.runExperiment(experiment_run)
@@ -93,9 +93,9 @@ class TestSchedulerApp(unittest.TestCase):
 
     def test_modify_experiment(self):
         app = scheduler.SchedulerApp(name="name", parent=QObject())
-        experiment_change = ExpInfo("exp1", {"rid": 1, "priority": 1})
-        experiment_new_info = ExpInfo("exp1", {"rid": 1, "priority": 2})
-        experiment_delete = ExpInfo("exp2", {"rid": 2, "priority": 1})
+        experiment_change = ExperimentInfo("1", {"rid": 1, "priority": 1})
+        experiment_new_info = ExperimentInfo("1", {"rid": 1, "priority": 2})
+        experiment_delete = ExperimentInfo("2", {"rid": 2, "priority": 1})
         app.schedulerFrame.model.experimentQueue.append(experiment_delete)
         app.schedulerFrame.model.experimentQueue.append(experiment_change)
         app.changeExperiment(1, experiment_new_info)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4,7 +4,7 @@ import unittest
 from unittest import mock
 
 from PyQt5.QtWidgets import QApplication
-from PyQt5.QtCore import Qt, QObject,  QMimeData, QAbstractListModel
+from PyQt5.QtCore import Qt, QObject,  QMimeData
 
 from iquip.apps import scheduler
 from iquip.protocols import ExperimentInfo
@@ -75,8 +75,8 @@ class SchedulerAppTest(unittest.TestCase):
     def test_run_experiment(self):
         app = scheduler.SchedulerApp(name="name")
         with mock.patch.object(app.schedulerFrame, "runningView") as mockedView:
-            experiment_run = ExperimentInfo("1", {"rid": 1, "priority": 1})
-            app.runExperiment(experiment_run)
+            info = ExperimentInfo("1", {"rid": 1, "priority": 1})
+            app.runExperiment(info)
             mockedView.updateInfo.assert_called_with(info)
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -21,24 +21,24 @@ class TestExperimentModel(unittest.TestCase):
     def test_model_index(self):
         data1 = []
         for i in range(10):
-            data1.append(ExpView(ExpInfo("exp" + str(i), {"rid": i, "priority": i})))
+            data1.append(ExpInfo("exp" + str(i), {"rid": i, "priority": i}))
         data2 = []
         for i in range(100):
-            data1.append(ExpView(ExpInfo("exp" + str(i), {"rid": i, "priority": 0})))
+            data1.append(ExpInfo("exp" + str(i), {"rid": i, "priority": 0}))
         for data in (data1, data2):
             mdl = scheduler.ExperimentModel()
-            mdl.experimentData.extend(data)
+            mdl.experimentQueue.extend(data)
             self.assertEqual(mdl.rowCount(), len(data))
             for i, exp in enumerate(data):
                 self.assertEqual(mdl.data(mdl.index(i)), exp)
 
     def test_drag_and_drop(self):
         mdl = scheduler.ExperimentModel()
-        data = [ExpView(ExpInfo("exp1", {"rid": 1, "priority": 2})),
-                ExpView(ExpInfo("exp2", {"rid": 2, "priority": 1})),
-                ExpView(ExpInfo("exp3", {"rid": 3, "priority": 1}))
+        data = [ExpInfo("exp1", {"rid": 1, "priority": 2}),
+                ExpInfo("exp2", {"rid": 2, "priority": 1}),
+                ExpInfo("exp3", {"rid": 3, "priority": 1})
                ]
-        mdl.experimentData.extend(data)
+        mdl.experimentQueue.extend(data)
         mime0 = QMimeData()
         mime0.setText("0")
         mime1 = QMimeData()
@@ -46,13 +46,13 @@ class TestExperimentModel(unittest.TestCase):
         mime2 = QMimeData()
         mime2.setText("2")
         mdl.dropMimeData(mime0, Qt.MoveAction, 0, 0, mdl.index(0)) # exp1 above exp1
-        self.assertEqual(mdl.experimentData, data)
+        self.assertEqual(mdl.experimentQueue, data)
         mdl.dropMimeData(mime0, Qt.MoveAction, 2, 0, mdl.index(0)) # exp1 above exp3
-        self.assertEqual(mdl.experimentData, data)
+        self.assertEqual(mdl.experimentQueue, data)
         mdl.dropMimeData(mime1, Qt.MoveAction, 3, 0, mdl.index(0)) # exp2 below exp3
-        self.assertEqual(mdl.experimentData, [data[0], data[2], data[1]])
+        self.assertEqual(mdl.experimentQueue, [data[0], data[2], data[1]])
         mdl.dropMimeData(mime2, Qt.MoveAction, 1, 0, mdl.index(0)) # exp2 above exp3
-        self.assertEqual(mdl.experimentData, data)
+        self.assertEqual(mdl.experimentQueue, data)
 
 class TestSchedulerApp(unittest.TestCase):
     """Unit tests for SchedulerApp class."""
@@ -65,45 +65,44 @@ class TestSchedulerApp(unittest.TestCase):
 
     def test_add_experiment(self):
         app = scheduler.SchedulerApp(name="name", parent=QObject())
-        data = [ExpView(ExpInfo("exp" + str(i),
-                                {"rid": i, "priority": 10-i})) for i in range(10)]
-        for exp in data:
-            app.addExperiment(exp=exp)
-        self.assertEqual(app.schedulerFrame.model.experimentData, data)
-        app.schedulerFrame.model.experimentData = []
+        data = [ExpInfo("exp" + str(i), {"rid": i, "priority": 10-i}) for i in range(10)]
+        for info in data:
+            app.addExperiment(info=info)
+        self.assertEqual(app.schedulerFrame.model.experimentQueue, data)
+        app.schedulerFrame.model.experimentQueue = []
         permutation = [1, 9, 3, 8, 7, 4, 2, 6, 5, 0]
         inv_permutation = [1, 3, 4, 7, 8, 5, 2, 6, 0, 9]
-        data = [ExpView(ExpInfo("exp" + str(i), {"rid": i, "priority": permutation[i]}
-                               )) for i in range(10)]
-        for exp in data:
-            app.addExperiment(exp=exp)
-        self.assertEqual(app.schedulerFrame.model.experimentData,
+        data = [ExpInfo("exp" + str(i), {"rid": i, "priority": permutation[i]}
+                       ) for i in range(10)]
+        for info in data:
+            app.addExperiment(info=info)
+        self.assertEqual(app.schedulerFrame.model.experimentQueue,
                          [data[inv_permutation[i]] for i in range(10)])
 
     def test_run_experiment(self):
         app = scheduler.SchedulerApp(name="name", parent=QObject())
-        experiment_run = ExpView(ExpInfo("exp1", {"rid": 1, "priority": 1}))
-        experiment_queue = ExpView(ExpInfo("exp2", {"rid": 2, "priority": 2}))
-        app.schedulerFrame.model.experimentData.append(experiment_run)
-        app.schedulerFrame.model.experimentData.append(experiment_queue)
+        experiment_run = ExpInfo("exp1", {"rid": 1, "priority": 1})
+        experiment_queue = ExpInfo("exp2", {"rid": 2, "priority": 2})
+        app.schedulerFrame.model.experimentQueue.append(experiment_run)
+        app.schedulerFrame.model.experimentQueue.append(experiment_queue)
         app.runExperiment(experiment_run)
-        self.assertEqual(app.schedulerFrame.model.experimentData, [experiment_queue])
-        self.assertEqual(app.schedulerFrame.runningView, experiment_run)
+        self.assertEqual(app.schedulerFrame.model.experimentQueue, [experiment_queue])
+        self.assertEqual(app.schedulerFrame.runningView.experimentInfo, experiment_run)
         app.runExperiment(None)
         self.assertEqual(app.schedulerFrame.runningView.experimentInfo, None)
 
     def test_modify_experiment(self):
         app = scheduler.SchedulerApp(name="name", parent=QObject())
-        experiment_change = ExpView(ExpInfo("exp1", {"rid": 1, "priority": 1}))
+        experiment_change = ExpInfo("exp1", {"rid": 1, "priority": 1})
         experiment_new_info = ExpInfo("exp1", {"rid": 1, "priority": 2})
-        experiment_delete = ExpView(ExpInfo("exp2", {"rid": 2, "priority": 1}))
-        app.schedulerFrame.model.experimentData.append(experiment_change)
-        app.schedulerFrame.model.experimentData.append(experiment_delete)
+        experiment_delete = ExpInfo("exp2", {"rid": 2, "priority": 1})
+        app.schedulerFrame.model.experimentQueue.append(experiment_delete)
+        app.schedulerFrame.model.experimentQueue.append(experiment_change)
         app.changeExperiment(1, experiment_new_info)
-        self.assertEqual(app.schedulerFrame.model.experimentData[0].priority(), 2)
-        self.assertEqual(app.schedulerFrame.model.experimentData[1], experiment_delete)
+        self.assertEqual(app.schedulerFrame.model.experimentQueue[0].arginfo["priority"], 2)
+        self.assertEqual(app.schedulerFrame.model.experimentQueue[1].arginfo["rid"], 2)
         app.changeExperiment(1, None)
-        self.assertEqual(app.schedulerFrame.model.experimentData[0], experiment_change)
+        self.assertEqual(app.schedulerFrame.model.experimentQueue[0].arginfo["rid"], 1)
         self.assertEqual(app.schedulerFrame.model.rowCount(), 1)
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -96,20 +96,15 @@ class SchedulerFunctionalTest(unittest.TestCase):
 
     def test_add_experiment(self):
         app = scheduler.SchedulerApp(name="name", parent=QObject())
-        data = [ExperimentInfo(str(i), {"rid": i, "priority": 10 - i}) for i in range(10)]
-        for info in data:
-            app.addExperiment(info)
-        self.assertEqual(app.schedulerFrame.model.experimentQueue, data)
-        app.schedulerFrame.model.experimentQueue = []
-        permutation = [1, 9, 3, 8, 7, 4, 2, 6, 5, 0] # "priority" value for each experiment
-        inv_permutation = [1, 3, 4, 7, 8, 5, 2, 6, 0, 9] # experiment number when sorted
+        priorities = [1, 9, 3, 8, 7, 4, 2, 6, 5, 0] # "priority" value for each experiment
+        sorted_indices = [1, 3, 4, 7, 8, 5, 2, 6, 0, 9] # experiment number when sorted
         data = [
-            ExperimentInfo(str(i), {"rid": i, "priority": permutation[i]}) for i in range(10)
+            ExperimentInfo(str(i), {"rid": i, "priority": priorities[i]}) for i in range(10)
         ]
         for info in data:
             app.addExperiment(info)
         self.assertEqual(app.schedulerFrame.model.experimentQueue,
-                         [data[inv_permutation[i]] for i in range(10)])
+                         [data[sorted_indices[i]] for i in range(10)])
 
     def test_run_experiment(self):
         app = scheduler.SchedulerApp(name="name", parent=QObject())

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -6,7 +6,6 @@ from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import Qt, QObject,  QMimeData
 
 from iquip.apps import scheduler
-from iquip.apps.scheduler import ExperimentView as ExpView
 from iquip.protocols import ExperimentInfo as ExpInfo
 
 class TestExperimentModel(unittest.TestCase):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -53,6 +53,7 @@ class TestExperimentModel(unittest.TestCase):
         mdl.dropMimeData(mime2, Qt.MoveAction, 1, 0, mdl.index(0)) # exp2 above exp3
         self.assertEqual(mdl.experimentQueue, data)
 
+
 class TestSchedulerApp(unittest.TestCase):
     """Unit tests for SchedulerApp class."""
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,9 +1,10 @@
 """Unit tests for scheduler module."""
 
 import unittest
+from unittest import mock
 
 from PyQt5.QtWidgets import QApplication
-from PyQt5.QtCore import Qt, QObject,  QMimeData
+from PyQt5.QtCore import Qt, QObject,  QMimeData, QAbstractListModel
 
 from iquip.apps import scheduler
 from iquip.protocols import ExperimentInfo
@@ -55,6 +56,31 @@ class ExperimentModelTest(unittest.TestCase):
 
 
 class SchedulerAppTest(unittest.TestCase):
+    """Unit tests for SchedulerApp class."""
+
+    def setUp(self):
+        self.qapp = QApplication([])
+
+    def tearDown(self):
+        del self.qapp
+
+    def test_add_experiment(self):
+        app = scheduler.SchedulerApp(name="name")
+        with mock.patch.object(app.schedulerFrame.model, "experimentQueue") as mockedQueue:
+            data = [ExperimentInfo(str(i), {"rid": i, "priority": 10 - i}) for i in range(10)]
+            for info in data:
+                app.addExperiment(info)
+                mockedQueue.append.assert_called_with(info)
+
+    def test_run_experiment(self):
+        app = scheduler.SchedulerApp(name="name")
+        with mock.patch.object(app.schedulerFrame, "runningView") as mockedView:
+            experiment_run = ExperimentInfo("1", {"rid": 1, "priority": 1})
+            app.runExperiment(experiment_run)
+            mockedView.updateInfo.assert_called_with(info)
+
+
+class SchedulerFunctionalTest(unittest.TestCase):
     """Functional tests for SchedulerApp class."""
 
     def setUp(self):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -19,16 +19,16 @@ class ExperimentModelTest(unittest.TestCase):
         del self.qapp
 
     def test_row_count(self):
-        data1 = [ExperimentInfo(str(i), {"rid": i, "priority": i}) for i in range(10)]
-        data2 = [ExperimentInfo(str(i), {"rid": i, "priority": 0}) for i in range(10)]
+        data1 = (ExperimentInfo(str(i), {"rid": i, "priority": i}) for i in range(10))
+        data2 = (ExperimentInfo(str(i), {"rid": i, "priority": 0}) for i in range(10))
         for data in (data1, data2):
             model = scheduler.ExperimentModel()
             model.experimentQueue.extend(data)
             self.assertEqual(model.rowCount(), len(data))
 
     def test_data(self):
-        data1 = [ExperimentInfo(str(i), {"rid": i, "priority": i}) for i in range(10)]
-        data2 = [ExperimentInfo(str(i), {"rid": i, "priority": 0}) for i in range(10)]
+        data1 = (ExperimentInfo(str(i), {"rid": i, "priority": i}) for i in range(10))
+        data2 = (ExperimentInfo(str(i), {"rid": i, "priority": 0}) for i in range(10))
         for data in (data1, data2):
             model = scheduler.ExperimentModel()
             model.experimentQueue.extend(data)
@@ -37,11 +37,11 @@ class ExperimentModelTest(unittest.TestCase):
 
     def test_drop_mime_data(self):
         model = scheduler.ExperimentModel()
-        data = [
+        data = (
             ExperimentInfo("1", {"rid": 1, "priority": 2}),
             ExperimentInfo("2", {"rid": 2, "priority": 1}),
             ExperimentInfo("3", {"rid": 3, "priority": 1})
-        ]
+        )
         model.experimentQueue.extend(data)
         mime0 = QMimeData()
         mime0.setText("0")
@@ -71,7 +71,7 @@ class SchedulerAppTest(unittest.TestCase):
     def test_add_experiment(self):
         app = scheduler.SchedulerApp(name="name")
         with mock.patch.object(app.schedulerFrame.model, "experimentQueue") as mocked_queue:
-            data = [ExperimentInfo(str(i), {"rid": i, "priority": 10 - i}) for i in range(10)]
+            data = (ExperimentInfo(str(i), {"rid": i, "priority": 10 - i}) for i in range(10))
             for info in data:
                 app.addExperiment(info)
                 mocked_queue.append.assert_called_with(info)
@@ -98,9 +98,9 @@ class SchedulerFunctionalTest(unittest.TestCase):
         app = scheduler.SchedulerApp(name="name", parent=QObject())
         priorities = [1, 9, 3, 8, 7, 4, 2, 6, 5, 0]
         sorted_indices = [1, 3, 4, 7, 8, 5, 2, 6, 0, 9]
-        data = [
+        data = (
             ExperimentInfo(str(i), {"rid": i, "priority": priorities[i]}) for i in range(10)
-        ]
+        )
         for info in data:
             app.addExperiment(info)
         self.assertEqual(app.schedulerFrame.model.experimentQueue,

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,119 @@
+"""Unit tests for monitor module."""
+
+import unittest
+
+from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import Qt, QObject, QAbstractListModel, QModelIndex, QMimeData
+from PyQt5.QtTest import QTest
+
+from iquip.apps import scheduler
+from iquip.apps.scheduler import ExperimentView as ExpView
+from iquip.protocols import ExperimentInfo as ExpInfo
+
+def _dropOnto(self, widget, mime_data):
+    action = Qt.CopyAction | Qt.MoveAction
+    pt = widget.rect().center()
+    drag_drop = QDropEvent(pt, action, mime_data, Qt.LeftButton, Qt.NoModifier)
+    drag_drop.acceptProposedAction()
+    widget.dropEvent(drag_drop)
+
+class TestExperimentModel(unittest.TestCase):
+    """Unit tests for ExperimentModel class."""
+
+    def setUp(self):
+        self.qapp = QApplication([])
+
+    def tearDown(self):
+        del self.qapp
+
+    def test_model_index(self):
+        data1 = []
+        for i in range(10):
+            data1.append(ExpView(ExpInfo("exp" + str(i), {"rid": i, "priority": i})))
+        data2 = []
+        for i in range(100):
+            data1.append(ExpView(ExpInfo("exp" + str(i), {"rid": i, "priority": 0})))
+        for data in (data1, data2):
+            mdl = scheduler.ExperimentModel()
+            mdl.experimentData.extend(data)
+            self.assertEqual(mdl.rowCount(), len(data))
+            for i, exp in enumerate(data):
+                self.assertEqual(mdl.data(mdl.index(i)), exp)
+
+    def test_drag_and_drop(self):
+        mdl = scheduler.ExperimentModel()
+        data = [ExpView(ExpInfo("exp1", {"rid": 1, "priority": 2})),
+                ExpView(ExpInfo("exp2", {"rid": 2, "priority": 1})),
+                ExpView(ExpInfo("exp3", {"rid": 3, "priority": 1}))
+               ]
+        mdl.experimentData.extend(data)
+        mime0 = QMimeData()
+        mime0.setText("0")
+        mime1 = QMimeData()
+        mime1.setText("1")
+        mime2 = QMimeData()
+        mime2.setText("2")
+        mdl.dropMimeData(mime0, Qt.MoveAction, 0, 0, mdl.index(0)) # exp1 above exp1
+        self.assertEqual(mdl.experimentData, data)
+        mdl.dropMimeData(mime0, Qt.MoveAction, 2, 0, mdl.index(0)) # exp1 above exp3
+        self.assertEqual(mdl.experimentData, data)
+        mdl.dropMimeData(mime1, Qt.MoveAction, 3, 0, mdl.index(0)) # exp2 below exp3
+        self.assertEqual(mdl.experimentData, [data[0], data[2], data[1]])
+        mdl.dropMimeData(mime2, Qt.MoveAction, 1, 0, mdl.index(0)) # exp2 above exp3
+        self.assertEqual(mdl.experimentData, data)
+
+class TestSchedulerApp(unittest.TestCase):
+    """Unit tests for SchedulerApp class."""
+
+    def setUp(self):
+        self.qapp = QApplication([])
+
+    def tearDown(self):
+        del self.qapp
+
+    def test_add_experiment(self):
+        app = scheduler.SchedulerApp(name="name", parent=QObject())
+        data = [ExpView(ExpInfo("exp" + str(i), 
+                                {"rid": i, "priority": 10-i})) for i in range(10)]
+        for exp in data:
+            app.addExperiment(exp=exp)
+        self.assertEqual(app.schedulerFrame.model.experimentData, data)
+        app.schedulerFrame.model.experimentData = []
+        permutation = [1, 9, 3, 8, 7, 4, 2, 6, 5, 0]
+        inv_permutation = [1, 3, 4, 7, 8, 5, 2, 6, 0, 9]
+        data = [ExpView(ExpInfo("exp" + str(i), {"rid": i, "priority": permutation[i]}
+                               )) for i in range(10)]
+        for exp in data:
+            app.addExperiment(exp=exp)
+        self.assertEqual(app.schedulerFrame.model.experimentData,
+                         [data[inv_permutation[i]] for i in range(10)])
+
+    def test_run_experiment(self):
+        app = scheduler.SchedulerApp(name="name", parent=QObject())
+        experiment_run = ExpView(ExpInfo("exp1", {"rid": 1, "priority": 1}))
+        experiment_queue = ExpView(ExpInfo("exp2", {"rid": 2, "priority": 2}))
+        app.schedulerFrame.model.experimentData.append(experiment_run)
+        app.schedulerFrame.model.experimentData.append(experiment_queue)
+        app.runExperiment(experiment_run)
+        self.assertEqual(app.schedulerFrame.model.experimentData, [experiment_queue])
+        self.assertEqual(app.schedulerFrame.runningView, experiment_run)
+        app.runExperiment(None)
+        self.assertEqual(app.schedulerFrame.runningView.experimentInfo, None)
+
+    def test_modify_experiment(self):
+        app = scheduler.SchedulerApp(name="name", parent=QObject())
+        experiment_change = ExpView(ExpInfo("exp1", {"rid": 1, "priority": 1}))
+        experiment_new_info = ExpInfo("exp1", {"rid": 1, "priority": 2})
+        experiment_delete = ExpView(ExpInfo("exp2", {"rid": 2, "priority": 1}))
+        app.schedulerFrame.model.experimentData.append(experiment_change)
+        app.schedulerFrame.model.experimentData.append(experiment_delete)
+        app.changeExperiment(1, experiment_new_info)
+        self.assertEqual(app.schedulerFrame.model.experimentData[0].priority(), 2)
+        self.assertEqual(app.schedulerFrame.model.experimentData[1], experiment_delete)
+        app.changeExperiment(1, None)
+        self.assertEqual(app.schedulerFrame.model.experimentData[0], experiment_change)
+        self.assertEqual(app.schedulerFrame.model.rowCount(), 1)
+        
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3,19 +3,11 @@
 import unittest
 
 from PyQt5.QtWidgets import QApplication
-from PyQt5.QtCore import Qt, QObject, QAbstractListModel, QModelIndex, QMimeData
-from PyQt5.QtTest import QTest
+from PyQt5.QtCore import Qt, QObject,  QMimeData
 
 from iquip.apps import scheduler
 from iquip.apps.scheduler import ExperimentView as ExpView
 from iquip.protocols import ExperimentInfo as ExpInfo
-
-def _dropOnto(self, widget, mime_data):
-    action = Qt.CopyAction | Qt.MoveAction
-    pt = widget.rect().center()
-    drag_drop = QDropEvent(pt, action, mime_data, Qt.LeftButton, Qt.NoModifier)
-    drag_drop.acceptProposedAction()
-    widget.dropEvent(drag_drop)
 
 class TestExperimentModel(unittest.TestCase):
     """Unit tests for ExperimentModel class."""
@@ -73,7 +65,7 @@ class TestSchedulerApp(unittest.TestCase):
 
     def test_add_experiment(self):
         app = scheduler.SchedulerApp(name="name", parent=QObject())
-        data = [ExpView(ExpInfo("exp" + str(i), 
+        data = [ExpView(ExpInfo("exp" + str(i),
                                 {"rid": i, "priority": 10-i})) for i in range(10)]
         for exp in data:
             app.addExperiment(exp=exp)
@@ -113,7 +105,7 @@ class TestSchedulerApp(unittest.TestCase):
         app.changeExperiment(1, None)
         self.assertEqual(app.schedulerFrame.model.experimentData[0], experiment_change)
         self.assertEqual(app.schedulerFrame.model.rowCount(), 1)
-        
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I made a unit test for `scheduler.py`, testing:

- the class `ExperimentModel`
  - Indexing & sorting data
  - Drag & Drop feature
- the class `TestSchedulerApp`
  - Add experiment
  - Run experiment
  - Modify (change/delete) experiment

### Problem
- The drag & drop feature is indirectly tested, by testing the function that is called internally when drag & drop occurs.
- I did not find any necessity of using `mock` as the functions do not call other functions.

### Future Works
- After implementing #72, more unit tests will be waiting for features related to `artiq-proxy`.