### PR TITLE
Minimal `DataViewerApp` part 3: Data policy

### DIFF
--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -5,7 +5,9 @@ import dataclasses
 import enum
 import functools
 import logging
-from typing import List, Dict, Tuple, Sequence, Optional, Union
+from typing import (
+    Any, List, Dict, Tuple, Sequence, Iterable, Callable, Optional, Union,
+)
 
 import numpy as np
 import pyqtgraph as pg
@@ -673,3 +675,29 @@ class SimpleScanDataPolicy:
         self.dataset = dataset
         self.parameters = parameters
         self.units = units
+
+    def symbolize(self, axis: Iterable[int]) -> Tuple[List[np.ndarray], np.ndarray]:
+        """Returns the list of unique parameters and symbolized parameter ndarray.
+        
+        It first identifies the unique parameter values in the dataset.
+        These unique values are called "symbols", and hence the process "symbolize".
+        Specifically, symbols are defined by the indices in the unique parameter
+          array (params), i.e., the "inverse" of np.unique().
+        
+        Args:
+            axis: Indices of interested axes. The other axes will be reduced.
+              Note that the index starts from 0, i.e., the index in paremeters,
+              not the dataset column index.
+        
+        Returns:
+            The list of unique parameter values and the symbolized parameter ndarray,
+              where each row corresponds to a parameter, i.e., the shape is
+              (#parameters, #data).
+        """
+        params_list: List[np.ndarray] = []
+        symbols_list: List[np.ndarray] = []
+        for index in axis:
+            params, symbols = np.unique(self.dataset[:, index+1], return_inverse=True)
+            params_list.append(params)
+            symbols_list.append(symbols)
+        return params_list, np.vstack(symbols_list)

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -652,9 +652,9 @@ class SimpleScanDataPolicy:
     """Data structure policy for simple scan experiments.
     
     Attriutes:
-        dataset: The raw data array which should be a list of equal-length tuples.
-          Each tuple should be (data, param1, param2, ...) where params are the
-          scan parameter values, which may appear on the plot axes.
+        dataset: The raw data array which should be a 2d array, whose each row
+          should be (data, param1, param2, ...) where params are the scan
+          parameter values, which may appear on the plot axes.
         parameters: The parameter names in the corresponding order with dataset.
         units: The parameter units corresponding to parameters. A unit can be
           None which stands for unitless.
@@ -662,7 +662,7 @@ class SimpleScanDataPolicy:
 
     def __init__(
         self,
-        dataset: List[Tuple],
+        dataset: np.ndarray,
         parameters: Sequence[str],
         units: Sequence[Optional[str]],
     ):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -723,6 +723,14 @@ class SimpleScanDataPolicy:
         if not axis:
             return np.array(reduce(data)), []
         params_list, symbol_array = self.symbolize(axis)
+        axis_infos: List[AxisInfo] = []
+        for dataset_axis, params in zip(axis, params_list):
+            axis_info = AxisInfo(
+                name=self.parameters[dataset_axis],
+                values=params,
+                unit=self.units[dataset_axis],
+            )
+            axis_infos.append(axis_info)
         shape = tuple(map(len, params_list))
         sorted_indices = np.lexsort(np.flip(symbol_array, axis=0))
         sorted_symbols = symbol_array.T[sorted_indices]  # shape=(N, M)
@@ -734,17 +742,4 @@ class SimpleScanDataPolicy:
         reduced = np.zeros(shape)
         for index, data_group in zip(unique_symbols, data_groups):
             reduced[tuple(index)] = reduce(data_group)
-        # sort by the actual parameter
-        axis_infos: List[AxisInfo] = []
-        for reduced_axis, (dataset_axis, params) in enumerate(zip(axis, params_list)):
-            argsorted = np.argsort(params)
-            axis_info = AxisInfo(
-                name=self.parameters[dataset_axis],
-                values=params[argsorted],
-                unit=self.units[dataset_axis],
-            )
-            axis_infos.append(axis_info)
-            permutation = tuple(argsorted if i == reduced_axis else slice(None)
-                                for i in range(reduced.ndim))
-            reduced = reduced[permutation]
         return reduced, axis_infos

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -13,7 +13,7 @@ import qiwis
 from pyqtgraph.GraphicsScene import mouseEvents
 from PyQt5.QtWidgets import (
     QWidget, QLabel, QPushButton, QRadioButton, QButtonGroup, QStackedWidget,
-    QAbstractSpinBox, QSpinBox, QDoubleSpinBox, QGroupBox, QSplitter,
+    QAbstractSpinBox, QSpinBox, QDoubleSpinBox, QGroupBox, QSplitter, QLineEdit,
     QHBoxLayout, QVBoxLayout, QGridLayout,
 )
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject
@@ -278,6 +278,7 @@ class SourceWidget(QWidget):
     
     Attributes:
         buttonGroup: The radio button group for source selection.
+        datasetEdit: The line edit for entering dataset name.
         stack: The stacked widget for additional interface of each source option.
     """
 
