### PR TITLE
Update unittest for logger.py

### DIFF
--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -175,6 +175,7 @@ class LoggerApp(qiwis.BaseApp):
         fileLevelBox.setCurrentText(self.levelsDict[self.fileHandler.level])
 
     def removeHandler(self):
+        """Closes opened file and removes handler of a root logger."""
         self.fileHandler.close()
         rootLogger = logging.getLogger()
         rootLogger.removeHandler(self.frameHandler)

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -174,13 +174,6 @@ class LoggerApp(qiwis.BaseApp):
         fileLevelBox.currentTextChanged.connect(functools.partial(self.setLevel, self.fileHandler))
         fileLevelBox.setCurrentText(self.levelsDict[self.fileHandler.level])
 
-    def removeHandler(self):
-        """Closes opened file and removes handler of a root logger."""
-        self.fileHandler.close()
-        rootLogger = logging.getLogger()
-        rootLogger.removeHandler(self.frameHandler)
-        rootLogger.removeHandler(self.fileHandler)
-
     def initLogger(self):
         """Initializes the root logger and handlers."""
         def namer(name):

--- a/iquip/apps/logger.py
+++ b/iquip/apps/logger.py
@@ -174,6 +174,12 @@ class LoggerApp(qiwis.BaseApp):
         fileLevelBox.currentTextChanged.connect(functools.partial(self.setLevel, self.fileHandler))
         fileLevelBox.setCurrentText(self.levelsDict[self.fileHandler.level])
 
+    def removeHandler(self):
+        self.fileHandler.close()
+        rootLogger = logging.getLogger()
+        rootLogger.removeHandler(self.frameHandler)
+        rootLogger.removeHandler(self.fileHandler)
+
     def initLogger(self):
         """Initializes the root logger and handlers."""
         def namer(name):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -21,7 +21,7 @@ class LoggingHandlerTest(unittest.TestCase):
         self.app = logger.LoggerApp(name="name", logFilePath=self.log_dir, parent=QObject())
 
     def tearDown(self):
-        self.app.removeHandler()
+        self.app.fileHandler.close()
         file_list = os.listdir(self.log_dir)
         for file in file_list:
             os.remove(os.path.join(self.log_dir, file))
@@ -47,7 +47,7 @@ class ConfirmClearingFrameTest(unittest.TestCase):
         self.app = logger.LoggerApp(name="name", logFilePath=self.log_dir, parent=QObject())
 
     def tearDown(self):
-        self.app.removeHandler()
+        self.app.fileHandler.close()
         file_list = os.listdir(self.log_dir)
         for file in file_list:
             os.remove(os.path.join(self.log_dir, file))
@@ -76,7 +76,7 @@ class LoggerAppTest(unittest.TestCase):
         self.app = logger.LoggerApp(name="name", logFilePath=self.log_dir, parent=QObject())
 
     def tearDown(self):
-        self.app.removeHandler()
+        self.app.fileHandler.close()
         file_list = os.listdir(self.log_dir)
         for file in file_list:
             os.remove(os.path.join(self.log_dir, file))
@@ -124,7 +124,7 @@ class LoggerAppTest(unittest.TestCase):
             app = logger.LoggerApp(name="name", logFilePath=self.log_dir, parent=QObject())
             app.loggerFrame.clearButton.clicked.emit()
             mocked_method.assert_called_once()
-            app.removeHandler()
+            app.fileHandler.close()
 
     def test_check_to_clear(self):
         with mock.patch("iquip.apps.logger.QWidget.show") as mocked_show:
@@ -136,7 +136,7 @@ class LoggerAppTest(unittest.TestCase):
             app = logger.LoggerApp(name="name", logFilePath=self.log_dir, parent=QObject())
             app.confirmFrame.buttonBox.accepted.emit()
             mocked_method.assert_called_once()
-            app.removeHandler()
+            app.fileHandler.close()
 
     @mock.patch("iquip.apps.logger.QTextEdit.clear")
     def test_clear_log(self, mocked_clear):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -132,5 +132,6 @@ class LoggerAppTest(unittest.TestCase):
                 msg = f"{timeString}: hello\n"
                 mocked_insert.assert_called_once_with(msg)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -20,10 +20,10 @@ class LoggingHandlerTest(unittest.TestCase):
 
     def test_emit(self):
         with mock.patch("iquip.apps.logger._Signaller.signal") as mocked_signal:
-            app = logger.LoggerApp(name="name", parent=QObject())
-            app.setLevel("DEBUG")
+            app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
+            app.setLevel(app.frameHandler ,"DEBUG")
             test_log = logging.makeLogRecord({"name": "hello"})
