### PR TITLE
Modification based dataset realtime update

### DIFF
--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -858,8 +858,8 @@ class _DatasetFetcherThread(QThread):
             return default
         return response.json()
 
-    def run(self):
-        """Overridden."""
+    def _get_dataset(self):
+        """Fetches the target dataset and emits the signal."""
         rawDataset = self._get("dataset/master/", {"key": self.name})
         if rawDataset is None:
             return
@@ -873,6 +873,10 @@ class _DatasetFetcherThread(QThread):
         else:
             units = [unit if unit else None for unit in rawUnits]
         self.fetched.emit(dataset, parameters, units)
+
+    def run(self):
+        """Overridden."""
+        self._get_dataset()
 
 
 class DataViewerApp(qiwis.BaseApp):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -931,8 +931,6 @@ class DataViewerApp(qiwis.BaseApp):
         self.frame = DataViewerFrame()
         self.thread: Optional[_DatasetFetcherThread] = None
         self.policy: Optional[SimpleScanDataPolicy] = None
-        self._data: Optional[np.ndarray] = None
-        self._axes: Tuple[AxisInfo, ...] = ()
         self.axis: Tuple[int, ...] = ()
         self.dataPointIndex: Tuple[int, ...] = ()
         self.frame.syncRequested.connect(self.synchronize)
@@ -1026,7 +1024,6 @@ class DataViewerApp(qiwis.BaseApp):
             return
         reduce = self._reduceFunction(dataType)
         data, axes = self.policy.extract(axis, reduce)
-        self._data, self._axes = data, axes
         self.frame.mainPlotWidget.setData(data, axes)
         index = self.dataPointIndex
         if data.ndim == len(index) and np.all(np.less(index, data.shape)):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -794,7 +794,6 @@ class DataViewerFrame(QSplitter):
         self.addWidget(leftWidget)
         self.addWidget(mainPlotBox)
         self.addWidget(toolBox)
-        realtimePart = self.sourceWidget.stack.widget(SourceWidget.ButtonId.REALTIME)
         # signal connection
         remotePart = self.sourceWidget.stack.widget(SourceWidget.ButtonId.REMOTE)
         remotePart.ridEditingFinished.connect(self.dataRequested)
@@ -942,6 +941,10 @@ class DataViewerApp(qiwis.BaseApp):
     @pyqtSlot()
     def synchronize(self):
         """Fetches the dataset from artiq master and updates the viewer."""
