### PR TITLE
Frame with all TTL controllers: `TTLControllerFrame`

### DIFF
--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -63,6 +63,7 @@ class TTLControllerFrame(QWidget):
             self.ttlWidgets[name] = ttlWidget
             ttlWidgetLayout.addWidget(ttlWidget, row, column)
         self.overrideButton = QPushButton("Not Overridden", self)
+        self.overrideButton.setCheckable(True)
         # layout
         layout = QVBoxLayout(self)
         layout.addLayout(ttlWidgetLayout)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, Optional
 
-from PyQt5.QtWidgets import QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QGridLayout, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
 
 class TTLControllerWidget(QWidget):
     """Single TTL channel controller widget.
@@ -33,16 +33,37 @@ class TTLControllerWidget(QWidget):
 
 class TTLControllerFrame(QWidget):
     """Frame for monitoring and controlling TTL channels.
+
+    Constants:
+        NUM_COLUMNS: Column number of TTL widgets container layout.
     
     Attributes:
+        ttlWidgets: Dictionary with TTL controller widgets.
+          Each key is a TTL channel name, and its value is the corresponding TTLControllerWidget.
         overrideButton: Button for setting the override.
     """
 
+    NUM_COLUMNS = 4
+
     def __init__(self, ttlInfo: Dict[str, int], parent: Optional[QWidget] = None):
-        """Extended."""
+        """Extended.
+        
+        Args:
+            ttlInfo: Dictionary with TTL channels info.
+              Each key is a TTL channel name, and its value is the channel number.
+        """
         super().__init__(parent=parent)
+        self.ttlWidgets = {}
         # widgets
+        ttlWidgetLayout = QGridLayout()
+        for idx, (name, channel) in enumerate(ttlInfo.items()):
+            ttlWidget = TTLControllerWidget(name, channel, self)
+            row = idx // TTLControllerFrame.NUM_COLUMNS
+            column = idx % TTLControllerFrame.NUM_COLUMNS
+            self.ttlWidgets[name] = ttlWidget
+            ttlWidgetLayout.addWidget(ttlWidget, row, column)
         self.overrideButton = QPushButton("Not Overridden", self)
         # layout
         layout = QVBoxLayout(self)
+        layout.addLayout(ttlWidgetLayout)
         layout.addWidget(self.overrideButton)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -88,7 +88,7 @@ class TTLControllerFrame(QWidget):
             column = idx % TTLControllerFrame.NUM_COLUMNS
             self.ttlWidgets[name] = ttlWidget
             ttlWidgetLayout.addWidget(ttlWidget, row, column)
-        self.overrideButton = QPushButton("Not Overridden", self)
+        self.overrideButton = QPushButton("Not Overriding", self)
         self.overrideButton.setCheckable(True)
         # layout
         layout = QVBoxLayout(self)
@@ -106,6 +106,6 @@ class TTLControllerFrame(QWidget):
             override: Whether the overrideButton is now checked or not.
         """
         if override:
-            self.overrideButton.setText("Overridden")
+            self.overrideButton.setText("Overriding")
         else:
-            self.overrideButton.setText("Not Overridden")
+            self.overrideButton.setText("Not Overriding")

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -1,9 +1,13 @@
 """App module for monitoring and controlling ARTIQ hardwares e.g., TTL, DDS, and DAC."""
 
+import logging
 from typing import Dict, Optional
 
 from PyQt5.QtCore import pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QGridLayout, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+
+logger = logging.getLogger(__name__)
+
 
 class TTLControllerWidget(QWidget):
     """Single TTL channel controller widget.
@@ -55,9 +59,6 @@ class TTLControllerWidget(QWidget):
 class TTLControllerFrame(QWidget):
     """Frame for monitoring and controlling TTL channels.
 
-    Constants:
-        NUM_COLUMNS: Column number of TTL widgets container layout.
-    
     Attributes:
         ttlWidgets: Dictionary with TTL controller widgets.
           Each key is a TTL channel name, and its value is the corresponding TTLControllerWidget.
@@ -67,25 +68,31 @@ class TTLControllerFrame(QWidget):
         overrideChanged(override): Current override value is changed to override.
     """
 
-    NUM_COLUMNS = 4
-
     overrideChanged = pyqtSignal(bool)
 
-    def __init__(self, ttlInfo: Dict[str, int], parent: Optional[QWidget] = None):
+    def __init__(
+        self,
+        ttlInfo: Dict[str, int],
+        numColumns: int = 4,
+        parent: Optional[QWidget] = None
+    ):
         """Extended.
         
         Args:
             ttlInfo: Dictionary with TTL channels info.
               Each key is a TTL channel name, and its value is the channel number.
+            numColumns: Number of columns in TTL widgets container layout.
         """
         super().__init__(parent=parent)
+        if numColumns <= 0:
+            logger.error("The number of columns must be positive.")
+            return
         self.ttlWidgets = {}
         # widgets
         ttlWidgetLayout = QGridLayout()
         for idx, (name, channel) in enumerate(ttlInfo.items()):
             ttlWidget = TTLControllerWidget(name, channel, self)
-            row = idx // TTLControllerFrame.NUM_COLUMNS
-            column = idx % TTLControllerFrame.NUM_COLUMNS
+            row, column = idx // numColumns, idx % numColumns
             self.ttlWidgets[name] = ttlWidget
             ttlWidgetLayout.addWidget(ttlWidget, row, column)
         self.overrideButton = QPushButton("Not Overriding", self)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -39,7 +39,8 @@ class TTLControllerWidget(QWidget):
         self.levelButton.clicked.connect(self.levelChanged)
         self.levelChanged.connect(self._setLevelButtonText)
 
-    def _setLevelButtonText(self, level: True):
+    @pyqtSlot(bool)
+    def _setLevelButtonText(self, level: bool):
         """Sets the levelButton text.
 
         Args:
