### PR TITLE
Add a result explorer

### DIFF
--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -5,7 +5,7 @@ from typing import Callable, List, Optional, Tuple
 
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
-from PyQt5.QtWidgets import QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QLabel, QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QWidget
 
 import qiwis
 
@@ -90,6 +90,22 @@ class ResultExplorerApp(qiwis.BaseApp):
     @pyqtSlot()
     def loadRidList(self):
         """Loads the RID list in self.explorerFrame.ridList."""
+
+    def _addRid(self, ridList: List[str]):
+        """Clears the original RID list and adds the RIDs into self.explorerFrame.ridList.
+        
+        Args:
+            ridList: The fetched RID list.
+        """
+        for _ in range(self.explorerFrame.ridList.count()):
+            item = self.explorerFrame.ridList.takeItem(0)
+            del item
+        for rid in ridList:
+            widget = QLabel(rid, self.explorerFrame)
+            item = QListWidgetItem(self.explorerFrame.ridList)
+            self.explorerFrame.ridList.addItem(item)
+            self.explorerFrame.ridList.setItemWidget(item, widget)
+
 
     def frames(self) -> Tuple[ResultExplorerFrame]:
         """Overridden."""

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -43,8 +43,7 @@ class _RidListThread(QThread):
     """QThread for obtaining the RID list from the proxy server.
     
     Signals:
-        fetched(ridList):
-          The RID list is fetched.
+        fetched(ridList): The RID list is fetched.
     """
 
     fetched = pyqtSignal(list)
@@ -54,6 +53,7 @@ class _RidListThread(QThread):
         
         Args:
             callback: The callback method called after this thread is finished.
+              It will be called with one argument; the fetched RID list.
         """
         super().__init__(parent=parent)
         self.fetched.connect(callback, type=Qt.QueuedConnection)

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -96,6 +96,8 @@ class ResultExplorerApp(qiwis.BaseApp):
     @pyqtSlot()
     def loadRidList(self):
         """Loads the RID list in self.explorerFrame.ridList."""
+        self.ridListThread = _RidListThread(self._addRid, self)
+        self.ridListThread.start()
 
     def _addRid(self, ridList: List[str]):
         """Clears the original RID list and adds the RIDs into self.explorerFrame.ridList.
@@ -107,7 +109,7 @@ class ResultExplorerApp(qiwis.BaseApp):
             item = self.explorerFrame.ridList.takeItem(0)
             del item
         for rid in ridList:
-            widget = QLabel(rid, self.explorerFrame)
+            widget = QLabel(str(rid), self.explorerFrame)
             item = QListWidgetItem(self.explorerFrame.ridList)
             self.explorerFrame.ridList.addItem(item)
             self.explorerFrame.ridList.setItemWidget(item, widget)

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -13,14 +13,13 @@ logger = logging.getLogger(__name__)
 
 
 class ResultExplorerFrame(QWidget):
-    """Frame for showing the RID list and a specific h5 result.
+    """Frame for showing the RID list and the H5 format result of the selected RID.
     
     Attributes:
         ridList: The list widget for showing the submitted RIDs.
-        resultInfoList: The list widget for showing a specific h5 result.
+        resultInfoList: The list widget for showing the H5 format result of the selected RID.
         reloadButton: The button for reloading the ridList.
         openButton: The button for opening the selected result visualizer.
-
     """
 
     def __init__(self, parent: Optional[QWidget] = None):
@@ -77,10 +76,11 @@ class _RidListThread(QThread):
 
 
 class ResultExplorerApp(qiwis.BaseApp):
-    """App for showing the RID list and a specific h5 result.
+    """App for showing the RID list and the H5 format result of the selected RID.
     
     Attributes:
-        explorerFrame: The frame that shows the RID list and a specific h5 result.
+        explorerFrame: The frame that shows the RID list and
+          the H5 format result of the selected RID.
         ridListThread: The most recently executed _RidListThread instance.
     """
 

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -1,7 +1,7 @@
 """App module for showing the simple results and opening a result visualizer."""
 
 import logging
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Tuple
 
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
@@ -88,3 +88,7 @@ class ResultExplorerApp(qiwis.BaseApp):
     @pyqtSlot()
     def loadRidList(self):
         """Loads the RID list in self.explorerFrame.ridList."""
+
+    def frames(self) -> Tuple[ResultExplorerFrame]:
+        """Overridden."""
+        return (self.explorerFrame,)

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -1,0 +1,6 @@
+"""App module for showing the RID list and opening a result visualizer."""
+
+import qiwis
+
+class ResultExplorerApp(qiwis.BaseApp):
+    """App for showing the RID list and a detailed result."""

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -84,6 +84,8 @@ class ResultExplorerApp(qiwis.BaseApp):
         super().__init__(name, parent=parent)
         self.explorerFrame = ResultExplorerFrame()
         self.loadRidList()