+        realtimePart: _RealtimePart = self.frame.sourceWidget.stack.widget(
+            SourceWidget.ButtonId.REALTIME
+        )
+        realtimePart.label.setText("Start synchronizing.")
         self.thread = _DatasetFetcherThread(
             self.frame.datasetName(),
             self.constants.proxy_ip,  # pylint: disable=no-member

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -839,6 +839,25 @@ class _DatasetFetcherThread(QThread):
         self.port = port
         self.fetched.connect(callback, type=Qt.QueuedConnection)
 
+    def _get(self, path: str, params: Dict[str, Any], default: Any = None, timeout: float = 10) -> Any:
+        """Returns the json()-ed response of a GET request.
+        
+        Args:
+            path: The API path, i.e., the request url is "http://{ip}:{port}/{path}".
+            params: Params argument for the GET request.
+            default: The return value of this method when an exception occurs
+              during the GET request.
+            timeout: Timeout argument for the GET request.
+        """
+        url = f"http://{self.ip}:{self.port}/{path}"
+        try:
+            response = requests.get(url, params=params, timeout=timeout)
+            response.raise_for_status()
+        except requests.exceptions.RequestException:
+            logger.exception("Failed to GET %s", url)
+            return default
+        return response.json()
+
     def run(self):
         """Overridden."""
         try:

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -845,6 +845,7 @@ class _DatasetFetcherThread(QThread):
         self.ip = ip
         self.port = port
         self.initialized.connect(callback, type=Qt.QueuedConnection)
+        self._running = True
 
     def _get(self, path: str, params: Dict[str, Any], default: Any = None, timeout: float = 10) -> Any:
         """Returns the json()-ed response of a GET request.
@@ -885,6 +886,10 @@ class _DatasetFetcherThread(QThread):
             units = [unit if unit else None for unit in rawUnits]
         self.initialized.emit(dataset, parameters, units)
         return True
+
+    def stop(self):
+        """Stops the thread."""
+        self._running = False
 
     def run(self):
         """Overridden."""

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -931,6 +931,8 @@ class DataViewerApp(qiwis.BaseApp):
         self.frame = DataViewerFrame()
         self.thread: Optional[_DatasetFetcherThread] = None
         self.policy: Optional[SimpleScanDataPolicy] = None
+        self._data: Optional[np.ndarray] = None
+        self._axes: Tuple[AxisInfo, ...] = ()
         self.axis: Tuple[int, ...] = ()
         self.dataPointIndex: Tuple[int, ...] = ()
         self.frame.syncRequested.connect(self.synchronize)
@@ -1003,6 +1005,7 @@ class DataViewerApp(qiwis.BaseApp):
             return
         reduce = self._reduceFunction(dataType)
         data, axes = self.policy.extract(axis, reduce)
+        self._data, self._axes = data, axes
         self.frame.mainPlotWidget.setData(data, axes)
         index = self.dataPointIndex
         if data.ndim == len(index) and np.all(np.less(index, data.shape)):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -882,14 +882,17 @@ class _DatasetFetcherThread(QThread):
             return -1
         timestamp, rawDataset = response
         dataset = np.array(rawDataset)
-        parameters = self._get("dataset/master/",
-                               {"key": f"{self.name}.parameters"},
-                               list(map(str, range(dataset.shape[1] - 1))))
+        numberOfParameters = dataset.shape[1] if dataset.ndim > 1 else 0
+        _, parameters = self._get(
+            "dataset/master/",
+            {"key": f"{self.name}.parameters"},
+            (0, list(map(str, range(numberOfParameters)))),
+        )
         rawUnits = self._get("dataset/master/", {"key": f"{self.name}.units"})
         if rawUnits is None:
-            units = [None] * (dataset.shape[1] - 1)
+            units = [None] * (numberOfParameters)
         else:
-            units = [unit if unit else None for unit in rawUnits]
+            units = [unit if unit else None for unit in rawUnits[1]]
         self.initialized.emit(dataset, parameters, units)
         return timestamp
 

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -808,7 +808,8 @@ class _DatasetFetcherThread(QThread):
     """QThread for fetching the dataset from the proxy server.
     
     Signals:
-        fetched(dataset, parameters, units): The dataset information is fetched.
+        initialized(dataset, parameters, units): Full dataset is fetched providing
+          the initialization information for the dataset.
           See `SimpleScanDataPolicy` for argument description.
     
     Attributes:
@@ -817,7 +818,7 @@ class _DatasetFetcherThread(QThread):
         port: The proxy server PORT number.
     """
 
-    fetched = pyqtSignal(np.ndarray, list, list)
+    initialized = pyqtSignal(np.ndarray, list, list)
 
     def __init__(
         self,
@@ -831,13 +832,13 @@ class _DatasetFetcherThread(QThread):
         
         Args:
             name, ip, port: See the attributes section.
-            callback: The callback which will be connected to the fetched signal.
+            callback: The callback which will be connected to the initialized signal.
         """
         super().__init__(parent=parent)
         self.name = name
         self.ip = ip
         self.port = port
-        self.fetched.connect(callback, type=Qt.QueuedConnection)
+        self.initialized.connect(callback, type=Qt.QueuedConnection)
 
     def _get(self, path: str, params: Dict[str, Any], default: Any = None, timeout: float = 10) -> Any:
         """Returns the json()-ed response of a GET request.
@@ -872,7 +873,7 @@ class _DatasetFetcherThread(QThread):
             units = [None] * (dataset.shape[1] - 1)
         else:
             units = [unit if unit else None for unit in rawUnits]
-        self.fetched.emit(dataset, parameters, units)
+        self.initialized.emit(dataset, parameters, units)
 
     def run(self):
         """Overridden."""

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -946,8 +946,8 @@ class DataViewerApp(qiwis.BaseApp):
             self.frame.datasetName(),
             self.constants.proxy_ip,  # pylint: disable=no-member
             self.constants.proxy_port,  # pylint: disable=no-member
-            self.setDataset,
         )
+        self.thread.initialized.connect(self.setDataset, type=Qt.QueuedConnection)
         self.thread.start()
 
     @pyqtSlot(np.ndarray, list, list)

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -846,6 +846,7 @@ class _DatasetFetcherThread(QThread):
         self.port = port
         self.initialized.connect(callback, type=Qt.QueuedConnection)
         self._running = True
+        self._timestamp = 0.
 
     def _get(self, path: str, params: Dict[str, Any], default: Any = None, timeout: float = 10) -> Any:
         """Returns the json()-ed response of a GET request.
@@ -872,9 +873,10 @@ class _DatasetFetcherThread(QThread):
         Returns:
             True if success.
         """
-        rawDataset = self._get("dataset/master/", {"key": self.name})
-        if rawDataset is None:
+        response = self._get("dataset/master/", {"key": self.name})
+        if response is None:
             return False
+        self._timestamp, rawDataset = response
         dataset = np.array(rawDataset)
         parameters = self._get("dataset/master/",
                                {"key": f"{self.name}.parameters"},

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -811,6 +811,9 @@ class _DatasetFetcherThread(QThread):
         initialized(dataset, parameters, units): Full dataset is fetched providing
           the initialization information for the dataset.
           See `SimpleScanDataPolicy` for argument description.
+        modified(modifications): Dataset modifications are fetched.
+          The argument modifications is a list of dictionary.
+          See mod dictionary in sipyco.sync_struct for its structure.
     
     Attributes:
         name: The target dataset name.
@@ -819,6 +822,7 @@ class _DatasetFetcherThread(QThread):
     """
 
     initialized = pyqtSignal(np.ndarray, list, list)
+    modified = pyqtSignal(list)
 
     def __init__(
         self,

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -1010,8 +1010,11 @@ class DataViewerApp(qiwis.BaseApp):
         if self.policy is None:
             logger.error("Tried to modify data when data policy is None.")
             return
-        appended = tuple(m["x"] for m in modifications if m["action"] == "append")
-        self.policy.dataset = np.concatenate((self.policy.dataset, np.vstack(appended)))
+        appended = np.vstack(tuple(m["x"] for m in modifications if m["action"] == "append"))
+        if self.policy.dataset.size == 0:
+            self.policy.dataset = appended
+        else:
+            self.policy.dataset = np.concatenate((self.policy.dataset, appended))
         if not self.axis:
             return
         self.updateMainPlot(self.axis, self.frame.dataPointWidget.dataType())
@@ -1024,6 +1027,8 @@ class DataViewerApp(qiwis.BaseApp):
             axis: See updateMainPlot().
         """
         self.axis = axis
+        if self.policy is None or self.policy.dataset.size == 0:
+            return
         dataType = self.frame.dataPointWidget.dataType()
         self.updateMainPlot(axis, dataType)
 

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -901,7 +901,7 @@ class _DatasetFetcherThread(QThread):
         if timestamp < 0:
             self.stopped.emit("Failed to get dataset.")
             return
-        url = "dataset/master/modifications"
+        url = "dataset/master/modification"
         params = {"key": self.name, "timestamp": timestamp, "timeout": 10}
         while self._running:
             response = self._get(url, params, timeout=12)

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -272,34 +272,31 @@ class ImageViewer(NDArrayViewer):  # pylint: disable=too-few-public-methods
 
 class _RealtimePart(QWidget):
     """Part widget for configuring realtime mode of the source widget.
-
-    This is a temporary implementation and will be updated after implementing
-      efficient realtime synchronization.
     
     Attributes:
-        spinbox: Spin box for setting the polling period.
-        button: Button for start/stop poilling.
+        button: Button for start/stop synchronization.
+        label: Status label for showing status including errors.
     
     Signals:
-        periodChanged(period): Polling period is changed to period.
-        pollingToggled(checked): Polling button is clicked and checked is True
-          when the button is checked, hence polling should be started.
+        syncToggled(checked): Synchronize button is clicked with the current
+          checked state (True for start sync, False for stop).
     """
 
-    periodChanged = pyqtSignal(float)
-    pollingToggled = pyqtSignal(bool)
+    syncToggled = pyqtSignal(bool)
 
     def __init__(self, parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(parent=parent)
-        self.button = QPushButton("Not polling", self)
+        self.button = QPushButton("OFF", self)
         self.button.setCheckable(True)
+        self.label = QLabel(self)
         layout = QHBoxLayout(self)
-        layout.addWidget(self.spinbox)
+        layout.addWidget(QLabel("Sync:", self))
         layout.addWidget(self.button)
+        layout.addWidget(self.label)
         # signal connection
         self.button.clicked.connect(self._buttonClicked)
-        self.button.clicked.connect(self.pollingToggled)
+        self.button.clicked.connect(self.syncToggled)
 
     @pyqtSlot(bool)
     def _buttonClicked(self, checked: bool):
@@ -308,10 +305,7 @@ class _RealtimePart(QWidget):
         Args:
             checked: Whether the button is now checked.
         """
-        if checked:
-            self.button.setText("Polling")
-        else:
-            self.button.setText("Not polling")
+        self.button.setText("ON" if checked else "OFF")
 
 
 class _RemotePart(QWidget):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -298,14 +298,15 @@ class _RealtimePart(QWidget):
         self.button.toggled.connect(self._buttonToggled)
         self.button.clicked.connect(self.syncToggled)
 
-    def setStatus(self, message: str, sync: Optional[bool] = None):
+    def setStatus(self, message: Optional[str] = None, sync: Optional[bool] = None):
         """Sets the status message and synchronization button status.
         
         Args:
-            message: New status message to display on the label.
+            message: New status message to display on the label. None for not changing.
             sync: New button checked status. None for not changing.
         """
-        self.label.setText(message)
+        if message is not None:
+            self.label.setText(message)
         if sync is not None:
             self.button.setChecked(sync)
 

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -831,20 +831,17 @@ class _DatasetFetcherThread(QThread):
         name: str,
         ip: str,
         port: int,
-        callback: Callable[[np.ndarray, List[str], List[Optional[str]]], Any],
         parent: Optional[QObject] = None,
-    ):  # pylint: disable=too-many-arguments
+    ):
         """Extended.
         
         Args:
             name, ip, port: See the attributes section.
-            callback: The callback which will be connected to the initialized signal.
         """
         super().__init__(parent=parent)
         self.name = name
         self.ip = ip
         self.port = port
