### PR TITLE
Set default value for `priority` and modify `sort`

### DIFF
--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -184,7 +184,7 @@ class ExperimentModel(QAbstractListModel):
 
     def sort(self):
         """Sorts the experiments by priority value."""
-        self.schedulerFrame.model.experimentQueue.sort(key=lambda x: x.priority, reverse=True)
+        self.schedulerFrame.model.experimentQueue.sort(key=lambda x: (-x.priority, x.rid))
 
     def supportedDropActions(self) -> int:
         """Overridden."""

--- a/iquip/protocols.py
+++ b/iquip/protocols.py
@@ -22,16 +22,16 @@ class SubmittedExperimentInfo:
     """Information holder for submitted experiments.
     
     Fields:
-        priority: The priority of the experiment.
         rid: The run identifier value of the experiment.
+        priority: The priority of the experiment.
         status: Current state of the experiment.
         pipeline: The pipeline of the experiment.
         expid: The overall information of the experiment, 
           which is a dictionary that may include arguments, file, etc.
         due_date: The due date of the experiment.
     """
-    priority: int
     rid: int
+    priority: int = 0
     status: str = ""
     pipeline: str = ""
     expid: Dict[str, Any] = dataclasses.field(default_factory=dict)


### PR DESCRIPTION
#91 has only `rid` to input, but in #116, it requires `priority` to sort in that order.

But as `priority` must be sorted in reverse and (I think) `rid` must be sorted in ascending order, the `order = True` here does not have any meaning. Thus, I deleted that part and modified the sort function.

This closes #128.