+        # connect signals to slots
+        self.explorerFrame.reloadButton.clicked.connect(self.loadRidList)
 
     @pyqtSlot()
     def loadRidList(self):

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -96,10 +96,10 @@ class ResultExplorerApp(qiwis.BaseApp):
     @pyqtSlot()
     def loadRidList(self):
         """Loads the RID list in self.explorerFrame.ridList."""
-        self.ridListThread = _RidListThread(self._addRid, self)
+        self.ridListThread = _RidListThread(self._updateRidList, self)
         self.ridListThread.start()
 
-    def _addRid(self, ridList: List[str]):
+    def _updateRidList(self, ridList: List[str]):
         """Clears the original RID list and adds the RIDs into self.explorerFrame.ridList.
         
         Args:

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -1,6 +1,33 @@
-"""App module for showing the RID list and opening a result visualizer."""
+"""App module for showing the simple results and opening a result visualizer."""
+
+from typing import Optional
+
+from PyQt5.QtCore import QObject
+from PyQt5.QtWidgets import QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QWidget
 
 import qiwis
 
+class ResultExplorerFrame(QWidget):
+    """Frame for showing the RID list and a specific h5 result."""
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        """Extended."""
+        super().__init__(parent=parent)
+        # widgets
+        self.ridList = QListWidget(self)
+        self.resultList = QListWidget(self)
+        self.openButton = QPushButton("Visualize", self)
+        # layout
+        layout = QVBoxLayout
+        layout.addWidget(self.ridList)
+        layout.addWidget(self.resultList)
+        layout.addWidget(self.openButton)
+        self.setLayout(layout)
+        
+
 class ResultExplorerApp(qiwis.BaseApp):
-    """App for showing the RID list and a detailed result."""
+    """App for showing the RID list and a specific h5 result."""
+
+    def __init__(self, name: str, parent: Optional[QObject] = None):
+        """Extended."""
+        super().__init__(name, parent=parent)

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -18,7 +18,9 @@ class ResultExplorerFrame(QWidget):
     Attributes:
         ridList: The list widget for showing the submitted RIDs.
         resultList: The list widget for showing a specific h5 result.
+        reloadButton: The button for reloading the ridList.
         openButton: The button for opening the selected result visualizer.
+
     """
 
     def __init__(self, parent: Optional[QWidget] = None):
@@ -27,11 +29,13 @@ class ResultExplorerFrame(QWidget):
         # widgets
         self.ridList = QListWidget(self)
         self.resultList = QListWidget(self)
+        self.reloadButton = QPushButton("Reload", self)
         self.openButton = QPushButton("Visualize", self)
         # layout
         layout = QVBoxLayout(self)
         layout.addWidget(self.ridList)
         layout.addWidget(self.resultList)
+        layout.addWidget(self.reloadButton)
         layout.addWidget(self.openButton)
         self.setLayout(layout)
 

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -17,7 +17,7 @@ class ResultExplorerFrame(QWidget):
     
     Attributes:
         ridList: The list widget for showing the submitted RIDs.
-        resultList: The list widget for showing a specific h5 result.
+        resultInfoList: The list widget for showing a specific h5 result.
         reloadButton: The button for reloading the ridList.
         openButton: The button for opening the selected result visualizer.
 
@@ -28,23 +28,23 @@ class ResultExplorerFrame(QWidget):
         super().__init__(parent=parent)
         # widgets
         self.ridList = QListWidget(self)
-        self.resultList = QListWidget(self)
+        self.resultInfoList = QListWidget(self)
         self.reloadButton = QPushButton("Reload", self)
         self.openButton = QPushButton("Visualize", self)
         # layout
         layout = QVBoxLayout(self)
         layout.addWidget(self.ridList)
-        layout.addWidget(self.resultList)
+        layout.addWidget(self.resultInfoList)
         layout.addWidget(self.reloadButton)
         layout.addWidget(self.openButton)
         self.setLayout(layout)
 
 
-class _ResultListThread(QThread):
+class _RidListThread(QThread):
     """QThread for obtaining the RID list from the proxy server.
     
     Signals:
-        fetched(resultList):
+        fetched(ridList):
           The RID list is fetched.
     """
 
@@ -77,11 +77,17 @@ class _ResultListThread(QThread):
 
 
 class ResultExplorerApp(qiwis.BaseApp):