-        self.initialized.connect(callback, type=Qt.QueuedConnection)
         self._running = True
 
     def _get(self, path: str, params: Dict[str, Any], default: Any = None, timeout: float = 10) -> Any:

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -865,8 +865,8 @@ class _DatasetFetcherThread(QThread):
             return default
         return response.json()
 
-    def _get_dataset(self):
-        """Fetches the target dataset and emits the signal."""
+    def _initialize(self):
+        """Fetches the target dataset to initialize the local dataset."""
         rawDataset = self._get("dataset/master/", {"key": self.name})
         if rawDataset is None:
             return

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -814,6 +814,7 @@ class _DatasetFetcherThread(QThread):
         modified(modifications): Dataset modifications are fetched.
           The argument modifications is a list of dictionary.
           See mod dictionary in sipyco.sync_struct for its structure.
+        stopped(cause): The thread is stopped with a cause message.
     
     Attributes:
         name: The target dataset name.
@@ -823,6 +824,7 @@ class _DatasetFetcherThread(QThread):
 
     initialized = pyqtSignal(np.ndarray, list, list)
     modified = pyqtSignal(list)
+    stopped = pyqtSignal(str)
 
     def __init__(
         self,

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -954,8 +954,12 @@ class DataViewerApp(qiwis.BaseApp):
             self.constants.proxy_port,  # pylint: disable=no-member
         )
         self.thread.initialized.connect(self.setDataset, type=Qt.QueuedConnection)
