### PR TITLE
Add `order` option to `SubmittedExperimentInfo`

### DIFF
--- a/iquip/protocols.py
+++ b/iquip/protocols.py
@@ -17,7 +17,7 @@ class ExperimentInfo:
     arginfo: Dict[str, Any]
 
 
-@dataclasses.dataclass(order = True)
+@dataclasses.dataclass(order=True)
 class SubmittedExperimentInfo:
     """Information holder for submitted experiments.
     

--- a/iquip/protocols.py
+++ b/iquip/protocols.py
@@ -22,16 +22,16 @@ class SubmittedExperimentInfo:
     """Information holder for submitted experiments.
     
     Fields:
-        rid: The run identifier value of the experiment.
         priority: The priority of the experiment.
+        rid: The run identifier value of the experiment.
         status: Current state of the experiment.
         pipeline: The pipeline of the experiment.
         expid: The overall information of the experiment, 
           which is a dictionary that may include arguments, file, etc.
         due_date: The due date of the experiment.
     """
+    priority: int
     rid: int
-    priority: int = 0
     status: str = ""
     pipeline: str = ""
     expid: Dict[str, Any] = dataclasses.field(default_factory = dict)

--- a/iquip/protocols.py
+++ b/iquip/protocols.py
@@ -34,7 +34,7 @@ class SubmittedExperimentInfo:
     rid: int
     status: str = ""
     pipeline: str = ""
-    expid: Dict[str, Any] = dataclasses.field(default_factory = dict)
+    expid: Dict[str, Any] = dataclasses.field(default_factory=dict)
     due_date: str = ""
 
     def items(self) -> Any:

--- a/iquip/protocols.py
+++ b/iquip/protocols.py
@@ -17,7 +17,7 @@ class ExperimentInfo:
     arginfo: Dict[str, Any]
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(order = True)
 class SubmittedExperimentInfo:
     """Information holder for submitted experiments.
     


### PR DESCRIPTION
This simple addition sets the instances' key value to sort by its defined order; the `priority` value, `rid` as its tiebreaker, `status` as its tiebreaker's tiebreaker, and so on.

```
@dataclasses.dataclass(order = True)
class SubmittedExperimentInfo:
    priority: int
    rid: int
    status: str = ""
    pipeline: str = ""
    expid: Dict[str, Any] = dataclasses.field(default_factory = dict)
    due_date: str = ""
```

This closes #116.