### PR TITLE
Single DDS controller: `DDSControllerWidget`

### DIFF
--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -2,7 +2,7 @@
 
 import functools
 import logging
-from typing import Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
@@ -410,6 +410,30 @@ class _DACVoltageThread(QThread):
             "Set the voltage of DAC %s CH %d to %fV. RID: %d",
             self.device, self.channel, self.voltage, rid
         )
+
+
+class DDSControllerWidget(QWidget):
+    """Single DDS channel controller widget."""
+
+    def __init__(
+        self,
+        name: str,
+        device: str,
+        channel: int,
+        frequencyInfo: Optional[Dict[str, Any]] = None,
+        parent: Optional[QWidget] = None
+    ):  # pylint: disable=too-many-arguments
+        """Extended.
+        
+        Args:
+            name: DDS channel name.
+            device: DDS device name.
+            channel: DDS channel number.
+            frequencyInfo: Dictionary with frequency info. Each key and its value are:
+              ndecimals: Number of decimals that can be set. (default=2)
+              min, max: Min/Maximum frequency that can be set. (default=0, 4e8)
+        """
+        super().__init__(parent=parent)
 
 
 class DeviceMonitorApp(qiwis.BaseApp):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -462,7 +462,11 @@ def profile_info(
 
 
 class DDSControllerWidget(QWidget):
-    """Single DDS channel controller widget."""
+    """Single DDS channel controller widget.
+    
+    Attributes:
+        switchButton: Button for turning on and off the TTL switch that controls the output of DDS.
+    """
 
     def __init__(
         self,
@@ -521,6 +525,9 @@ class DDSControllerWidget(QWidget):
         attenuatorLayout.addWidget(QLabel("attenuator:", self), alignment=Qt.AlignRight)
         attenuatorLayout.addWidget(attenuatorSpinbox)
         attenuatorLayout.addWidget(attenuatorButton, alignment=Qt.AlignRight)
+        # switch button
+        self.switchButton = QPushButton("OFF?", self)
+        self.switchButton.setCheckable(True)
         # layout
         infoLayout = QHBoxLayout()
         infoLayout.addWidget(nameLabel)
@@ -530,6 +537,7 @@ class DDSControllerWidget(QWidget):
         layout.addLayout(infoLayout)
         layout.addWidget(profileBox)
         layout.addWidget(attenuatorBox)
+        layout.addWidget(self.switchButton)
 
     def spinBoxWithInfo(self, info: Optional[Dict[str, Any]]) -> QDoubleSpinBox:
         """Returns a spinbox with the given info.

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -427,7 +427,8 @@ def profile_info(
 
     Returns:
         The dictionary with three keys; frequency, amplitude, and phase.
-          Its value is the corresponding info dictionary.
+          Its value is the corresponding info dictionary with the following keys:
+          ndecimals, min, max, unit, and step.
     """
     # frequency info
     if frequency_info is None:
@@ -505,12 +506,7 @@ class DDSControllerWidget(QWidget):
         profileLayout = QHBoxLayout(profileBox)
         for name_ in ("frequency", "amplitude", "phase"):
             info = profileInfo[name_]
-            spinbox = QDoubleSpinBox(self)
-            spinbox.setSuffix(info["unit"])
-            spinbox.setMinimum(info["min"])
-            spinbox.setMaximum(info["max"])
-            spinbox.setDecimals(info["ndecimals"])
-            spinbox.setSingleStep(info["step"])
+            spinbox = self.spinBoxWithInfo(info)
             profileLayout.addWidget(QLabel(f"{name_}:", self), alignment=Qt.AlignRight)
             profileLayout.addWidget(spinbox)
         profileButton = QPushButton("Set")
@@ -538,6 +534,20 @@ class DDSControllerWidget(QWidget):
         layout.addLayout(infoLayout)
         layout.addWidget(profileBox)
         layout.addWidget(attenuatorBox)
+
+    def spinBoxWithInfo(self, info: Optional[Dict[str, Any]]) -> QDoubleSpinBox:
+        """Returns a spinbox with the given info.
+        
+        Args:
+            See *Info arguments in self.__init__().
+        """
+        spinbox = QDoubleSpinBox(self)
+        spinbox.setSuffix(info["unit"])
+        spinbox.setMinimum(info["min"])
+        spinbox.setMaximum(info["max"])
+        spinbox.setDecimals(info["ndecimals"])
+        spinbox.setSingleStep(info["step"])
+        return spinbox
 
 
 class DeviceMonitorApp(qiwis.BaseApp):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -433,31 +433,31 @@ def profile_info(
     # frequency info
     if frequency_info is None:
         frequency_info = {}
-    frequency_info["ndecimals"] = frequency_info.get("ndecimals", 2)
-    frequency_info["min"] = frequency_info.get("min", 0)
-    frequency_info["max"] = frequency_info.get("max", 4e8)
-    unit = frequency_info.get("unit", "Hz")
+    frequency_info.setdefault("ndecimals", 2)
+    frequency_info.setdefault("min", 0)
+    frequency_info.setdefault("max", 4e8)
+    unit = frequency_info.setdefault("unit", "Hz")
     if unit not in ["Hz", "kHz", "MHz"]:
-        logger.warning("The unit of frequency, %s is invalid.", unit)
-        unit = "Hz"
-    frequency_info["unit"] = unit
-    frequency_info["step"] = frequency_info.get("step", 1)
+        frequency_info["unit"] = "Hz"
+        logger.warning("The unit of frequency, %s is invalid."
+                       "Hence, the unit is set to Hz.", unit)
+    frequency_info.setdefault("step", 1)
     # amplitude info
     if amplitude_info is None:
         amplitude_info = {}
-    amplitude_info["ndecimals"] = amplitude_info.get("ndecimals", 2)
+    amplitude_info.setdefault("ndecimals", 2)
     amplitude_info["min"] = 0
     amplitude_info["max"] = 1
     amplitude_info["unit"] = ""
-    amplitude_info["step"] = amplitude_info.get("step", 0.01)
+    amplitude_info.setdefault("step", 0.01)
     # phase info
     if phase_info is None:
         phase_info = {}
-    phase_info["ndecimals"] = phase_info.get("ndecimals", 2)
+    phase_info.setdefault("ndecimals", 2)
     phase_info["min"] = 0
     phase_info["max"] = 1
     phase_info["unit"] = ""
-    phase_info["step"] = phase_info.get("step", 0.01)
+    phase_info.setdefault("step", 0.01)
     return {"frequency": frequency_info, "amplitude": amplitude_info, "phase": phase_info}
 
 

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -415,9 +415,9 @@ class _DACVoltageThread(QThread):
 
 def profile_info(
     frequency_info: Optional[Dict[str, Any]] = None,
-    amplitudeInfo: Optional[Dict[str, Any]] = None,
-    phaseInfo: Optional[Dict[str, Any]] = None
-):
+    amplitude_info: Optional[Dict[str, Any]] = None,
+    phase_info: Optional[Dict[str, Any]] = None
+) -> Dict[str, Dict[str, Any]]:
     """Returns the profile info.
 
     It completes the profile info by adding default values.
@@ -442,24 +442,22 @@ def profile_info(
     frequency_info["unit"] = unit
     frequency_info["step"] = frequency_info.get("step", 1)
     # amplitude info
-    if amplitudeInfo is None:
-        amplitudeInfo = {}
-    amplitudeInfo["ndecimals"] = amplitudeInfo.get("ndecimals", 2)
-    amplitudeInfo["min"] = 0
-    amplitudeInfo["max"] = 1
-    amplitudeInfo["unit"] = ""
-    amplitudeInfo["step"] = amplitudeInfo.get("step", 0.01)
+    if amplitude_info is None:
+        amplitude_info = {}
+    amplitude_info["ndecimals"] = amplitude_info.get("ndecimals", 2)
+    amplitude_info["min"] = 0
+    amplitude_info["max"] = 1
+    amplitude_info["unit"] = ""
+    amplitude_info["step"] = amplitude_info.get("step", 0.01)
     # phase info
-    if phaseInfo is None:
-        phaseInfo = {}
-    phaseInfo["ndecimals"] = phaseInfo.get("ndecimals", 2)
-    phaseInfo["min"] = 0
-    phaseInfo["max"] = 1
-    phaseInfo["unit"] = ""
-    phaseInfo["step"] = phaseInfo.get("step", 0.01)
-    # profile info
-    info = {"frequency": frequency_info, "amplitude": amplitudeInfo, "phase": phaseInfo}
-    return info
+    if phase_info is None:
+        phase_info = {}
+    phase_info["ndecimals"] = phase_info.get("ndecimals", 2)
+    phase_info["min"] = 0
+    phase_info["max"] = 1
+    phase_info["unit"] = ""
+    phase_info["step"] = phase_info.get("step", 0.01)
+    return {"frequency": frequency_info, "amplitude": amplitude_info, "phase": phase_info}
 
 
 class DDSControllerWidget(QWidget):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -465,13 +465,14 @@ class DDSControllerWidget(QWidget):
         """
         super().__init__(parent=parent)
         profileInfo = profile_info(frequencyInfo)
-        # widgets
+        # info widgets
         nameLabel = QLabel(name, self)
         nameLabel.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
         deviceLabel = QLabel(device, self)
         deviceLabel.setAlignment(Qt.AlignCenter)
         channelLabel = QLabel(f"CH {channel}", self)
         channelLabel.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        # profile widgets
         profileBox = QGroupBox("Profile", self)
         profileLayout = QHBoxLayout(profileBox)
         for name_ in ("frequency",):
@@ -485,6 +486,20 @@ class DDSControllerWidget(QWidget):
             profileLayout.addWidget(spinbox)
         profileButton = QPushButton("Set")
         profileLayout.addWidget(profileButton, alignment=Qt.AlignRight)
+        # attenuator widgets
+        attenuatorBox = QGroupBox("Attenuator", self)
+        attenuatorLayout = QHBoxLayout(attenuatorBox)
+        spinbox = QDoubleSpinBox(self)
+        spinbox.setPrefix("-")
+        spinbox.setSuffix("dB")
+        spinbox.setMinimum(0)
+        spinbox.setMaximum(31.5)
+        spinbox.setDecimals(1)
+        spinbox.setSingleStep(0.5)
+        attenuatorButton = QPushButton("Set")
+        attenuatorLayout.addWidget(QLabel("attenuator:", self))
+        attenuatorLayout.addWidget(spinbox)
+        attenuatorLayout.addWidget(attenuatorButton, alignment=Qt.AlignRight)
         # layout
         infoLayout = QHBoxLayout()
         infoLayout.addWidget(nameLabel)
@@ -493,6 +508,7 @@ class DDSControllerWidget(QWidget):
         layout = QVBoxLayout(self)
         layout.addLayout(infoLayout)
         layout.addWidget(profileBox)
+        layout.addWidget(attenuatorBox)
 
 
 class DeviceMonitorApp(qiwis.BaseApp):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -434,6 +434,20 @@ class DDSControllerWidget(QWidget):
               min, max: Min/Maximum frequency that can be set. (default=0, 4e8)
         """
         super().__init__(parent=parent)
+        # widgets
+        nameLabel = QLabel(name, self)
+        nameLabel.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        deviceLabel = QLabel(device, self)
+        deviceLabel.setAlignment(Qt.AlignCenter)
+        channelLabel = QLabel(f"CH {channel}", self)
+        channelLabel.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        # layout
+        infoLayout = QHBoxLayout()
+        infoLayout.addWidget(nameLabel)
+        infoLayout.addWidget(deviceLabel)
+        infoLayout.addWidget(channelLabel)
+        layout = QVBoxLayout(self)
+        layout.addLayout(infoLayout)
 
 
 class DeviceMonitorApp(qiwis.BaseApp):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -466,7 +466,12 @@ class DDSControllerWidget(QWidget):
     
     Attributes:
         switchButton: Button for turning on and off the TTL switch that controls the output of DDS.
+
+    Signals:
+        switchClicked(on): If on is True, the switchButton is currently checked.
     """
+
+    switchClicked = pyqtSignal(bool)
 
     def __init__(
         self,
@@ -538,6 +543,8 @@ class DDSControllerWidget(QWidget):
         layout.addWidget(profileBox)
         layout.addWidget(attenuatorBox)
         layout.addWidget(self.switchButton)
+        # signal connection
+        self.switchButton.clicked.connect(self._setSwitchButtonText)
 
     def spinBoxWithInfo(self, info: Optional[Dict[str, Any]]) -> QDoubleSpinBox:
         """Returns a spinbox with the given info.
@@ -552,6 +559,19 @@ class DDSControllerWidget(QWidget):
         spinbox.setDecimals(info["ndecimals"])
         spinbox.setSingleStep(info["step"])
         return spinbox
+
+    @pyqtSlot(bool)
+    def _setSwitchButtonText(self, on: bool):
+        """Sets the switchButton text.
+
+        Args:
+            on: Whether the switchButton is now checked or not.
+        """
+        if on:
+            self.switchButton.setText("ON")
+        else:
+            self.switchButton.setText("OFF")
+        self.switchClicked.emit(on)
 
 
 class DeviceMonitorApp(qiwis.BaseApp):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -41,7 +41,7 @@ class TTLControllerWidget(QWidget):
         nameLabel.setAlignment(Qt.AlignLeft)
         deviceLabel = QLabel(device, self)
         deviceLabel.setAlignment(Qt.AlignRight)
-        self.button = QPushButton("OFF?")
+        self.button = QPushButton("OFF?", self)
         self.button.setCheckable(True)
         # layout
         infoLayout = QHBoxLayout()

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -424,6 +424,7 @@ def profile_info(
 
     Args:
         See DDSControllerWidget.__init__().
+        Note that this function may change the argument dictionaries.
 
     Returns:
         The dictionary with three keys; frequency, amplitude, and phase.

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -7,8 +7,8 @@ from typing import Any, Dict, Optional, Tuple, Union
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
-    QDoubleSpinBox, QGridLayout, QGroupBox, QHBoxLayout, QLabel,
-    QPushButton, QSlider, QVBoxLayout, QWidget
+    QCheckBox, QDoubleSpinBox, QGridLayout, QGroupBox, QHBoxLayout,
+    QLabel, QPushButton, QSlider, QVBoxLayout, QWidget
 )
 
 import qiwis
@@ -470,13 +470,15 @@ class DDSControllerWidget(QWidget):
         switchButton: Button for turning on and off the TTL switch that controls the output of DDS.
 
     Signals:
-        profileSet(frequency, amplitude, phase): Current profile setting is set to the arguments.
+        profileSet(frequency, amplitude, phase, switching):
+          The default profile setting is set to frequency, amplitude, and phase.
+          If switching is True, the current DDS profile is set to the default profile.
         attenuationSet(attenuation): Current attenuation setting is set to attenuation.
         switchClicked(on): If on is True, the switchButton is currently checked.
     """
 
     switchClicked = pyqtSignal(bool)
-    profileSet = pyqtSignal(float, float, float)
+    profileSet = pyqtSignal(float, float, float, bool)
     attenuationSet = pyqtSignal(float)
 
     def __init__(
@@ -526,6 +528,10 @@ class DDSControllerWidget(QWidget):
             self.profileBoxes[name_] = spinbox
             profileLayout.addWidget(QLabel(f"{name_}:", self), alignment=Qt.AlignRight)
             profileLayout.addWidget(spinbox)
+        switchingCheckbox = QCheckBox("Switch to this profile", self)
+        switchingCheckbox.setChecked(True)
+        self.profileBoxes["switching"] = switchingCheckbox
+        profileLayout.addWidget(switchingCheckbox, alignment=Qt.AlignRight)
         profileButton = QPushButton("Set")
         profileLayout.addWidget(profileButton, alignment=Qt.AlignRight)
         # attenuation widgets
@@ -574,7 +580,8 @@ class DDSControllerWidget(QWidget):
     def _profileButtonClicked(self):
         """The profileButton is clicked.
         
-        The profileSet signal is emitted with the current frequency, amplitude, and phase.
+        The profileSet signal is emitted with the current frequency, amplitude, phase,
+        and switching.
         """
         frequencySpinbox = self.profileBoxes["frequency"]
         unit = {
@@ -585,7 +592,8 @@ class DDSControllerWidget(QWidget):
         frequency = frequencySpinbox.value() * unit
         amplitude = self.profileBoxes["amplitude"].value()
         phase = self.profileBoxes["phase"].value()
-        self.profileSet.emit(frequency, amplitude, phase)
+        switching = self.profileBoxes["switching"].isChecked()
+        self.profileSet.emit(frequency, amplitude, phase, switching)
 
     @pyqtSlot()
     def _attenuationButtonClicked(self):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -440,6 +440,7 @@ def profile_info(
         logger.warning("The unit of frequency, %s is invalid.", unit)
         unit = "Hz"
     frequency_info["unit"] = unit
+    frequency_info["step"] = frequency_info.get("step", 1)
     # amplitude info
     if amplitudeInfo is None:
         amplitudeInfo = {}
@@ -447,6 +448,7 @@ def profile_info(
     amplitudeInfo["min"] = 0
     amplitudeInfo["max"] = 1
     amplitudeInfo["unit"] = ""
+    amplitudeInfo["step"] = amplitudeInfo.get("step", 0.01)
     # phase info
     if phaseInfo is None:
         phaseInfo = {}
@@ -454,6 +456,7 @@ def profile_info(
     phaseInfo["min"] = 0
     phaseInfo["max"] = 1
     phaseInfo["unit"] = ""
+    phaseInfo["step"] = phaseInfo.get("step", 0.01)
     # profile info
     info = {"frequency": frequency_info, "amplitude": amplitudeInfo, "phase": phaseInfo}
     return info
@@ -481,11 +484,14 @@ class DDSControllerWidget(QWidget):
             frequencyInfo: Dictionary with frequency info. Each key and its value are:
               ndecimals: Number of decimals that can be set. (default=2)
               min, max: Min/Maximum frequency that can be set. (default=0, 4e8)
+              step: Step increased/decreased through spinbox arrows. (default=1)
               unit: Unit of frequency. It should be one of "Hz", "kHz", and "MHz". (default="Hz")
             amplitudeInfo: Dictionary with amplitude info. Each key and its value are:
               ndecimals: Number of decimals that can be set. (default=2)
+              step: Step increased/decreased through spinbox arrows. (default=0.01)
             phaseInfo: Dictionary with phase info. Each key and its value are:
               ndecimals: Number of decimals that can be set. (default=2)
+              step: Step increased/decreased through spinbox arrows. (default=0.01)
         """
         super().__init__(parent=parent)
         profileInfo = profile_info(frequencyInfo, amplitudeInfo, phaseInfo)
@@ -499,14 +505,15 @@ class DDSControllerWidget(QWidget):
         # profile widgets
         profileBox = QGroupBox("Profile", self)
         profileLayout = QHBoxLayout(profileBox)
-        for name_ in ("frequency",):
+        for name_ in ("frequency", "amplitude", "phase"):
             info = profileInfo[name_]
             spinbox = QDoubleSpinBox(self)
             spinbox.setSuffix(info["unit"])
             spinbox.setMinimum(info["min"])
             spinbox.setMaximum(info["max"])
             spinbox.setDecimals(info["ndecimals"])
-            profileLayout.addWidget(QLabel(f"{name_}:", self))
+            spinbox.setSingleStep(info["step"])
+            profileLayout.addWidget(QLabel(f"{name_}:", self), alignment=Qt.AlignRight)
             profileLayout.addWidget(spinbox)
         profileButton = QPushButton("Set")
         profileLayout.addWidget(profileButton, alignment=Qt.AlignRight)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -490,7 +490,7 @@ class DDSControllerWidget(QWidget):
         amplitudeInfo: Optional[Dict[str, Any]] = None,
         phaseInfo: Optional[Dict[str, Any]] = None,
         parent: Optional[QWidget] = None
-    ):  # pylint: disable=too-many-arguments
+    ):  # pylint: disable=too-many-arguments, too-many-locals
         """Extended.
         
         Args:

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -533,7 +533,7 @@ class DDSControllerWidget(QWidget):
         switchingCheckbox.setChecked(True)
         self.profileBoxes["switching"] = switchingCheckbox
         profileLayout.addWidget(switchingCheckbox, alignment=Qt.AlignRight)
-        profileButton = QPushButton("Set")
+        profileButton = QPushButton("Set", self)
         profileLayout.addWidget(profileButton, alignment=Qt.AlignRight)
         # attenuation widgets
         attenuationBox = QGroupBox("attenuation", self)
@@ -541,7 +541,7 @@ class DDSControllerWidget(QWidget):
         attenuationInfo = {"ndecimals": 1, "min": 0, "max": 31.5, "step": 0.5, "unit": "dB"}
         self.attenuationSpinbox = self.spinBoxWithInfo(attenuationInfo)
         self.attenuationSpinbox.setPrefix("-")
-        attenuationButton = QPushButton("Set")
+        attenuationButton = QPushButton("Set", self)
         attenuationLayout.addWidget(QLabel("attenuation:", self), alignment=Qt.AlignRight)
         attenuationLayout.addWidget(self.attenuationSpinbox)
         attenuationLayout.addWidget(attenuationButton, alignment=Qt.AlignRight)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -472,7 +472,7 @@ class DDSControllerWidget(QWidget):
 
     Signals:
         profileSet(frequency, amplitude, phase, switching):
-          The default profile setting is set to frequency, amplitude, and phase.
+          The default profile setting is set to frequency in Hz, amplitude, and phase.
           If switching is True, the current DDS profile is set to the default profile.
         attenuationSet(attenuation): Current attenuation setting is set to attenuation.
         switchClicked(on): If on is True, the switchButton is currently checked.

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -568,19 +568,6 @@ class DDSControllerWidget(QWidget):
         spinbox.setSingleStep(info["step"])
         return spinbox
 
-    @pyqtSlot(bool)
-    def _setSwitchButtonText(self, on: bool):
-        """Sets the switchButton text.
-
-        Args:
-            on: Whether the switchButton is now checked or not.
-        """
-        if on:
-            self.switchButton.setText("ON")
-        else:
-            self.switchButton.setText("OFF")
-        self.switchClicked.emit(on)
-
     @pyqtSlot()
     def _profileButtonClicked(self):
         """The profileButton is clicked.
@@ -597,6 +584,19 @@ class DDSControllerWidget(QWidget):
         amplitude = self.profileBoxes["amplitude"].value()
         phase = self.profileBoxes["phase"].value()
         self.profileSet.emit(frequency, amplitude, phase)
+
+    @pyqtSlot(bool)
+    def _setSwitchButtonText(self, on: bool):
+        """Sets the switchButton text.
+
+        Args:
+            on: Whether the switchButton is now checked or not.
+        """
+        if on:
+            self.switchButton.setText("ON")
+        else:
+            self.switchButton.setText("OFF")
+        self.switchClicked.emit(on)
 
 
 class DeviceMonitorApp(qiwis.BaseApp):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -472,6 +472,19 @@ class DDSControllerWidget(QWidget):
         deviceLabel.setAlignment(Qt.AlignCenter)
         channelLabel = QLabel(f"CH {channel}", self)
         channelLabel.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        profileBox = QGroupBox("Profile", self)
+        profileLayout = QHBoxLayout(profileBox)
+        for name_ in ("frequency",):
+            info = profileInfo[name_]
+            spinbox = QDoubleSpinBox(self)
+            spinbox.setSuffix(info["unit"])
+            spinbox.setMinimum(info["min"])
+            spinbox.setMaximum(info["max"])
+            spinbox.setDecimals(info["ndecimals"])
+            profileLayout.addWidget(QLabel(f"{name_}:", self))
+            profileLayout.addWidget(spinbox)
+        profileButton = QPushButton("Set")
+        profileLayout.addWidget(profileButton, alignment=Qt.AlignRight)
         # layout
         infoLayout = QHBoxLayout()
         infoLayout.addWidget(nameLabel)
@@ -479,6 +492,7 @@ class DDSControllerWidget(QWidget):
         infoLayout.addWidget(channelLabel)
         layout = QVBoxLayout(self)
         layout.addLayout(infoLayout)
+        layout.addWidget(profileBox)
 
 
 class DeviceMonitorApp(qiwis.BaseApp):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -465,7 +465,8 @@ class DDSControllerWidget(QWidget):
     """Single DDS channel controller widget.
     
     Attributes:
-        profileBoxes: Dictionary with frequency, amplitude, phase spinbox, and switching checkbox.
+        profileBoxes: Dictionary with frequency, amplitude, phase spin box, and switching check box.
+        attenuationSpinbox: Spin box for setting the attenuation.
         switchButton: Button for turning on and off the TTL switch that controls the output of DDS.
 
     Signals:
@@ -531,11 +532,11 @@ class DDSControllerWidget(QWidget):
         attenuationBox = QGroupBox("attenuation", self)
         attenuationLayout = QHBoxLayout(attenuationBox)
         attenuationInfo = {"ndecimals": 1, "min": 0, "max": 31.5, "step": 0.5, "unit": "dB"}
-        attenuationSpinbox = self.spinBoxWithInfo(attenuationInfo)
-        attenuationSpinbox.setPrefix("-")
+        self.attenuationSpinbox = self.spinBoxWithInfo(attenuationInfo)
+        self.attenuationSpinbox.setPrefix("-")
         attenuationButton = QPushButton("Set")
         attenuationLayout.addWidget(QLabel("attenuation:", self), alignment=Qt.AlignRight)
-        attenuationLayout.addWidget(attenuationSpinbox)
+        attenuationLayout.addWidget(self.attenuationSpinbox)
         attenuationLayout.addWidget(attenuationButton, alignment=Qt.AlignRight)
         # switch button
         self.switchButton = QPushButton("OFF?", self)
@@ -552,6 +553,7 @@ class DDSControllerWidget(QWidget):
         layout.addWidget(self.switchButton)
         # signal connection
         profileButton.clicked.connect(self._profileButtonClicked)
+        attenuationButton.clicked.connect(self._attenuationButtonClicked)
         self.switchButton.clicked.connect(self._setSwitchButtonText)
 
     def spinBoxWithInfo(self, info: Optional[Dict[str, Any]]) -> QDoubleSpinBox:
@@ -584,6 +586,15 @@ class DDSControllerWidget(QWidget):
         amplitude = self.profileBoxes["amplitude"].value()
         phase = self.profileBoxes["phase"].value()
         self.profileSet.emit(frequency, amplitude, phase)
+
+    @pyqtSlot()
+    def _attenuationButtonClicked(self):
+        """The attenuationButton is clicked.
+        
+        The attenuationSet signal is emitted with the current attenuation.
+        """
+        attenuation = self.attenuationSpinbox.value()
+        self.attenuationSet.emit(attenuation)
 
     @pyqtSlot(bool)
     def _setSwitchButtonText(self, on: bool):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -479,9 +479,9 @@ class DDSControllerWidget(QWidget):
         switchClicked(on): If on is True, the switchButton is currently checked.
     """
 
-    switchClicked = pyqtSignal(bool)
     profileSet = pyqtSignal(float, float, float, bool)
     attenuationSet = pyqtSignal(float)
+    switchClicked = pyqtSignal(bool)
 
     def __init__(
         self,

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -440,8 +440,7 @@ def profile_info(
     unit = frequency_info.setdefault("unit", "Hz")
     if unit not in ["Hz", "kHz", "MHz"]:
         frequency_info["unit"] = "Hz"
-        logger.warning("The unit of frequency, %s is invalid."
-                       "Hence, the unit is set to Hz.", unit)
+        logger.warning("Invalid frequency unit: %s (set to Hz).", unit)
     frequency_info.setdefault("step", 1)
     # amplitude info
     if amplitude_info is None:

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -466,7 +466,7 @@ class DDSControllerWidget(QWidget):
     """Single DDS channel controller widget.
     
     Attributes:
-        profileBoxes: Dictionary with frequency, amplitude, phase spin box, and switching check box.
+        profileWidgets: Dictionary with frequency, amplitude, phase spin box, and switching check box.
         attenuationSpinbox: Spin box for setting the attenuation.
         switchButton: Button for turning on and off the TTL switch that controls the output of DDS.
 
@@ -520,18 +520,18 @@ class DDSControllerWidget(QWidget):
         channelLabel = QLabel(f"CH {channel}", self)
         channelLabel.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
         # profile widgets
-        self.profileBoxes: Dict[str, Union[QDoubleSpinBox, QCheckBox]] = {}
-        profileBox = QGroupBox("Profile", self)
-        profileLayout = QHBoxLayout(profileBox)
+        self.profileWidgets: Dict[str, Union[QDoubleSpinBox, QCheckBox]] = {}
+        profileGroupbox = QGroupBox("Profile", self)
+        profileLayout = QHBoxLayout(profileGroupbox)
         for name_ in ("frequency", "amplitude", "phase"):
             info = profileInfo[name_]
             spinbox = self.spinBoxWithInfo(info)
-            self.profileBoxes[name_] = spinbox
+            self.profileWidgets[name_] = spinbox
             profileLayout.addWidget(QLabel(f"{name_}:", self), alignment=Qt.AlignRight)
             profileLayout.addWidget(spinbox)
         switchingCheckbox = QCheckBox("Switch to this profile", self)
         switchingCheckbox.setChecked(True)
-        self.profileBoxes["switching"] = switchingCheckbox
+        self.profileWidgets["switching"] = switchingCheckbox
         profileLayout.addWidget(switchingCheckbox, alignment=Qt.AlignRight)
         profileButton = QPushButton("Set", self)
         profileLayout.addWidget(profileButton, alignment=Qt.AlignRight)
@@ -555,7 +555,7 @@ class DDSControllerWidget(QWidget):
         infoLayout.addWidget(channelLabel)
         layout = QVBoxLayout(self)
         layout.addLayout(infoLayout)
-        layout.addWidget(profileBox)
+        layout.addWidget(profileGroupbox)
         layout.addWidget(attenuationBox)
         layout.addWidget(self.switchButton)
         # signal connection
@@ -584,16 +584,16 @@ class DDSControllerWidget(QWidget):
         The profileSet signal is emitted with the current frequency, amplitude, phase,
         and switching.
         """
-        frequencySpinbox = self.profileBoxes["frequency"]
+        frequencySpinbox = self.profileWidgets["frequency"]
         unit = {
             "Hz": 1,
             "kHz": 1e3,
             "MHz": 1e6
         }[frequencySpinbox.suffix()]
         frequency = frequencySpinbox.value() * unit
-        amplitude = self.profileBoxes["amplitude"].value()
-        phase = self.profileBoxes["phase"].value()
-        switching = self.profileBoxes["switching"].isChecked()
+        amplitude = self.profileWidgets["amplitude"].value()
+        phase = self.profileWidgets["phase"].value()
+        switching = self.profileWidgets["switching"].isChecked()
         self.profileSet.emit(frequency, amplitude, phase, switching)
 
     @pyqtSlot()

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -514,8 +514,8 @@ class DDSControllerWidget(QWidget):
         # attenuator widgets
         attenuatorBox = QGroupBox("Attenuator", self)
         attenuatorLayout = QHBoxLayout(attenuatorBox)
-        attenuatorinfo = {"ndecimals": 1, "min": 0, "max": 31.5, "step": 0.5, "unit": "dB"}
-        attenuatorSpinbox = self.spinBoxWithInfo(attenuatorinfo)
+        attenuatorInfo = {"ndecimals": 1, "min": 0, "max": 31.5, "step": 0.5, "unit": "dB"}
+        attenuatorSpinbox = self.spinBoxWithInfo(attenuatorInfo)
         attenuatorSpinbox.setPrefix("-")
         attenuatorButton = QPushButton("Set")
         attenuatorLayout.addWidget(QLabel("attenuator:", self), alignment=Qt.AlignRight)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -435,7 +435,7 @@ def profile_info(
     if frequency_info is None:
         frequency_info = {}
     frequency_info.setdefault("ndecimals", 2)
-    frequency_info.setdefault("min", 0)
+    frequency_info.setdefault("min", 1e6)
     frequency_info.setdefault("max", 4e8)
     unit = frequency_info.setdefault("unit", "Hz")
     if unit not in ["Hz", "kHz", "MHz"]:
@@ -501,7 +501,7 @@ class DDSControllerWidget(QWidget):
             channel: DDS channel number.
             frequencyInfo: Dictionary with frequency info. Each key and its value are:
               ndecimals: Number of decimals that can be set. (default=2)
-              min, max: Min/Maximum frequency that can be set. (default=0, 4e8)
+              min, max: Min/Maximum frequency that can be set. (default=1e6, 4e8)
               step: Step increased/decreased through spinbox arrows. (default=1)
               unit: Unit of frequency. It should be one of "Hz", "kHz", and "MHz". (default="Hz")
             amplitudeInfo: Dictionary with amplitude info. Each key and its value are:

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -7,7 +7,8 @@ from typing import Any, Dict, Optional, Tuple, Union
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
-    QDoubleSpinBox, QGridLayout, QHBoxLayout, QLabel, QPushButton, QSlider, QVBoxLayout, QWidget
+    QDoubleSpinBox, QGridLayout, QGroupBox, QHBoxLayout, QLabel,
+    QPushButton, QSlider, QVBoxLayout, QWidget
 )
 
 import qiwis
@@ -412,6 +413,34 @@ class _DACVoltageThread(QThread):
         )
 
 
+def profile_info(frequency_info: Optional[Dict[str, Any]] = None):
+    """Returns the profile info.
+
+    It completes the profile info by adding default values.
+
+    Args:
+        See DDSControllerWidget.__init__().
+
+    Returns:
+        The dictionary with three keys; frequency, amplitude, and phase.
+          Its value is the corresponding info dictionary.
+    """
+    # frequency info
+    if frequency_info is None:
+        frequency_info = {}
+    frequency_info["ndecimals"] = frequency_info.get("ndecimals", 2)
+    frequency_info["min"] = frequency_info.get("min", 0)
+    frequency_info["max"] = frequency_info.get("max", 4e8)
+    unit = frequency_info.get("unit", "Hz")
+    if unit not in ["Hz", "kHz", "MHz"]:
+        logger.warning("The unit of frequency, %s is invalid.", unit)
+        unit = "Hz"
+    frequency_info["unit"] = unit
+    # profile info
+    info = {"frequency": frequency_info}
+    return info
+
+
 class DDSControllerWidget(QWidget):
     """Single DDS channel controller widget."""
 
@@ -432,8 +461,10 @@ class DDSControllerWidget(QWidget):
             frequencyInfo: Dictionary with frequency info. Each key and its value are:
               ndecimals: Number of decimals that can be set. (default=2)
               min, max: Min/Maximum frequency that can be set. (default=0, 4e8)
+              unit: Unit of frequency. It should be one of "Hz", "kHz", and "MHz". (default="Hz")
         """
         super().__init__(parent=parent)
+        profileInfo = profile_info(frequencyInfo)
         # widgets
         nameLabel = QLabel(name, self)
         nameLabel.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -2,7 +2,7 @@
 
 import functools
 import logging
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Mapping, Optional, Tuple, Union
 
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
@@ -520,7 +520,7 @@ class DDSControllerWidget(QWidget):
         channelLabel = QLabel(f"CH {channel}", self)
         channelLabel.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
         # profile widgets
-        self.profileBoxes = {}
+        self.profileBoxes: Dict[str, Union[QDoubleSpinBox, QCheckBox]] = {}
         profileBox = QGroupBox("Profile", self)
         profileLayout = QHBoxLayout(profileBox)
         for name_ in ("frequency", "amplitude", "phase"):
@@ -563,7 +563,7 @@ class DDSControllerWidget(QWidget):
         attenuationButton.clicked.connect(self._attenuationButtonClicked)
         self.switchButton.clicked.connect(self._setSwitchButtonText)
 
-    def spinBoxWithInfo(self, info: Optional[Dict[str, Any]]) -> QDoubleSpinBox:
+    def spinBoxWithInfo(self, info: Mapping[str, Any]) -> QDoubleSpinBox:
         """Returns a spinbox with the given info.
         
         Args:

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -468,10 +468,14 @@ class DDSControllerWidget(QWidget):
         switchButton: Button for turning on and off the TTL switch that controls the output of DDS.
 
     Signals:
+        profileSet(frequency, amplitude, phase): Current profile setting is set to the arguments.
+        attenuationSet(attenuation): Current attenuation setting is set to attenuation.
         switchClicked(on): If on is True, the switchButton is currently checked.
     """
 
     switchClicked = pyqtSignal(bool)
+    profileSet = pyqtSignal(float, float, float)
+    attenuationSet = pyqtSignal(float)
 
     def __init__(
         self,
@@ -520,16 +524,16 @@ class DDSControllerWidget(QWidget):
             profileLayout.addWidget(spinbox)
         profileButton = QPushButton("Set")
         profileLayout.addWidget(profileButton, alignment=Qt.AlignRight)
-        # attenuator widgets
-        attenuatorBox = QGroupBox("Attenuator", self)
-        attenuatorLayout = QHBoxLayout(attenuatorBox)
-        attenuatorInfo = {"ndecimals": 1, "min": 0, "max": 31.5, "step": 0.5, "unit": "dB"}
-        attenuatorSpinbox = self.spinBoxWithInfo(attenuatorInfo)
-        attenuatorSpinbox.setPrefix("-")
-        attenuatorButton = QPushButton("Set")
-        attenuatorLayout.addWidget(QLabel("attenuator:", self), alignment=Qt.AlignRight)
-        attenuatorLayout.addWidget(attenuatorSpinbox)
-        attenuatorLayout.addWidget(attenuatorButton, alignment=Qt.AlignRight)
+        # attenuation widgets
+        attenuationBox = QGroupBox("attenuation", self)
+        attenuationLayout = QHBoxLayout(attenuationBox)
+        attenuationInfo = {"ndecimals": 1, "min": 0, "max": 31.5, "step": 0.5, "unit": "dB"}
+        attenuationSpinbox = self.spinBoxWithInfo(attenuationInfo)
+        attenuationSpinbox.setPrefix("-")
+        attenuationButton = QPushButton("Set")
+        attenuationLayout.addWidget(QLabel("attenuation:", self), alignment=Qt.AlignRight)
+        attenuationLayout.addWidget(attenuationSpinbox)
+        attenuationLayout.addWidget(attenuationButton, alignment=Qt.AlignRight)
         # switch button
         self.switchButton = QPushButton("OFF?", self)
         self.switchButton.setCheckable(True)
@@ -541,7 +545,7 @@ class DDSControllerWidget(QWidget):
         layout = QVBoxLayout(self)
         layout.addLayout(infoLayout)
         layout.addWidget(profileBox)
-        layout.addWidget(attenuatorBox)
+        layout.addWidget(attenuationBox)
         layout.addWidget(self.switchButton)
         # signal connection
         self.switchButton.clicked.connect(self._setSwitchButtonText)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -466,7 +466,8 @@ class DDSControllerWidget(QWidget):
     """Single DDS channel controller widget.
     
     Attributes:
-        profileWidgets: Dictionary with frequency, amplitude, phase spin box, and switching check box.
+        profileWidgets: Dictionary with frequency, amplitude, phase spin box,
+          and switching check box.
         attenuationSpinbox: Spin box for setting the attenuation.
         switchButton: Button for turning on and off the TTL switch that controls the output of DDS.
 

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -514,16 +514,12 @@ class DDSControllerWidget(QWidget):
         # attenuator widgets
         attenuatorBox = QGroupBox("Attenuator", self)
         attenuatorLayout = QHBoxLayout(attenuatorBox)
-        spinbox = QDoubleSpinBox(self)
-        spinbox.setPrefix("-")
-        spinbox.setSuffix("dB")
-        spinbox.setMinimum(0)
-        spinbox.setMaximum(31.5)
-        spinbox.setDecimals(1)
-        spinbox.setSingleStep(0.5)
+        attenuatorinfo = {"ndecimals": 1, "min": 0, "max": 31.5, "step": 0.5, "unit": "dB"}
+        attenuatorSpinbox = self.spinBoxWithInfo(attenuatorinfo)
+        attenuatorSpinbox.setPrefix("-")
         attenuatorButton = QPushButton("Set")
-        attenuatorLayout.addWidget(QLabel("attenuator:", self))
-        attenuatorLayout.addWidget(spinbox)
+        attenuatorLayout.addWidget(QLabel("attenuator:", self), alignment=Qt.AlignRight)
+        attenuatorLayout.addWidget(attenuatorSpinbox)
         attenuatorLayout.addWidget(attenuatorButton, alignment=Qt.AlignRight)
         # layout
         infoLayout = QHBoxLayout()

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -413,7 +413,11 @@ class _DACVoltageThread(QThread):
         )
 
 
-def profile_info(frequency_info: Optional[Dict[str, Any]] = None):
+def profile_info(
+    frequency_info: Optional[Dict[str, Any]] = None,
+    amplitudeInfo: Optional[Dict[str, Any]] = None,
+    phaseInfo: Optional[Dict[str, Any]] = None
+):
     """Returns the profile info.
 
     It completes the profile info by adding default values.
@@ -436,8 +440,22 @@ def profile_info(frequency_info: Optional[Dict[str, Any]] = None):
         logger.warning("The unit of frequency, %s is invalid.", unit)
         unit = "Hz"
     frequency_info["unit"] = unit
+    # amplitude info
+    if amplitudeInfo is None:
+        amplitudeInfo = {}
+    amplitudeInfo["ndecimals"] = amplitudeInfo.get("ndecimals", 2)
+    amplitudeInfo["min"] = 0
+    amplitudeInfo["max"] = 1
+    amplitudeInfo["unit"] = ""
+    # phase info
+    if phaseInfo is None:
+        phaseInfo = {}
+    phaseInfo["ndecimals"] = phaseInfo.get("ndecimals", 2)
+    phaseInfo["min"] = 0
+    phaseInfo["max"] = 1
+    phaseInfo["unit"] = ""
     # profile info
-    info = {"frequency": frequency_info}
+    info = {"frequency": frequency_info, "amplitude": amplitudeInfo, "phase": phaseInfo}
     return info
 
 
@@ -450,6 +468,8 @@ class DDSControllerWidget(QWidget):
         device: str,
         channel: int,
         frequencyInfo: Optional[Dict[str, Any]] = None,
+        amplitudeInfo: Optional[Dict[str, Any]] = None,
+        phaseInfo: Optional[Dict[str, Any]] = None,
         parent: Optional[QWidget] = None
     ):  # pylint: disable=too-many-arguments
         """Extended.
@@ -462,9 +482,13 @@ class DDSControllerWidget(QWidget):
               ndecimals: Number of decimals that can be set. (default=2)
               min, max: Min/Maximum frequency that can be set. (default=0, 4e8)
               unit: Unit of frequency. It should be one of "Hz", "kHz", and "MHz". (default="Hz")
+            amplitudeInfo: Dictionary with amplitude info. Each key and its value are:
+              ndecimals: Number of decimals that can be set. (default=2)
+            phaseInfo: Dictionary with phase info. Each key and its value are:
+              ndecimals: Number of decimals that can be set. (default=2)
         """
         super().__init__(parent=parent)
-        profileInfo = profile_info(frequencyInfo)
+        profileInfo = profile_info(frequencyInfo, amplitudeInfo, phaseInfo)
         # info widgets
         nameLabel = QLabel(name, self)
         nameLabel.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)


### PR DESCRIPTION
This closes #173.

I'm sorry that the updated code is too many. But, I think it is similar to that of DDS, so may be legible😅

For test, use the following code.
```python
from PyQt5.QtWidgets import QApplication

from iquip.apps.monitor import DDSControllerWidget

qapp = QApplication([])
widget = DDSControllerWidget(
    name="DDS_test",
    device="urukul0",
    channel=0,
    frequencyInfo={
        "ndecimals": 3,
        "min": 1,
        "max": 400,
        "unit": "MHz",
        "step": 0.01
    }
)
widget.show()
qapp.exec_()
```

We can set the detailed options of frequency, amplitude, and phase spin box.
I think it is okay to set the attenuation spin box to the fixed option, but if you think it is also necessary, I will update it.

### Screenshot
<img width="70%" src="https://github.com/snu-quiqcl/iquip/assets/76851886/a7b5ff84-aad1-47d0-8beb-d4ecd86b4d4e">
