### PR TITLE
Improve unit test output

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,5 +32,5 @@ jobs:
         pip install git+https://github.com/snu-quiqcl/qiwis.git@${{ env.QIWIS_VERSION }}
     - name: Run the unit tests and check coverage
       run: |
-        xvfb-run `which coverage` run --source=iquip/ -m unittest discover
+        xvfb-run `which coverage` run --source=iquip/ -m unittest discover -b
         xvfb-run `which coverage` report

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -395,7 +395,6 @@ class BuilderAppTest(unittest.TestCase):
         )
 
     def test_on_reloaded(self):
-        print(EXPERIMENT_INFO)
         app = builder.BuilderApp(
             name="name",
             experimentPath="experimentPath",


### PR DESCRIPTION
This closes #126.

This adds `-b` option to the unittest command, and also removes an unnecessary `print()` in `test_builder.py`.