### PR TITLE
Match 3.8 Python supports

### DIFF
--- a/iquip/protocols.py
+++ b/iquip/protocols.py
@@ -37,6 +37,6 @@ class SubmittedExperimentInfo:
     expid: Dict[str, Any] = dataclasses.field(default_factory = dict)
     due_date: str = ""
 
-    def items(self) -> ItemsView[str, Any]:
+    def items(self) -> Any:
         """Returns the attributes of the experiment."""
         return self.__dict__.items()

--- a/iquip/protocols.py
+++ b/iquip/protocols.py
@@ -1,7 +1,7 @@
 """Protocol module for defining common forms."""
 
 import dataclasses
-from typing import Any, Dict, ItemsView
+from typing import Any, Dict
 
 @dataclasses.dataclass
 class ExperimentInfo:


### PR DESCRIPTION
This is a simple PR that changes the type of return value of `SubmittedExperimentInfo.items()` to `Any` from `ItemsView[str, Any]`. This is for Python 3.8.

This closes #109.