-        self.thread.stopped.connect(realtimePart.setStatus)
-        self.thread.finished.connect(functools.partial(realtimePart.setStatus, sync=False))
+        self.thread.modified.connect(self.modifyDataset, type=Qt.QueuedConnection)
+        self.thread.stopped.connect(realtimePart.setStatus, type=Qt.QueuedConnection)
+        self.thread.finished.connect(
+            functools.partial(realtimePart.setStatus, sync=False),
+            type=Qt.QueuedConnection
+        )
         self.thread.finished.connect(self.thread.deleteLater)
         self.thread.start()
 

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -952,6 +952,9 @@ class DataViewerApp(qiwis.BaseApp):
             self.constants.proxy_port,  # pylint: disable=no-member
         )
         self.thread.initialized.connect(self.setDataset, type=Qt.QueuedConnection)
+        self.thread.stopped.connect(realtimePart.setStatus)
+        self.thread.finished.connect(functools.partial(realtimePart.setStatus, sync=False))
+        self.thread.finished.connect(self.thread.deleteLater)
         self.thread.start()
 
     @pyqtSlot(np.ndarray, list, list)

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -883,7 +883,7 @@ class _DatasetFetcherThread(QThread):
 
     def run(self):
         """Overridden."""
-        self._get_dataset()
+        self._initialize()
 
 
 class DataViewerApp(qiwis.BaseApp):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -295,12 +295,12 @@ class _RealtimePart(QWidget):
         layout.addWidget(self.button)
         layout.addWidget(self.label)
         # signal connection