-            app.handler.emit(test_log)
+            app.frameHandler.emit(test_log)
             mocked_signal.emit.assert_called_once()
 
 
@@ -38,13 +38,13 @@ class ConfirmClearingFrameTest(unittest.TestCase):
 
     def test_button_ok_clicked(self):
         with mock.patch("iquip.apps.logger.QWidget.close") as mocked_close:
-            app = logger.LoggerApp(name="name", parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
             app.confirmFrame.buttonOKClicked()
             mocked_close.assert_called_once()
 
     def test_button_cancel_clicked(self):
         with mock.patch("iquip.apps.logger.QWidget.close") as mocked_close:
-            app = logger.LoggerApp(name="name", parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
             app.confirmFrame.buttonCancelClicked()
             mocked_close.assert_called_once()
 
@@ -58,6 +58,11 @@ class LoggerAppTest(unittest.TestCase):
     def tearDown(self):
         del self.qapp
 
+    def test_init_logger(self):
+        app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
+        self.assertEqual(app.frameHandler.level, logging.WARNING)
+        self.assertEqual(app.fileHandler.level, logging.WARNING)
+
     def test_set_level(self):
         levels = {
             "DEBUG": logging.DEBUG,
@@ -67,51 +72,53 @@ class LoggerAppTest(unittest.TestCase):
             "CRITICAL": logging.CRITICAL
         }
         root_logger = logging.getLogger()
-        app = logger.LoggerApp(name="name", parent=QObject())
+        app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
         for levelText, level in levels.items():
-            app.setLevel(levelText)
-            self.assertEqual(app.handler.level, level)
+            app.setLevel(app.frameHandler, levelText)
+            app.setLevel(app.fileHandler, levelText)
+            self.assertEqual(app.frameHandler.level, level)
             self.assertEqual(root_logger.level, level)
-        prev_level = app.handler.level
+        prev_level = app.frameHandler.level
         non_level = "non_level"
-        app.setLevel(non_level)
-        self.assertEqual(prev_level, app.handler.level)
+        app.setLevel(app.frameHandler, non_level)
+        app.setLevel(app.fileHandler, non_level)
+        self.assertEqual(prev_level, app.frameHandler.level)
         self.assertEqual(prev_level, root_logger.level)
 
     def test_frames(self):
-        app = logger.LoggerApp(name="name", parent=QObject())
+        app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
         self.assertEqual(app.frames(), (app.loggerFrame,))
 
     def test_call_check_to_clear(self):
         with mock.patch("iquip.apps.logger.LoggerApp.checkToClear") as mocked_method:
-            app = logger.LoggerApp(name="name", parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
             app.loggerFrame.clearButton.clicked.emit()
             mocked_method.assert_called_once()
 
     def test_check_to_clear(self):
         with mock.patch("iquip.apps.logger.QWidget.show") as mocked_show:
-            app = logger.LoggerApp(name="name", parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
             app.checkToClear()
             mocked_show.assert_called_once()
 
     def test_call_clear_log(self):
         with mock.patch("iquip.apps.logger.LoggerApp.clearLog") as mocked_method:
-            app = logger.LoggerApp(name="name", parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
             app.confirmFrame.buttonBox.accepted.emit()
             mocked_method.assert_called_once()
 
     @mock.patch("iquip.apps.logger.QTextEdit.clear")
     def test_clear_log(self, mocked_clear):
         with mock.patch("iquip.apps.logger.logger") as mocked_logger:
-            app = logger.LoggerApp(name="name", parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
             app.clearLog()
             mocked_clear.assert_called_once()
             mocked_logger.info.called_once_with("Tried to clear logs by clicking clear button")
 
     def test_add_log(self):
+        app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
         with mock.patch("iquip.apps.logger.QTextEdit.insertPlainText") as mocked_insert:
             with mock.patch("iquip.apps.logger.QDateTime.currentDateTime") as mocked_time:
-                app = logger.LoggerApp(name="name", parent=QObject())
                 app.addLog("hello")
                 timeString = mocked_time().toString("yyyy-MM-dd HH:mm:ss")
                 msg = f"{timeString}: hello\n"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -15,17 +15,17 @@ class LoggingHandlerTest(unittest.TestCase):
 
     def setUp(self):
         self.qapp = QApplication([])
-        self.logdir = "logfile-unittest"
-        if not os.path.exists(self.logdir):
-            os.mkdir(self.logdir)
-        self.app = logger.LoggerApp(name="name", logFilePath=self.logdir, parent=QObject())
+        self.log_dir = "logfile-unittest/"
+        if not os.path.exists(self.log_dir):
+            os.mkdir(self.log_dir)
+        self.app = logger.LoggerApp(name="name", logFilePath=self.log_dir, parent=QObject())
 
     def tearDown(self):
         self.app.removeHandler()
-        file_list = os.listdir(self.logdir)
+        file_list = os.listdir(self.log_dir)
         for file in file_list:
-            os.remove(self.logdir+"/"+file)
-        os.rmdir(self.logdir)
+            os.remove(os.path.join(self.log_dir, file))
+        os.rmdir(self.log_dir)
         del self.qapp
 
     def test_emit(self):
@@ -41,17 +41,17 @@ class ConfirmClearingFrameTest(unittest.TestCase):
 
     def setUp(self):
         self.qapp = QApplication([])
-        self.logdir = "logfile-unittest"
-        if not os.path.exists(self.logdir):
-            os.mkdir(self.logdir)
-        self.app = logger.LoggerApp(name="name", logFilePath=self.logdir, parent=QObject())
+        self.log_dir = "logfile-unittest/"
+        if not os.path.exists(self.log_dir):
+            os.mkdir(self.log_dir)
+        self.app = logger.LoggerApp(name="name", logFilePath=self.log_dir, parent=QObject())
 
     def tearDown(self):
         self.app.removeHandler()
-        file_list = os.listdir(self.logdir)
+        file_list = os.listdir(self.log_dir)
         for file in file_list:
-            os.remove(self.logdir+"/"+file)
-        os.rmdir(self.logdir)
+            os.remove(os.path.join(self.log_dir, file))
+        os.rmdir(self.log_dir)
         del self.qapp
 
     def test_button_ok_clicked(self):
@@ -70,17 +70,17 @@ class LoggerAppTest(unittest.TestCase):
 
     def setUp(self):
         self.qapp = QApplication([])
-        self.logdir = "logfile-unittest"
-        if not os.path.exists(self.logdir):
-            os.mkdir(self.logdir)
-        self.app = logger.LoggerApp(name="name", logFilePath=self.logdir, parent=QObject())
+        self.log_dir = "logfile-unittest/"
+        if not os.path.exists(self.log_dir):
+            os.mkdir(self.log_dir)
+        self.app = logger.LoggerApp(name="name", logFilePath=self.log_dir, parent=QObject())
 
     def tearDown(self):
         self.app.removeHandler()
-        file_list = os.listdir(self.logdir)
+        file_list = os.listdir(self.log_dir)
         for file in file_list:
-            os.remove(self.logdir+"/"+file)
-        os.rmdir(self.logdir)
+            os.remove(os.path.join(self.log_dir, file))
+        os.rmdir(self.log_dir)
         del self.qapp
 
     def test_init_logger(self):
@@ -121,7 +121,7 @@ class LoggerAppTest(unittest.TestCase):
 
     def test_call_check_to_clear(self):
         with mock.patch("iquip.apps.logger.LoggerApp.checkToClear") as mocked_method:
-            app = logger.LoggerApp(name="name", logFilePath=self.logdir, parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath=self.log_dir, parent=QObject())
             app.loggerFrame.clearButton.clicked.emit()
             mocked_method.assert_called_once()
             app.removeHandler()
@@ -133,7 +133,7 @@ class LoggerAppTest(unittest.TestCase):
 
     def test_call_clear_log(self):
         with mock.patch("iquip.apps.logger.LoggerApp.clearLog") as mocked_method:
-            app = logger.LoggerApp(name="name", logFilePath=self.logdir, parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath=self.log_dir, parent=QObject())
             app.confirmFrame.buttonBox.accepted.emit()
             mocked_method.assert_called_once()
             app.removeHandler()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -20,7 +20,7 @@ class LoggingHandlerTest(unittest.TestCase):
 
     def test_emit(self):
         with mock.patch("iquip.apps.logger._Signaller.signal") as mocked_signal:
-            app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath="", parent=QObject())
             app.setLevel(app.frameHandler ,"DEBUG")
             test_log = logging.makeLogRecord({"name": "hello"})
             app.frameHandler.emit(test_log)
@@ -38,13 +38,13 @@ class ConfirmClearingFrameTest(unittest.TestCase):
 
     def test_button_ok_clicked(self):
         with mock.patch("iquip.apps.logger.QWidget.close") as mocked_close:
-            app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath="", parent=QObject())
             app.confirmFrame.buttonOKClicked()
             mocked_close.assert_called_once()
 
     def test_button_cancel_clicked(self):
         with mock.patch("iquip.apps.logger.QWidget.close") as mocked_close:
-            app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath="", parent=QObject())
             app.confirmFrame.buttonCancelClicked()
             mocked_close.assert_called_once()
 
@@ -59,7 +59,7 @@ class LoggerAppTest(unittest.TestCase):
         del self.qapp
 
     def test_init_logger(self):
-        app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
+        app = logger.LoggerApp(name="name", logFilePath="", parent=QObject())
         self.assertEqual(app.frameHandler.level, logging.WARNING)
         self.assertEqual(app.fileHandler.level, logging.WARNING)
 
@@ -72,7 +72,7 @@ class LoggerAppTest(unittest.TestCase):
             "CRITICAL": logging.CRITICAL
         }
         root_logger = logging.getLogger()
-        app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
+        app = logger.LoggerApp(name="name", logFilePath="", parent=QObject())
         for levelText, level in levels.items():
             app.setLevel(app.frameHandler, levelText)
             app.setLevel(app.fileHandler, levelText)
@@ -86,37 +86,37 @@ class LoggerAppTest(unittest.TestCase):
         self.assertEqual(prev_level, root_logger.level)
 
     def test_frames(self):
-        app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
+        app = logger.LoggerApp(name="name", logFilePath="", parent=QObject())
         self.assertEqual(app.frames(), (app.loggerFrame,))
 
     def test_call_check_to_clear(self):
         with mock.patch("iquip.apps.logger.LoggerApp.checkToClear") as mocked_method:
-            app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath="", parent=QObject())
             app.loggerFrame.clearButton.clicked.emit()
             mocked_method.assert_called_once()
 
     def test_check_to_clear(self):
         with mock.patch("iquip.apps.logger.QWidget.show") as mocked_show:
-            app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath="", parent=QObject())
             app.checkToClear()
             mocked_show.assert_called_once()
 
     def test_call_clear_log(self):
         with mock.patch("iquip.apps.logger.LoggerApp.clearLog") as mocked_method:
