### PR TITLE
Implement H5 result viewer

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -24,6 +24,7 @@ jobs:
         pip install pylint
     - name: Add dependencies about external libraries
       run: |
+        pip install h5py
         pip install pyqt5
         pip install requests
         pip install numpy

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,6 +24,7 @@ jobs:
         pip install coverage
     - name: Add dependencies about external libraries
       run: |
+        pip install h5py
         pip install pyqt5
         pip install requests
         pip install numpy

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -417,6 +417,7 @@ class BuilderApp(qiwis.BaseApp):
         proxy_port: The proxy server PORT number.
         builderFrame: The frame that shows the build arguments and requests to submit it.
         experimentPath: The path of the experiment file.
+        experimentClsName: The class name of the experiment.
         experimentSubmitThread: The most recently executed _ExperimentSubmitThread instance.
         experimentInfoThread: The most recently executed ExperimentInfoThread instance.
     """
@@ -432,14 +433,14 @@ class BuilderApp(qiwis.BaseApp):
         """Extended.
         
         Args:
-            experimentPath: See the attributes section in BuilderApp.
-            experimentClsName: The class name of the experiment.
+            experimentPath, experimentClsName: See the attributes section in BuilderApp.
             experimentInfo: The experiment information, a dictionary of protocols.ExperimentInfo.
         """
         super().__init__(name, parent=parent)
         self.proxy_ip = self.constants.proxy_ip  # pylint: disable=no-member
         self.proxy_port = self.constants.proxy_port  # pylint: disable=no-member
         self.experimentPath = experimentPath
+        self.experimentClsName = experimentClsName
         self.experimentSubmitThread: Optional[_ExperimentSubmitThread] = None
         self.experimentInfoThread: Optional[ExperimentInfoThread] = None
         self.builderFrame = BuilderFrame(experimentInfo["name"], experimentClsName)
@@ -564,6 +565,8 @@ class BuilderApp(qiwis.BaseApp):
         except ValueError:
             logger.exception("The submission is rejected because of an invalid argument.")
             return
+        if schedOpts["visualize"]:
+            schedOpts["cls"] = self.experimentClsName
         self.experimentSubmitThread = _ExperimentSubmitThread(
             self.experimentPath,
             experimentArgs,

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -488,10 +488,14 @@ class BuilderApp(qiwis.BaseApp):
             "ndecimals": 0,
             "type": "int"
         }
+        visualizeInfo = {
+            "default": False
+        }
         for widget in (
             _StringEntry("pipeline", pipelineInfo),
             _NumberEntry("priority", priorityInfo),
-            _DateTimeEntry("timed")
+            _DateTimeEntry("timed"),
+            _BooleanEntry("visualize", visualizeInfo)
         ):
             item = QListWidgetItem(self.builderFrame.schedOptsListWidget)
             item.setSizeHint(widget.sizeHint())

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -1,6 +1,5 @@
 """App module for showing the simple results and opening a result visualizer."""
 
-import functools
 import io
 import json
 import logging
@@ -39,6 +38,7 @@ class ResultExplorerFrame(QWidget):
         self.resultInfoTree.header().setVisible(False)
         self.reloadButton = QPushButton("Reload", self)
         self.openButton = QPushButton("Visualize", self)
+        self.openButton.setEnabled(False)
         # layout
         layout = QVBoxLayout(self)
         layout.addWidget(self.ridList)
@@ -236,10 +236,20 @@ class ResultExplorerApp(qiwis.BaseApp):
         rid = widget.text()
         self.h5FileThread = _H5FileThread(
             rid,
-            functools.partial(self._addResults, widget=self.explorerFrame.resultInfoTree),
+            self.showResults,
             self
         )
         self.h5FileThread.start()
+
+    def showResults(self, resultDict: Dict[str, Any]):
+        """Shows the results in self.explorerFrame.resultInfoTree.
+
+        Args:
+            resultDict: The dictionary with results of the selected RID.
+        """
+        self._addResults(resultDict, self.explorerFrame.resultInfoTree)
+        visualize = resultDict.get("visualize", False)
+        self.explorerFrame.openButton.setEnabled(visualize)
 
     def _addResults(self, resultDict: Dict[str, Any], widget: Union[QTreeWidget, QTreeWidgetItem]):
         """Adds the results into the children of the widget.

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -1,7 +1,7 @@
 """App module for showing the simple results and opening a result visualizer."""
 
 import logging
-from typing import Callable, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
@@ -92,11 +92,38 @@ class _H5FileThread(QThread):
     """QThread for obtaining the H5 format result file from the proxy server.
     
     Signals:
-        fetched(results): The H5 format result file is fetched.
+        fetched(results):
+          The H5 format result file is fetched.
+          The "results" is a dictionary with the following keys.
+            expid: The experiment identifier containing submitted information.
+            datasets: A dictionary with datasets.
+              Each key is a dataset name, and its value is a numpy array.
+            submission_time: The submission date-time in ISO format string.
+            start_time: The start date-time in ISO format string.
+            run_time: The run date-time in ISO format string.
+            visualize: True if the visualize option is checked, otherwise False.
 
     Attributes:
         rid: The run identifier value of the target executed experiment.
     """
