### PR TITLE
fix setup.json

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -20,18 +20,6 @@
             "cls": "SchedulerApp",
             "show": true,
             "pos": "bottom"
-        },
-        "scheduler": {
-            "module": "iquip.apps.scheduler",
-            "cls": "SchedulerApp",
-            "show": true,
-            "pos": "bottom"
-        },
-        "logger": {
-            "module": "iquip.apps.logger",
-            "cls": "LoggerApp",
-            "show": true,
-            "pos": "bottom"
         }
     }
 }


### PR DESCRIPTION
Fixed duplicated codes in setup.json.

This error occured because of repeated updates in setup.json.
I first added `scheduler` info in closed PR #88.
And @giwon2004 also added `logger` info in closed PR #101.

This happened because I couldn't see `scheduler` in setup.json and @giwon2004  couldn't see `logger` in setup.json.
So we added both app again and that difference is added to the develop branch, which caused this error.

This conflict would be resolved by this PR.
This closes #107. 