@@ -97,7 +98,8 @@ class TTLControllerFrame(QWidget):
         self.overrideButton.clicked.connect(self.overrideChanged)
         self.overrideChanged.connect(self._setOverrideButtonText)
 
-    def _setOverrideButtonText(self, override: True):
+    @pyqtSlot(bool)
+    def _setOverrideButtonText(self, override: bool):
         """Sets the levelButton text.
         
         Args:

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -40,7 +40,11 @@ class TTLControllerWidget(QWidget):
         self.levelChanged.connect(self._setLevelButtonText)
 
     def _setLevelButtonText(self, level: True):
-        """Sets the levelButton text."""
+        """Sets the levelButton text.
+
+        Args:
+            level: Whether the levelButton is now checked or not.
+        """
         if level:
             self.levelButton.setText("ON")
         else:
@@ -97,7 +101,7 @@ class TTLControllerFrame(QWidget):
         """Sets the levelButton text.
         
         Args:
-            override: Whether the override is active.
+            override: Whether the overrideButton is now checked or not.
         """
         if override:
             self.overrideButton.setText("Overridden")

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -1,6 +1,6 @@
 """App module for monitoring and controlling ARTIQ hardwares e.g., TTL, DDS, and DAC."""
 
-from typing import Optional
+from typing import Dict, Optional
 
 from PyQt5.QtWidgets import QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
 
@@ -29,3 +29,20 @@ class TTLControllerWidget(QWidget):
         layout = QVBoxLayout(self)
         layout.addLayout(infoLayout)
         layout.addWidget(self.levelButton)
+
+
+class TTLControllerFrame(QWidget):
+    """Frame for monitoring and controlling TTL channels.
+    
+    Attributes:
+        overrideButton: Button for setting the override.
+    """
+
+    def __init__(self, ttl_info: Dict[str, int], parent: Optional[QWidget] = None):
+        """Extended."""
+        super().__init__(parent=parent)
+        # widgets
+        self.overrideButton = QPushButton("Not Overridden", self)
+        # layout
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.overrideButton)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -2,6 +2,7 @@
 
 from typing import Dict, Optional
 
+from PyQt5.QtCore import pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QGridLayout, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
 
 class TTLControllerWidget(QWidget):
@@ -9,7 +10,12 @@ class TTLControllerWidget(QWidget):
     
     Attributes:
         levelButton: Button for setting the level.
+
+    Signals:
+        levelChanged(level): Current level value is changed to level.
     """
+
+    levelChanged = pyqtSignal(bool)
 
     def __init__(self, name: str, channel: int, parent: Optional[QWidget] = None):
         """Extended.
@@ -29,6 +35,16 @@ class TTLControllerWidget(QWidget):
         layout = QVBoxLayout(self)
         layout.addLayout(infoLayout)
         layout.addWidget(self.levelButton)
+        # signal connection
+        self.levelButton.clicked.connect(self.levelChanged)
+        self.levelChanged.connect(self._setLevelButtonText)
+
+    def _setLevelButtonText(self, level: True):
+        """Sets the levelButton text."""
+        if level:
+            self.levelButton.setText("ON")
+        else:
+            self.levelButton.setText("OFF")
 
 
 class TTLControllerFrame(QWidget):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -38,7 +38,7 @@ class TTLControllerFrame(QWidget):
         overrideButton: Button for setting the override.
     """
 
-    def __init__(self, ttl_info: Dict[str, int], parent: Optional[QWidget] = None):
+    def __init__(self, ttlInfo: Dict[str, int], parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(parent=parent)
         # widgets

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -57,9 +57,14 @@ class TTLControllerFrame(QWidget):
         ttlWidgets: Dictionary with TTL controller widgets.
           Each key is a TTL channel name, and its value is the corresponding TTLControllerWidget.
         overrideButton: Button for setting the override.
+
+    Signals:
+        overrideChanged(override): Current override value is changed to override.
     """
 
     NUM_COLUMNS = 4
+
+    overrideChanged = pyqtSignal(bool)
 
     def __init__(self, ttlInfo: Dict[str, int], parent: Optional[QWidget] = None):
         """Extended.
@@ -84,3 +89,17 @@ class TTLControllerFrame(QWidget):
         layout = QVBoxLayout(self)
         layout.addLayout(ttlWidgetLayout)
         layout.addWidget(self.overrideButton)
+        # signal connection
+        self.overrideButton.clicked.connect(self.overrideChanged)
+        self.overrideChanged.connect(self._setOverrideButtonText)
+
+    def _setOverrideButtonText(self, override: True):
+        """Sets the levelButton text.
+        
+        Args:
+            override: Whether the override is active.
+        """
+        if override:
+            self.overrideButton.setText("Overridden")
+        else:
+            self.overrideButton.setText("Not Overridden")


### PR DESCRIPTION
This closes #154.

For test, store the following code in the repository path.
```python
from PyQt5.QtWidgets import QApplication

from iquip.apps.monitor import TTLControllerFrame

qapp = QApplication([])
widget = TTLControllerFrame({
    "AAA": 0, "BBB": 1, "CCC": 2, "DDD": 3,
    "EEE": 4, "FFF": 5, "GGG": 6, "HHH": 7
})
widget.show()
qapp.exec_()
```

### Result
_(updated)_

<img width="50%" src="https://github.com/snu-quiqcl/iquip/assets/76851886/498bce1d-a286-497b-8295-0e0783582632">