+
+    fetched = pyqtSignal(dict)
+
+    def __init__(
+        self,
+        rid: str,
+        callback: Callable[[Dict[str, Any]], None],
+        parent: Optional[QObject] = None
+    ):
+        """Extended.
+        
+        Args:
+            rid: See the attributes section in _H5FileThread.
+            callback: The callback method called after this thread is finished.
+        """
+        super().__init__(parent=parent)
+        self.rid = rid
+        self.fetched.connect(callback, type=Qt.QueuedConnection)
 
 
 class ResultExplorerApp(qiwis.BaseApp):

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -148,7 +148,7 @@ class _H5FileThread(QThread):
             results = {}
             with h5py.File(io.BytesIO(file_contents), "r") as f:
                 # expid
-                expid_str = f["expid"][()].decode("utf-8")
+                expid_str = f["expid"][()].decode("utf-8")  # pylint: disable=no-member
                 results["expid"] = json.loads(expid_str)
                 # datasets
                 results["datasets"] = {}

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -113,6 +113,8 @@ class _H5FileThread(QThread):
             visualize: True if the visualize option is checked, otherwise False.
 
     Attributes:
+        ip: The proxy server IP address.
+        port: The proxy server PORT number.
         rid: The run identifier value of the target executed experiment.
     """
 
@@ -121,17 +123,21 @@ class _H5FileThread(QThread):
     def __init__(
         self,
         rid: str,
+        ip: str,
+        port: int,
         callback: Callable[[Dict[str, Any]], None],
         parent: Optional[QObject] = None
     ):
         """Extended.
         
         Args:
-            rid: See the attributes section in _H5FileThread.
+            rid, ip, port: See the attributes section.
             callback: The callback method called after this thread is finished.
         """
         super().__init__(parent=parent)
         self.rid = rid
+        self.ip = ip
+        self.port = port
         self.fetched.connect(callback, type=Qt.QueuedConnection)
 
     def run(self):
@@ -142,7 +148,7 @@ class _H5FileThread(QThread):
         After finished, the fetched signal is emitted.
         """
         try:
-            response = requests.get(f"http://127.0.0.1:8000/result/{self.rid}/h5/", timeout=10)
+            response = requests.get(f"http://{self.ip}:{self.port}/result/{self.rid}/h5/", timeout=10)
             response.raise_for_status()
             file_contents = response.content
             results = {}
@@ -236,6 +242,8 @@ class ResultExplorerApp(qiwis.BaseApp):
         rid = widget.text()
         self.h5FileThread = _H5FileThread(
             rid,
+            self.proxy_ip,
+            self.proxy_port,
             self.showResults,
             self
         )

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -8,7 +8,10 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import h5py
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
-from PyQt5.QtWidgets import QLabel, QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import (
+    QLabel, QListWidget, QListWidgetItem, QPushButton, QTreeWidget, QTreeWidgetItem,
+    QVBoxLayout, QWidget
+)
 
 import qiwis
 
@@ -20,7 +23,7 @@ class ResultExplorerFrame(QWidget):
     
     Attributes:
         ridList: The list widget for showing the submitted RIDs.
-        resultInfoList: The list widget for showing the H5 format result of the selected RID.
+        resultInfoTree: The tree widget for showing the H5 format result of the selected RID.
         reloadButton: The button for reloading the ridList.
         openButton: The button for opening the selected result visualizer.
     """
@@ -30,13 +33,13 @@ class ResultExplorerFrame(QWidget):
         super().__init__(parent=parent)
         # widgets
         self.ridList = QListWidget(self)
-        self.resultInfoList = QListWidget(self)
+        self.resultInfoTree = QTreeWidget(self)
         self.reloadButton = QPushButton("Reload", self)
         self.openButton = QPushButton("Visualize", self)
         # layout
         layout = QVBoxLayout(self)
         layout.addWidget(self.ridList)
-        layout.addWidget(self.resultInfoList)
+        layout.addWidget(self.resultInfoTree)
         layout.addWidget(self.reloadButton)
         layout.addWidget(self.openButton)
         self.setLayout(layout)
@@ -223,7 +226,7 @@ class ResultExplorerApp(qiwis.BaseApp):
         After fetching througth _H5FileThread, shows them in self.explorerFrame.
         
         Args:
-            ridItem: The doubled-clicked RID item in self.explorerFrame.ridList.resultInfoList.
+            ridItem: The doubled-clicked RID item in self.explorerFrame.ridList.
         """
         widget = self.explorerFrame.ridList.itemWidget(ridItem)
         rid = widget.text()
@@ -231,7 +234,7 @@ class ResultExplorerApp(qiwis.BaseApp):
         self.h5FileThread.start()
 
     def _showResults(self, results: Dict[str, Any]):
-        """Shows the results in self.explorerFrame.ridList.resultInfoList.
+        """Shows the results in self.explorerFrame.ridList.resultInfoTree.
         
         Args:
             results: See the signals section in _H5FileThread.

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -127,7 +127,7 @@ class _H5FileThread(QThread):
         port: int,
         callback: Callable[[Dict[str, Any]], None],
         parent: Optional[QObject] = None