@@ -300,6 +301,9 @@ class SourceWidget(QWidget):
             self.buttonGroup.addButton(button, id=buttonId)
             buttonGroupLayout.addWidget(button)
         self.buttonGroup.button(SourceWidget.ButtonId.REALTIME).setChecked(True)
+        self.datasetEdit = QLineEdit(self)
+        self.datasetEdit.setPlaceholderText("Dataset")
+        buttonGroupLayout.addWidget(self.datasetEdit)
         self.stack = QStackedWidget(self)
         for _Part in (_RealtimePart, _RemotePart):  # same order as in ButtonId
             self.stack.addWidget(_Part(self))

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -277,8 +277,8 @@ class SourceWidget(QWidget):
     """Widget for data source selection.
     
     Attributes:
-        buttonGroup: The radio button group for source selection.
         datasetEdit: The line edit for entering dataset name.
+        buttonGroup: The radio button group for source selection.
         stack: The stacked widget for additional interface of each source option.
     """
 
@@ -295,15 +295,15 @@ class SourceWidget(QWidget):
         """Extended."""
         super().__init__(parent=parent)
         buttonGroupLayout = QVBoxLayout()
+        self.datasetEdit = QLineEdit(self)
+        self.datasetEdit.setPlaceholderText("Dataset")
+        buttonGroupLayout.addWidget(self.datasetEdit)
         self.buttonGroup = QButtonGroup(self)
         for buttonId in SourceWidget.ButtonId:
             button = QRadioButton(buttonId.name.capitalize(), self)
             self.buttonGroup.addButton(button, id=buttonId)
             buttonGroupLayout.addWidget(button)
         self.buttonGroup.button(SourceWidget.ButtonId.REALTIME).setChecked(True)
-        self.datasetEdit = QLineEdit(self)
-        self.datasetEdit.setPlaceholderText("Dataset")
-        buttonGroupLayout.addWidget(self.datasetEdit)
         self.stack = QStackedWidget(self)
         for _Part in (_RealtimePart, _RemotePart):  # same order as in ButtonId
             self.stack.addWidget(_Part(self))

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -626,6 +626,10 @@ class DataViewerFrame(QSplitter):
         remotePart = self.sourceWidget.stack.widget(SourceWidget.ButtonId.REMOTE)
         remotePart.ridEditingFinished.connect(self.dataRequested)
 
+    def datasetName(self) -> str:
+        """Returns the current dataset name in the line edit."""
+        return self.sourceWidget.datasetEdit.text()
+
 
 class DataViewerApp(qiwis.BaseApp):
     """App for data visualization.

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -653,7 +653,7 @@ class SimpleScanDataPolicy:
     
     Attriutes:
         dataset: The raw data array which should be a 2d array, whose each row
-          should be (data, param1, param2, ...) where params are the scan
+          should be (data, param0, param1, ...) where params are the scan
           parameter values, which may appear on the plot axes.
         parameters: The parameter names in the corresponding order with dataset.
         units: The parameter units corresponding to parameters. A unit can be

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -639,12 +639,14 @@ class DataViewerApp(qiwis.BaseApp):
     
     Attributes:
         frame: DataViewerFrame instance.
+        policy: Data policy instance. None if there is currently no data.
     """
 
     def __init__(self, name: str, parent: Optional[QObject] = None):
         """Extended."""
         super().__init__(name, parent=parent)
         self.frame = DataViewerFrame()
