### PR TITLE
BUG: Click open button of explorer without selecting any item

### DIFF
--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -174,6 +174,8 @@ class ExplorerApp(qiwis.BaseApp):
         If the selected element is a directory, it will be ignored.
         """
         experimentFileItem = self.explorerFrame.fileTree.currentItem()
+        if experimentFileItem is None:
+            return
         experimentPath = self.fullPath(experimentFileItem)
         self.experimentInfoThread = ExperimentInfoThread(experimentPath, self.openBuilder, self)
         self.experimentInfoThread.start()

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -143,6 +143,16 @@ class ExplorerAppTest(unittest.TestCase):
             app
         )
 
+    @mock.patch("iquip.apps.explorer.ExperimentInfoThread")
+    def test_open_experiment_not_selected(self, mocked_experiment_info_thread_cls):
+        app = explorer.ExplorerApp(name="name", parent=QObject())
+        with mock.patch.multiple(
+            app, fullPath=mock.DEFAULT, openBuilder=mock.DEFAULT
+        ) as mocked:
+            app.openExperiment()
+        mocked["fullPath"].assert_not_called()
+        mocked_experiment_info_thread_cls.assert_not_called()
+
     def test_open_builder(self):
         app = explorer.ExplorerApp(name="name", parent=QObject())
         experimentInfo = protocols.ExperimentInfo("name", {"arg0": "value0"})


### PR DESCRIPTION
This PR will close #81.

I resolved the bug that without selecting any item, `open_experiment()` causes an error.