-    ):
+    ):  # pylint: disable=too-many-arguments
         """Extended.
         
         Args:
@@ -148,7 +148,10 @@ class _H5FileThread(QThread):
         After finished, the fetched signal is emitted.
         """
         try:
-            response = requests.get(f"http://{self.ip}:{self.port}/result/{self.rid}/h5/", timeout=10)
+            response = requests.get(
+                f"http://{self.ip}:{self.port}/result/{self.rid}/h5/",
+                timeout=10
+            )
             response.raise_for_status()
             file_contents = response.content
             results = {}

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -129,7 +129,12 @@ class _H5FileThread(QThread):
         self.fetched.connect(callback, type=Qt.QueuedConnection)
 
     def run(self):
-        """Overridden."""
+        """Overridden.
+
+        Fetches the H5 format result file and extracts results.
+
+        After finished, the fetched signal is emitted.
+        """
         try:
             response = requests.get(f"http://127.0.0.1:8000/result/{self.rid}/h5/", timeout=10)
             response.raise_for_status()

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -138,6 +138,7 @@ class ResultExplorerApp(qiwis.BaseApp):
         explorerFrame: The frame that shows the RID list and
           the H5 format result of the selected RID.
         ridListThread: The most recently executed _RidListThread instance.
+        h5FileThread: The most recently executed _H5FileThread instance.
     """
 
     def __init__(self, name: str, parent: Optional[QObject] = None):
@@ -146,9 +147,11 @@ class ResultExplorerApp(qiwis.BaseApp):
         self.proxy_ip = self.constants.proxy_ip  # pylint: disable=no-member
         self.proxy_port = self.constants.proxy_port  # pylint: disable=no-member
         self.ridListThread: Optional[_RidListThread] = None
+        self.h5FileThread: Optional[_H5FileThread] = None
         self.explorerFrame = ResultExplorerFrame()
         self.loadRidList()
         # connect signals to slots
+        self.explorerFrame.ridList.itemDoubleClicked.connect(self.fetchResults)
         self.explorerFrame.reloadButton.clicked.connect(self.loadRidList)
 
     @pyqtSlot()
@@ -176,6 +179,19 @@ class ResultExplorerApp(qiwis.BaseApp):
             item = QListWidgetItem(self.explorerFrame.ridList)
             self.explorerFrame.ridList.addItem(item)
             self.explorerFrame.ridList.setItemWidget(item, widget)
+
+    @pyqtSlot(QListWidgetItem)
+    def fetchResults(self, ridItem: QListWidgetItem):
+        """Fetches the results of the double-clicked RID.
+
+        After fetching througth _H5FileThread, shows them in self.explorerFrame.
+        
+        Args:
+            ridItem: The doubled-clicked RID item in self.explorerFrame.ridList.resultInfoList.
+        """
+        widget = self.explorerFrame.ridList.itemWidget(ridItem)
+        rid = widget.text()
+
 
     def frames(self) -> Tuple[ResultExplorerFrame]:
         """Overridden."""

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -125,6 +125,9 @@ class _H5FileThread(QThread):
         self.rid = rid
         self.fetched.connect(callback, type=Qt.QueuedConnection)
 
+    def run(self):
+        """Overridden."""
+
 
 class ResultExplorerApp(qiwis.BaseApp):
     """App for showing the RID list and the H5 format result of the selected RID.

--- a/iquip/apps/result_explorer.py
+++ b/iquip/apps/result_explorer.py
@@ -88,6 +88,17 @@ class _RidListThread(QThread):
         self.fetched.emit(ridList)
 
 
+class _H5FileThread(QThread):
+    """QThread for obtaining the H5 format result file from the proxy server.
+    
+    Signals:
+        fetched(results): The H5 format result file is fetched.
+
+    Attributes:
+        rid: The run identifier value of the target executed experiment.
+    """
+
+
 class ResultExplorerApp(qiwis.BaseApp):
     """App for showing the RID list and the H5 format result of the selected RID.
     

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -428,7 +428,7 @@ class BuilderAppTest(unittest.TestCase):
             experimentInfo=copy.deepcopy(EMPTY_EXPERIMENT_INFO)
         )
         experimentArgs = {"key1": "value1"}
-        schedOpts = {"key2": "value2"}
+        schedOpts = {"key2": "value2", "visualize": False}
         with mock.patch.multiple(
             app,
             argumentsFromListWidget=mock.DEFAULT,


### PR DESCRIPTION
This will close #93.

# What was implemented
- H5 result viewer in `resultInfoTree`.
- The implementation is similar to the explorer app.

# Results
Before clicking a RID

<img width="60%" src="https://github.com/snu-quiqcl/iquip/assets/76851886/b04dab12-b5e0-4040-b55e-8f131152788d">

After clicking a RID

<img width="60%" src="https://github.com/snu-quiqcl/iquip/assets/76851886/a5ae3e6a-89d2-4892-a314-d4aa178c79e9">
