### PR TITLE
Single TTL controller: `TTLControllerWidget`

### DIFF
--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -2,12 +2,16 @@
 
 from typing import Optional
 
-from PyQt5.QtWidgets import QHBoxLayout, QLabel, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
 
 from iquip.monitor import Monitor, TTLMonitorWidget
 
 class TTLControllerWidget(QWidget):
-    """Single TTL channel controller widget."""
+    """Single TTL channel controller widget.
+    
+    Attributes:
+        levelButton: Button for setting the level.
+    """
 
     def __init__(self, name: str, channel: int, parent: Optional[QWidget] = None):
         """Extended.
@@ -20,6 +24,7 @@ class TTLControllerWidget(QWidget):
         # widgets
         monitor = Monitor(initial_value=None)
         monitorWidget = TTLMonitorWidget(monitor, self)
+        self.levelButton = QPushButton("OFF")
         # layout
         infoLayout = QHBoxLayout()
         infoLayout.addWidget(QLabel(name, self))
@@ -27,3 +32,4 @@ class TTLControllerWidget(QWidget):
         layout = QVBoxLayout(self)
         layout.addLayout(infoLayout)
         layout.addWidget(monitorWidget)
+        layout.addWidget(self.levelButton)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -4,8 +4,6 @@ from typing import Optional
 
 from PyQt5.QtWidgets import QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
 
-from iquip.monitor import Monitor, TTLMonitorWidget
-
 class TTLControllerWidget(QWidget):
     """Single TTL channel controller widget.
     
@@ -22,8 +20,6 @@ class TTLControllerWidget(QWidget):
         """
         super().__init__(parent=parent)
         # widgets
-        monitor = Monitor(initial_value=None)
-        monitorWidget = TTLMonitorWidget(monitor, self)
         self.levelButton = QPushButton("OFF")
         self.levelButton.setCheckable(True)
         # layout
@@ -32,5 +28,4 @@ class TTLControllerWidget(QWidget):
         infoLayout.addWidget(QLabel(f"CH {channel}", self))
         layout = QVBoxLayout(self)
         layout.addLayout(infoLayout)
-        layout.addWidget(monitorWidget)
         layout.addWidget(self.levelButton)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -4,6 +4,8 @@ from typing import Optional
 
 from PyQt5.QtWidgets import QHBoxLayout, QLabel, QVBoxLayout, QWidget
 
+from iquip.monitor import Monitor, TTLMonitorWidget
+
 class TTLControllerWidget(QWidget):
     """Single TTL channel controller widget."""
 
@@ -16,11 +18,12 @@ class TTLControllerWidget(QWidget):
         """
         super().__init__(parent=parent)
         # widgets
-        nameLabel = QLabel(name, self)
-        channelLabel = QLabel(f"CH {channel}", self)
+        monitor = Monitor(initial_value=None)
+        monitorWidget = TTLMonitorWidget(monitor, self)
         # layout
         infoLayout = QHBoxLayout()
-        infoLayout.addWidget(nameLabel)
-        infoLayout.addWidget(channelLabel)
+        infoLayout.addWidget(QLabel(name, self))
+        infoLayout.addWidget(QLabel(f"CH {channel}", self))
         layout = QVBoxLayout(self)
         layout.addLayout(infoLayout)
+        layout.addWidget(monitorWidget)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -25,6 +25,7 @@ class TTLControllerWidget(QWidget):
         monitor = Monitor(initial_value=None)
         monitorWidget = TTLMonitorWidget(monitor, self)
         self.levelButton = QPushButton("OFF")
+        self.levelButton.setCheckable(True)
         # layout
         infoLayout = QHBoxLayout()
         infoLayout.addWidget(QLabel(name, self))

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -1,6 +1,26 @@
 """App module for monitoring and controlling ARTIQ hardwares e.g., TTL, DDS, and DAC."""
 
-from PyQt5.QtWidgets import QWidget
+from typing import Optional
+
+from PyQt5.QtWidgets import QHBoxLayout, QLabel, QVBoxLayout, QWidget
 
 class TTLControllerWidget(QWidget):
     """Single TTL channel controller widget."""
+
+    def __init__(self, name: str, channel: int, parent: Optional[QWidget] = None):
+        """Extended.
+        
+        Args:
+            name: TTL channel name.
+            channel: TTL channel number.
+        """
+        super().__init__(parent=parent)
+        # widgets
+        nameLabel = QLabel(name, self)
+        channelLabel = QLabel(f"CH {channel}", self)
+        # layout
+        infoLayout = QHBoxLayout()
+        infoLayout.addWidget(nameLabel)
+        infoLayout.addWidget(channelLabel)
+        layout = QVBoxLayout(self)
+        layout.addLayout(infoLayout)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -1,0 +1,6 @@
+"""App module for monitoring and controlling ARTIQ hardwares e.g., TTL, DDS, and DAC."""
+
+from PyQt5.QtWidgets import QWidget
+
+class TTLControllerWidget(QWidget):
+    """Single TTL channel controller widget."""


### PR DESCRIPTION
This closes #153.

For test, please save the following code in the repository directory.
```python
from PyQt5.QtWidgets import QApplication

from iquip.apps.monitor import TTLControllerWidget

qapp = QApplication([])
widget = TTLControllerWidget("Cooling Beam", 10)
widget.show()
qapp.exec_()
```

### Result
<img width="30%" src="https://github.com/snu-quiqcl/iquip/assets/76851886/9711422c-ccf6-44ec-b679-bc50fda4eba3">