-        self.button.clicked.connect(self._buttonClicked)
+        self.button.toggled.connect(self._buttonToggled)
         self.button.clicked.connect(self.syncToggled)
 
     @pyqtSlot(bool)
-    def _buttonClicked(self, checked: bool):
-        """Called when the button is clicked.
+    def _buttonToggled(self, checked: bool):
+        """Called when the button is toggled.
         
         Args:
             checked: Whether the button is now checked.

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -20,7 +20,7 @@ from PyQt5.QtWidgets import (
     QAbstractSpinBox, QSpinBox, QDoubleSpinBox, QGroupBox, QSplitter, QLineEdit,
     QCheckBox, QComboBox, QHBoxLayout, QVBoxLayout, QGridLayout,
 )
-from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, QThread, Qt, QTimer
+from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, QThread, Qt
 
 logger = logging.getLogger(__name__)
 
@@ -292,19 +292,12 @@ class _RealtimePart(QWidget):
     def __init__(self, parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(parent=parent)
-        self.spinbox = QDoubleSpinBox(self)
-        self.spinbox.setSuffix("s")
-        self.spinbox.setDecimals(1)
-        self.spinbox.setMinimum(0.5)
-        self.spinbox.setSingleStep(0.5)
-        self.spinbox.setValue(1)
         self.button = QPushButton("Not polling", self)
         self.button.setCheckable(True)
         layout = QHBoxLayout(self)
         layout.addWidget(self.spinbox)
         layout.addWidget(self.button)
         # signal connection
-        self.spinbox.valueChanged.connect(self.periodChanged)
         self.button.clicked.connect(self._buttonClicked)
         self.button.clicked.connect(self.pollingToggled)
 
@@ -797,16 +790,6 @@ class DataViewerFrame(QSplitter):
         self.addWidget(mainPlotBox)
         self.addWidget(toolBox)
         realtimePart = self.sourceWidget.stack.widget(SourceWidget.ButtonId.REALTIME)
-        # TODO(kangz12345@snu.ac.kr): temporary implementation (#180)
-        timer = QTimer(self)
-        timer.setInterval(int(realtimePart.spinbox.value() * 1000))
-        timer.timeout.connect(self.syncRequested)
-        realtimePart.periodChanged.connect(
-            lambda period: timer.setInterval(int(period * 1000))
-        )
-        realtimePart.pollingToggled.connect(
-            lambda checked: timer.start() if checked else timer.stop()
-        )
         # signal connection
         remotePart = self.sourceWidget.stack.widget(SourceWidget.ButtonId.REMOTE)
         remotePart.ridEditingFinished.connect(self.dataRequested)

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -298,6 +298,17 @@ class _RealtimePart(QWidget):
         self.button.toggled.connect(self._buttonToggled)
         self.button.clicked.connect(self.syncToggled)
 
+    def setStatus(self, message: str, sync: Optional[bool] = None):
+        """Sets the status message and synchronization button status.
+        
+        Args:
+            message: New status message to display on the label.
+            sync: New button checked status. None for not changing.
+        """
+        self.label.setText(message)
+        if sync is not None:
+            self.button.setChecked(sync)
+
     @pyqtSlot(bool)
     def _buttonToggled(self, checked: bool):
         """Called when the button is toggled.

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -974,6 +974,23 @@ class DataViewerApp(qiwis.BaseApp):
         self.policy = SimpleScanDataPolicy(dataset, parameters, units)
         self.frame.sourceWidget.setParameters(parameters, units)
 
+    @pyqtSlot(list)
+    def modifyDataset(self, modifications: List[Dict[str, Any]]):
+        """Modifies the dataset and updates the plot.
+
+        Args:
+            See _DatasetFetcherThread.modified signal.
+        """
+        # TODO(kangz12345@snu.ac.kr): Implement modifications other than "append".
+        if self.policy is None:
+            logger.error("Tried to modify data when data policy is None.")
+            return
+        appended = tuple(m["x"] for m in modifications if m["action"] == "append")
+        self.policy.dataset = np.concatenate((self.policy.dataset, np.vstack(appended)))
+        if not self.axis:
+            return
+        self.updateMainPlot(self.axis, self.frame.dataPointWidget.dataType())
+
     @pyqtSlot(tuple)
     def setAxis(self, axis: Sequence[int]):
         """Given the axis information, draws the main plot.

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -844,7 +844,13 @@ class _DatasetFetcherThread(QThread):
         self.port = port
         self._running = True
 
-    def _get(self, path: str, params: Dict[str, Any], default: Any = None, timeout: float = 10) -> Any:
+    def _get(
+        self,
+        path: str,
+        params: Dict[str, Any],
+        default: Any = None,
+        timeout: float = 10
+    ) -> Any:
         """Returns the json()-ed response of a GET request.
         
         Args:


### PR DESCRIPTION
I apologize for the large diffs...
It was an urgent patch so I didn't break it to several PRs.

To summarize this PR:
1. Change polling strategy: periodic polling -> long polling
2. Change dataset update strategy: fetch whole dataset every time -> only modifications since the last fetch
3. Change threading strategy: Spawn a new thread for every fetch -> Spawn a thread for each sync (spawn once start sync, destroy after stop sync) and run a long polling loop
4. Synchronize fetching thread and GUI thread with a `QMutex` and a `QWaitCondition`
5. _NOT_ changed the data structure or plot strategy: it still updates the plot for the whole dataset when the dataset is updated (even by modifications)

More description for the thread synchronization:
- Without any synchronization, the fetching thread will report new modifications continuously while the GUI suffers from organizing and plotting the dataset.
- As the dataset size grows, the GUI latency becomes longer and the `modified` signals start to be queued.
- Then the GUI event queue will be full of `modified` signals, so the GUI might freeze or glitches may appear.
- Therefore, using a mutex and wait condition, the fetcher thread should wait for the GUI thread to update the plot before fetching the next modifications.

As I tested, the most of the latency was because of the large data transfer.
Therefore, I didn't change the dataset organizing and plotting policy.

This branch is already tested and used in the experiment PC.
It works well without any glitch up to 200,000 data points (tested so far, will work for even more!) (the previous version crashed for 20,000 data points).

This branch works after snu-quiqcl/artiq-proxy#93 is done (already done in a not-merged branch).

This closes #207.