+        self.policy: Optional[SimpleScanDataPolicy] = None
 
     def frames(self) -> Tuple[DataViewerFrame]:
         """Overridden."""

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -5,7 +5,7 @@ import dataclasses
 import enum
 import functools
 import logging
-from typing import Dict, Tuple, Sequence, Optional, Union
+from typing import List, Dict, Tuple, Sequence, Optional, Union
 
 import numpy as np
 import pyqtgraph as pg
@@ -646,3 +646,30 @@ class DataViewerApp(qiwis.BaseApp):
     def frames(self) -> Tuple[DataViewerFrame]:
         """Overridden."""
         return (self.frame,)
+
+
+class SimpleScanDataPolicy:
+    """Data structure policy for simple scan experiments.
+    
+    Attriutes:
+        dataset: The raw data array which should be a list of equal-length tuples.
+          Each tuple should be (data, param1, param2, ...) where params are the
+          scan parameter values, which may appear on the plot axes.
+        parameters: The parameter names in the corresponding order with dataset.
+        units: The parameter units corresponding to parameters. A unit can be
+          None which stands for unitless.
+    """
+
+    def __init__(
+        self,
+        dataset: List[Tuple],
+        parameters: Sequence[str],
+        units: Sequence[Optional[str]],
+    ):
+        """
+        Args:
+            See attribute section.
+        """
+        self.dataset = dataset
+        self.parameters = parameters
+        self.units = units


### PR DESCRIPTION
See #144 for details.

This PR introduces 2 things:
- Dataset name selection: enter the dataset name to show.
- `SimpleScanDataPolicy`: define the dataset format protocol.

Since `SimpleScanDataPolicy` is quite complicated, I separated the PR. I will make another PR for connecting all the signals to complete the `DataViewerApp`.

For testing the `SimpleScanDataPolicy`, the following script would be helpful:
```python
import iquip.apps.dataviewer as dv
import numpy as np

dataset = np.array((
    (0, 0e-6, 0),
    (1, 0e-6, 1),
    (0, 0e-6, 2),
    (2, 1e-6, 0),
    (3, 1e-6, 1),
    (3, 1e-6, 2),
    (5, 2e-6, 0),
    (5, 2e-6, 1),
    (4, 2e-6, 2),
    (10, 3e-6, 0),
    (9, 3e-6, 1),
    (8, 3e-6, 2),
))
parameters = ("time", "shot")
units = ("s", None)
policy = dv.SimpleScanDataPolicy(dataset, parameters, units)

for axis in ((), (0,), (1,), (0, 1), (1, 0)):
    print(f"\n{axis=}")
    print(policy.extract(axis, np.mean))
```
And I got the output:
```

axis=()
(array(4.16666667), [])

axis=(0,)
(array([0.33333333, 2.66666667, 4.66666667, 9.        ]), [AxisInfo(name='time', values=array([0.e+00, 1.e-06, 2.e-06, 3.e-06]), unit='s')])

axis=(1,)
(array([4.25, 4.5 , 3.75]), [AxisInfo(name='shot', values=array([0., 1., 2.]), unit=None)])

axis=(0, 1)
(array([[ 0.,  1.,  0.],
       [ 2.,  3.,  3.],
       [ 5.,  5.,  4.],
       [10.,  9.,  8.]]), [AxisInfo(name='time', values=array([0.e+00, 1.e-06, 2.e-06, 3.e-06]), unit='s'), AxisInfo(name='shot', values=array([0., 1., 2.]), unit=None)])

axis=(1, 0)
(array([[ 0.,  2.,  5., 10.],
       [ 1.,  3.,  5.,  9.],
       [ 0.,  3.,  4.,  8.]]), [AxisInfo(name='shot', values=array([0., 1., 2.]), unit=None), AxisInfo(name='time', values=array([0.e+00, 1.e-06, 2.e-06, 3.e-06]), unit='s')])
```