-            app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath="", parent=QObject())
             app.confirmFrame.buttonBox.accepted.emit()
             mocked_method.assert_called_once()
 
     @mock.patch("iquip.apps.logger.QTextEdit.clear")
     def test_clear_log(self, mocked_clear):
         with mock.patch("iquip.apps.logger.logger") as mocked_logger:
-            app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
+            app = logger.LoggerApp(name="name", logFilePath="", parent=QObject())
             app.clearLog()
             mocked_clear.assert_called_once()
             mocked_logger.info.called_once_with("Tried to clear logs by clicking clear button")
 
     def test_add_log(self):
-        app = logger.LoggerApp(name="name", logFilePath = "", parent=QObject())
+        app = logger.LoggerApp(name="name", logFilePath="", parent=QObject())
         with mock.patch("iquip.apps.logger.QTextEdit.insertPlainText") as mocked_insert:
             with mock.patch("iquip.apps.logger.QDateTime.currentDateTime") as mocked_time:
                 app.addLog("hello")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -77,17 +77,25 @@ class LoggerAppTest(unittest.TestCase):
             app.setLevel(app.frameHandler, levelText)
             app.setLevel(app.fileHandler, levelText)
             self.assertEqual(app.frameHandler.level, level)
+            self.assertEqual(app.fileHandler.level, level)
             self.assertEqual(root_logger.level, level)
         prev_level = app.frameHandler.level
         non_level = "non_level"
         app.setLevel(app.frameHandler, non_level)
         app.setLevel(app.fileHandler, non_level)