-    """App for showing the RID list and a specific h5 result."""
+    """App for showing the RID list and a specific h5 result.
+    
+    Attributes:
+        explorerFrame: The frame that shows the RID list and a specific h5 result.
+        ridListThread: The most recently executed _RidListThread instance.
+    """
 
     def __init__(self, name: str, parent: Optional[QObject] = None):
         """Extended."""
         super().__init__(name, parent=parent)
+        self.ridListThread: Optional[_RidListThread] = None
         self.explorerFrame = ResultExplorerFrame()
         self.loadRidList()
         # connect signals to slots
@@ -105,7 +111,6 @@ class ResultExplorerApp(qiwis.BaseApp):
             item = QListWidgetItem(self.explorerFrame.ridList)
             self.explorerFrame.ridList.addItem(item)
             self.explorerFrame.ridList.setItemWidget(item, widget)
-
 
     def frames(self) -> Tuple[ResultExplorerFrame]:
         """Overridden."""

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -1,8 +1,8 @@
 """App module for showing the simple results and opening a result visualizer."""
 
-from typing import Optional
+from typing import Callable, List, Optional
 
-from PyQt5.QtCore import QObject
+from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal
 from PyQt5.QtWidgets import QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QWidget
 
 import qiwis
@@ -23,7 +23,27 @@ class ResultExplorerFrame(QWidget):
         layout.addWidget(self.resultList)
         layout.addWidget(self.openButton)
         self.setLayout(layout)
+
+
+class _ResultListThread(QThread):
+    """QThread for obtaining the RID list from the proxy server.
+    
+    Signals:
+        fetched(resultList):
+          The RID list is fetched.
+    """
+
+    fetched = pyqtSignal(List[str])
+
+    def __init__(self, callback: Callable[[List[str]], None], parent: Optional[QObject] = None):
+        """Extended.
         
+        Args:
+            callback: The callback method called after this thread is finished.
+        """
+        super().__init__(parent=parent)
+        self.fetched.connect(callback, type=Qt.QueuedConnection)
+
 
 class ResultExplorerApp(qiwis.BaseApp):
     """App for showing the RID list and a specific h5 result."""

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -4,7 +4,7 @@ import logging
 from typing import Callable, List, Optional
 
 import requests
-from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal
+from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QWidget
 
 import qiwis
@@ -13,7 +13,13 @@ logger = logging.getLogger(__name__)
 
 
 class ResultExplorerFrame(QWidget):
-    """Frame for showing the RID list and a specific h5 result."""
+    """Frame for showing the RID list and a specific h5 result.
+    
+    Attributes:
+        ridList: The list widget for showing the submitted RIDs.
+        resultList: The list widget for showing a specific h5 result.
+        openButton: The button for opening the selected result visualizer.
+    """
 
     def __init__(self, parent: Optional[QWidget] = None):
         """Extended."""
@@ -23,7 +29,7 @@ class ResultExplorerFrame(QWidget):
         self.resultList = QListWidget(self)
         self.openButton = QPushButton("Visualize", self)
         # layout
-        layout = QVBoxLayout
+        layout = QVBoxLayout(self)
         layout.addWidget(self.ridList)
         layout.addWidget(self.resultList)
         layout.addWidget(self.openButton)
@@ -38,7 +44,7 @@ class _ResultListThread(QThread):
           The RID list is fetched.
     """
 
-    fetched = pyqtSignal(List[str])
+    fetched = pyqtSignal(list)
 
     def __init__(self, callback: Callable[[List[str]], None], parent: Optional[QObject] = None):
         """Extended.
@@ -72,3 +78,9 @@ class ResultExplorerApp(qiwis.BaseApp):
     def __init__(self, name: str, parent: Optional[QObject] = None):
         """Extended."""
         super().__init__(name, parent=parent)
+        self.explorerFrame = ResultExplorerFrame()
+        self.loadRidList()
+
+    @pyqtSlot()
+    def loadRidList(self):
+        """Loads the RID list in self.explorerFrame.ridList."""

--- a/setup.json
+++ b/setup.json
@@ -6,6 +6,12 @@
             "show": true,
             "pos": "left"
         },
+        "result_explorer": {
+            "module": "iquip.apps.result_explorer",
+            "cls": "ResultExplorerApp",
+            "show": true,
+            "pos": "right"
+        },
         "logger": {
             "module": "iquip.apps.logger",
             "cls": "LoggerApp",


### PR DESCRIPTION
This PR implemented a half of #93.

For details, please read the contents of #93.

# What was implemented in this PR
- Add a new app, `ResultExplorerApp`
- Fetch the submitted RID list and show it
- Able to reload it

# Result
<img width="60%" src="https://github.com/snu-quiqcl/iquip/assets/76851886/53449d93-faf0-4394-9c6a-8c1412c1027d">
