### PR TITLE
Handle an empty `choice`s of enumeration value

### DIFF
--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -141,7 +141,11 @@ class _EnumerationEntry(_BaseEntry):
         
         Returns the value of the comboBox.
         """
-        return self.comboBox.currentText()
+        if self.argInfo["choices"]:
+            return self.comboBox.currentText()
+        else:
+            
+            raise ValueError
 
 
 class _NumberEntry(_BaseEntry):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -541,8 +541,12 @@ class BuilderApp(qiwis.BaseApp):
         
         Once the submitButton is clicked, this is called.
         """
-        experimentArgs = self.argumentsFromListWidget(self.builderFrame.argsListWidget)
-        schedOpts = self.argumentsFromListWidget(self.builderFrame.schedOptsListWidget)
+        try:
+            experimentArgs = self.argumentsFromListWidget(self.builderFrame.argsListWidget)
+            schedOpts = self.argumentsFromListWidget(self.builderFrame.schedOptsListWidget)
+        except ValueError:
+            logger.error("The submission is rejected because of invalid arguments.")
+            return
         self.experimentSubmitThread = _ExperimentSubmitThread(
             self.experimentPath,
             experimentArgs,

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -541,8 +541,8 @@ class BuilderApp(qiwis.BaseApp):
         try:
             experimentArgs = self.argumentsFromListWidget(self.builderFrame.argsListWidget)
             schedOpts = self.argumentsFromListWidget(self.builderFrame.schedOptsListWidget)
-        except ValueError as e:
-            logger.exception("The submission is rejected because of invalid arguments: %s", e)
+        except ValueError:
+            logger.exception("The submission is rejected because of an invalid argument.")
             return
         self.experimentSubmitThread = _ExperimentSubmitThread(
             self.experimentPath,

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -1,6 +1,7 @@
 """App module for editting the build arguments and submitting the experiment."""
 
 import json
+import logging
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import requests
@@ -13,6 +14,9 @@ from PyQt5.QtWidgets import (
 import qiwis
 from iquip.protocols import ExperimentInfo
 from iquip.apps.thread import ExperimentInfoThread
+
+logger = logging.getLogger(__name__)
+
 
 def compute_scale(unit: str) -> Optional[float]:
     """Computes the scale of the given unit string based on ARTIQ units.
@@ -144,7 +148,8 @@ class _EnumerationEntry(_BaseEntry):
         if self.argInfo["choices"]:
             return self.comboBox.currentText()
         else:
-            
+            logger.error("The empty choice of %s argument "
+                         "will cause an error in the experiment.", self.name)
             raise ValueError
 
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -147,10 +147,9 @@ class _EnumerationEntry(_BaseEntry):
         """
         if self.argInfo["choices"]:
             return self.comboBox.currentText()
-        else:
-            logger.error("The empty choice of %s argument "
-                         "will cause an error in the experiment.", self.name)
-            raise ValueError
+        logger.error("The empty choice of %s argument "
+                        "will cause an error in the experiment.", self.name)
+        raise ValueError
 
 
 class _NumberEntry(_BaseEntry):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -128,13 +128,11 @@ class _EnumerationEntry(_BaseEntry):
         """Extended."""
         super().__init__(name, argInfo, parent=parent)
         choices = self.argInfo["choices"]
-        # TODO(BECATRUE): Handling an empty choices will be implemented in the issue #55.
-        if not choices:
-            pass
         # widgets
         self.comboBox = QComboBox(self)
         self.comboBox.addItems(choices)
-        self.comboBox.setCurrentText(self.argInfo.get("default", choices[0]))
+        if choices:
+            self.comboBox.setCurrentText(self.argInfo.get("default", choices[0]))
         # layout
         self.layout.addWidget(self.comboBox)
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -147,9 +147,7 @@ class _EnumerationEntry(_BaseEntry):
         """
         if self.argInfo["choices"]:
             return self.comboBox.currentText()
-        logger.error("The empty choice of %s argument "
-                        "will cause an error in the experiment.", self.name)
-        raise ValueError
+        raise ValueError(f"_EnumerationEntry {self.name} with the empty choice")
 
 
 class _NumberEntry(_BaseEntry):
@@ -543,8 +541,8 @@ class BuilderApp(qiwis.BaseApp):
         try:
             experimentArgs = self.argumentsFromListWidget(self.builderFrame.argsListWidget)
             schedOpts = self.argumentsFromListWidget(self.builderFrame.schedOptsListWidget)
-        except ValueError:
-            logger.error("The submission is rejected because of invalid arguments.")
+        except ValueError as e:
+            logger.exception("The submission is rejected because of invalid arguments: %s", e)
             return
         self.experimentSubmitThread = _ExperimentSubmitThread(
             self.experimentPath,

--- a/setup.json
+++ b/setup.json
@@ -6,6 +6,12 @@
             "show": true,
             "pos": "left"
         },
+        "logger": {
+            "module": "iquip.apps.logger",
+            "cls": "LoggerApp",
+            "show": true,
+            "pos": "bottom"
+        },
         "scheduler": {
             "module": "iquip.apps.scheduler",
             "cls": "SchedulerApp",


### PR DESCRIPTION
This PR will close #55.

To handle an empty `choice` of enumeration value, I implemented the following:
1. When an `_EnumerationEntry` has an empty `choice` and its `value()` is called, it raises a `ValueError`.
2. Once the submission button is cliced, the app obtains each value of all entries and if a `ValueError` occurs, the submission is rejected.

### Result
![image](https://github.com/snu-quiqcl/iquip/assets/76851886/9334840d-61fa-449c-b039-0c8b5e081b0a)

In this case, the `color` argument has an empty `choice` and if the submission button is clicked, several logs are printed.