-        self.assertEqual(prev_level, app.frameHandler.level)
-        self.assertEqual(prev_level, root_logger.level)
+        self.assertEqual(app.frameHandler.level, prev_level)
+        self.assertEqual(app.fileHandler.level, prev_level)
+        self.assertEqual(root_logger.level, prev_level)
 
     def test_frames(self):
         app = logger.LoggerApp(name="name", logFilePath="", parent=QObject())
         self.assertEqual(app.frames(), (app.loggerFrame,))
+
+    def test_namer(self):
+        app = logger.LoggerApp(name="name", logFilePath="", parent=QObject())
+        name = "hell.logo"
+        modified_name = app.fileHandler.namer(name)
+        self.assertEqual(modified_name, "hello.log")
 
     def test_call_check_to_clear(self):
         with mock.patch("iquip.apps.logger.LoggerApp.checkToClear") as mocked_method:


### PR DESCRIPTION
This closes #112 

I updated unittest for logger.py. 
Now, unittest and pylint has error at develop branch since I implemented unittest of old version of logger app and merge it.

This unittest does not have coverage rate 100% because of function `namer` inside `initLogger` in `LoggerApp`.
I don't have good idea about implementing unittest for function defined inside function.
So I am planning to make namer as private class method `_namer` if no idea is suggested.

