### PR TITLE
Add functions to run actually: `DeviceMonitorApp`

### DIFF
--- a/config_template.json
+++ b/config_template.json
@@ -26,6 +26,18 @@
             "cls": "SchedulerApp",
             "show": true,
             "pos": "bottom"
+        },
+        "monitor": {
+            "module": "iquip.apps.monitor",
+            "cls": "DeviceMonitorApp",
+            "show": true,
+            "pos": "right",
+            "args": {
+                "ttlInfo": {
+                    "TTL_test_0": 0,
+                    "TTL_test_1": 1
+                }
+            }
         }
     },
     "constant": {

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -160,7 +160,6 @@ class _TTLOverrideThread(QThread):
             response.raise_for_status()
         except requests.exceptions.RequestException:
             logger.exception("Failed to set the override of all TTL channels.")
-            return
 
 
 class _TTLLevelThread(QThread):
@@ -210,7 +209,6 @@ class _TTLLevelThread(QThread):
             response.raise_for_status()
         except requests.exceptions.RequestException:
             logger.exception("Failed to set the level of the target TTL channel.")
-            return
 
 
 class DeviceMonitorApp(qiwis.BaseApp):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -147,8 +147,7 @@ class _TTLOverrideThread(QThread):
         
         Sets the override of all TTL channels through the proxy server.
 
-        Since it just sends a POST query, it cannot be guaranteed that
-        the override will be applied immediately.
+        It cannot be guaranteed that the override will be applied immediately.
         """
         params = {"value": self.override}
         try:
@@ -196,8 +195,7 @@ class _TTLLevelThread(QThread):
         
         Sets the level of the target TTL channel through the proxy server.
 
-        Since it just sends a POST query, it cannot be guaranteed that
-        the level will be applied immediately.
+        It cannot be guaranteed that the level will be applied immediately.
         """
         params = {"channel": self.channel, "value": self.level}
         try:

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Dict, Optional, Tuple
 
-from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QGridLayout, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
 
 import qiwis
@@ -118,6 +118,25 @@ class TTLControllerFrame(QWidget):
             self.overrideButton.setText("Overriding")
         else:
             self.overrideButton.setText("Not Overriding")
+
+
+class _TTLOverrideThread(QThread):
+    """QThread for setting the override through the proxy server.
+    
+    Attributes:
+        ip: The proxy server IP address.
+        port: The proxy server PORT number.
+    """
+
+    def __init__(self, ip: str, port: int, parent: Optional[QObject] = None):
+        """Extended.
+        
+        Args:
+            ip, port: See the attributes section.
+        """
+        super().__init__(parent=parent)
+        self.ip = ip
+        self.port = port
 
 
 class DeviceMonitorApp(qiwis.BaseApp):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -1,10 +1,12 @@
 """App module for monitoring and controlling ARTIQ hardwares e.g., TTL, DDS, and DAC."""
 
 import logging
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
-from PyQt5.QtCore import pyqtSignal, pyqtSlot
+from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QGridLayout, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+
+import qiwis
 
 logger = logging.getLogger(__name__)
 
@@ -116,3 +118,27 @@ class TTLControllerFrame(QWidget):
             self.overrideButton.setText("Overriding")
         else:
             self.overrideButton.setText("Not Overriding")
+
+
+class DeviceMonitorApp(qiwis.BaseApp):
+    """App for monitoring and controlling ARTIQ hardwares e.g., TTL, DDS, and DAC.
+
+    Attributes:
+        proxy_id: The proxy server IP address.
+        proxy_port: The proxy server PORT number.
+    """
+
+    def __init__(self, name: str, ttlInfo: Dict[str, int], parent: Optional[QObject] = None):
+        """Extended.
+        
+        Args:
+            ttlInfo: See ttlInfo in TTLControllerFrame.__init__().
+        """
+        super().__init__(name, parent=parent)
+        self.proxy_ip = self.constants.proxy_ip  # pylint: disable=no-member
+        self.proxy_port = self.constants.proxy_port  # pylint: disable=no-member
+        self.ttlControllerFrame = TTLControllerFrame(ttlInfo)
+
+    def frames(self) -> Tuple[TTLControllerFrame]:
+        """Overridden."""
+        return (self.ttlControllerFrame,)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -5,7 +5,7 @@ import logging
 from typing import Dict, Optional, Tuple
 
 import requests
-from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import QObject, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QGridLayout, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
 
 import qiwis
@@ -238,8 +238,8 @@ class DeviceMonitorApp(qiwis.BaseApp):
         self.ttlControllerFrame = TTLControllerFrame(ttlInfo)
         # signal connection
         self.ttlControllerFrame.overrideChanged.connect(self._setOverride)
-        for name, channel in ttlInfo.items():
-            self.ttlControllerFrame.ttlWidgets[name].levelChanged.connect(
+        for name_, channel in ttlInfo.items():
+            self.ttlControllerFrame.ttlWidgets[name_].levelChanged.connect(
                 functools.partial(self._setLevel, channel)
             )
 

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -91,7 +91,7 @@ class TTLControllerFrame(QWidget):
         if numColumns <= 0:
             logger.error("The number of columns must be positive.")
             return
-        self.ttlWidgets = {}
+        self.ttlWidgets: Dict[str, TTLControllerWidget] = {}
         # widgets
         ttlWidgetLayout = QGridLayout()
         for idx, (name, channel) in enumerate(ttlInfo.items()):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -153,7 +153,7 @@ class _TTLOverrideThread(QThread):
         try:
             response = requests.post(
                 f"http://{self.ip}:{self.port}/ttl/override/",
-                params=params
+                params=params,
                 timeout=10
             )
             response.raise_for_status()
@@ -168,6 +168,8 @@ class DeviceMonitorApp(qiwis.BaseApp):
     Attributes:
         proxy_id: The proxy server IP address.
         proxy_port: The proxy server PORT number.
+        ttlControllerFrame: The frame that monitoring and controlling TTL channels.
+        ttlOverrideThread: The most recently executed _TTLOverrideThread instance.
     """
 
     def __init__(self, name: str, ttlInfo: Dict[str, int], parent: Optional[QObject] = None):
@@ -179,7 +181,14 @@ class DeviceMonitorApp(qiwis.BaseApp):
         super().__init__(name, parent=parent)
         self.proxy_ip = self.constants.proxy_ip  # pylint: disable=no-member
         self.proxy_port = self.constants.proxy_port  # pylint: disable=no-member
+        self.ttlOverrideThread: Optional[_TTLOverrideThread] = None
         self.ttlControllerFrame = TTLControllerFrame(ttlInfo)
+        # signal connection
+        self.ttlControllerFrame.overrideChanged.connect(self._setOverride)
+
+    @pyqtSlot(bool)
+    def _setOverride(self, override: bool):
+        print(override)
 
     def frames(self) -> Tuple[TTLControllerFrame]:
         """Overridden."""

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -220,6 +220,7 @@ class DeviceMonitorApp(qiwis.BaseApp):
         proxy_port: Proxy server PORT number.
         ttlControllerFrame: Frame that monitoring and controlling TTL channels.
         ttlOverrideThread: Most recently executed _TTLOverrideThread instance.
+        ttlLevelThread: Most recently executed _TTLLevelThread instance.
     """
 
     def __init__(self, name: str, ttlInfo: Dict[str, int], parent: Optional[QObject] = None):
@@ -232,14 +233,30 @@ class DeviceMonitorApp(qiwis.BaseApp):
         self.proxy_ip = self.constants.proxy_ip  # pylint: disable=no-member
         self.proxy_port = self.constants.proxy_port  # pylint: disable=no-member
         self.ttlOverrideThread: Optional[_TTLOverrideThread] = None
+        self.ttlLevelThread: Optional[_TTLLevelThread] = None
         self.ttlControllerFrame = TTLControllerFrame(ttlInfo)
         # signal connection
         self.ttlControllerFrame.overrideChanged.connect(self._setOverride)
 
     @pyqtSlot(bool)
     def _setOverride(self, override: bool):
+        """Sets the override of all TTL channels through _TTLOverrideThread.
+        
+        Args:
+            override: See _TTLOverrideThread attributes section.
+        """
         self.ttlOverrideThread = _TTLOverrideThread(override, self.proxy_ip, self.proxy_port)
         self.ttlOverrideThread.start()
+
+    @pyqtSlot(int, bool)
+    def _setLevel(self, channel: int, override: bool):
+        """Sets the level of the target TTL channel through _TTLLevelThread.
+        
+        Args:
+            channel, level: See _TTLLevelThread attributes section.
+        """
+        self.ttlLevelThread = _TTLLevelThread(override, channel, self.proxy_ip, self.proxy_port)
+        self.ttlLevelThread.start()
 
     def frames(self) -> Tuple[TTLControllerFrame]:
         """Overridden."""

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -188,7 +188,8 @@ class DeviceMonitorApp(qiwis.BaseApp):
 
     @pyqtSlot(bool)
     def _setOverride(self, override: bool):
-        print(override)
+        self.ttlOverrideThread = _TTLOverrideThread(override, self.proxy_ip, self.proxy_port)
+        self.ttlOverrideThread.start()
 
     def frames(self) -> Tuple[TTLControllerFrame]:
         """Overridden."""


### PR DESCRIPTION
This closes #159.

For details, please see #159.

I implemented a device monitor app, which controlls TTL channels, so now we can set the override and level manually.

### Result

#### config.json
```json
"monitor": {
  "module": "iquip.apps.monitor",
  "cls": "DeviceMonitorApp",
  "show": true,
  "pos": "right",
  "args": {
    "ttlInfo": {
      "TTL_test_0": 22,
      "TTL_test_1": 23
    }
  }
}
```

#### Screenshot
![image](https://github.com/snu-quiqcl/iquip/assets/76851886/c4c01b5c-4bf1-4074-a957-7692b71ec693)

As I tested through input mode TTL3 which is connected to output mode TTL23, these functions seem to run well😃
