### PR TITLE
Enable to open the builder by double-clicking a file entry

### DIFF
--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -204,6 +204,7 @@ class ExplorerApp(qiwis.BaseApp):
         )
         self.experimentInfoThread.start()
 
+    @pyqtSlot(str, str, ExperimentInfo)
     def openBuilder(
         self,
         experimentPath: str,

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -123,7 +123,7 @@ class ExplorerApp(qiwis.BaseApp):
         self.explorerFrame.fileTree.itemExpanded.connect(self.lazyLoadFile)
         self.explorerFrame.fileTree.itemDoubleClicked.connect(self.fetchExperimentInfo)
         self.explorerFrame.reloadButton.clicked.connect(self.loadFileTree)
-        # self.explorerFrame.openButton.clicked.connect(self.fetchExperimentInfo)
+        self.explorerFrame.openButton.clicked.connect(self.openButtonClicked)
 
     @pyqtSlot()
     def loadFileTree(self):
@@ -186,6 +186,17 @@ class ExplorerApp(qiwis.BaseApp):
                 experimentFileItem = QTreeWidgetItem(widget)
                 experimentFileItem.setText(0, experimentFile)
 
+    @pyqtSlot()
+    def openButtonClicked(self):
+        """Called when the openButton is clicked.
+        
+        If no item is selected, nothing happens.
+        """
+        item = self.explorerFrame.fileTree.currentItem()
+        if item is not None:  # item is selected
+            self.fetchExperimentInfo(item)
+
+
     @pyqtSlot(QTreeWidgetItem)
     def fetchExperimentInfo(self, item: QTreeWidgetItem):
         """Fetches the given experiment info.
@@ -193,7 +204,7 @@ class ExplorerApp(qiwis.BaseApp):
         After fetched, it opens the builder of the experiment.
 
         Once an experiment item is double-clicked or the openButton is clicked, this is called.
-        If the given item is a directory, it will be ignored.
+        If the given item is a directory, nothing happens.
         """
         if item.childCount():  # item is a directory
             return

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -121,8 +121,9 @@ class ExplorerApp(qiwis.BaseApp):
         self.loadFileTree()
         # connect signals to slots
         self.explorerFrame.fileTree.itemExpanded.connect(self.lazyLoadFile)
+        self.explorerFrame.fileTree.itemDoubleClicked.connect(self.fetchExperimentInfo)
         self.explorerFrame.reloadButton.clicked.connect(self.loadFileTree)
-        self.explorerFrame.openButton.clicked.connect(self.fetchExperimentInfo)
+        # self.explorerFrame.openButton.clicked.connect(self.fetchExperimentInfo)
 
     @pyqtSlot()
     def loadFileTree(self):

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -122,7 +122,7 @@ class ExplorerApp(qiwis.BaseApp):
         # connect signals to slots
         self.explorerFrame.fileTree.itemExpanded.connect(self.lazyLoadFile)
         self.explorerFrame.reloadButton.clicked.connect(self.loadFileTree)
-        self.explorerFrame.openButton.clicked.connect(self.openExperiment)
+        self.explorerFrame.openButton.clicked.connect(self.fetchExperimentInfo)
 
     @pyqtSlot()
     def loadFileTree(self):
@@ -185,17 +185,18 @@ class ExplorerApp(qiwis.BaseApp):
                 experimentFileItem = QTreeWidgetItem(widget)
                 experimentFileItem.setText(0, experimentFile)
 
-    @pyqtSlot()
-    def openExperiment(self):
-        """Opens the experiment builder of the selected experiment.
+    @pyqtSlot(QTreeWidgetItem)
+    def fetchExperimentInfo(self, item: QTreeWidgetItem):
+        """Fetches the given experiment info.
+         
+        After fetched, it opens the builder of the experiment.
 
-        Once the openButton is clicked, this is called.
-        If the selected element is a directory, it will be ignored.
+        Once an experiment item is double-clicked or the openButton is clicked, this is called.
+        If the given item is a directory, it will be ignored.
         """
-        experimentFileItem = self.explorerFrame.fileTree.currentItem()
-        if experimentFileItem is None or experimentFileItem.childCount():
+        if item.childCount():  # item is a directory
             return
-        experimentPath = self.fullPath(experimentFileItem)
+        experimentPath = self.fullPath(item)
         self.experimentInfoThread = ExperimentInfoThread(
             experimentPath,
             self.proxy_ip,

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -163,6 +163,7 @@ class ExplorerApp(qiwis.BaseApp):
         )
         self.fileFinderThread.start()
 
+    @pyqtSlot(list, object)
     def _addFile(self, experimentList: List[str], widget: Union[QTreeWidget, QTreeWidgetItem]):
         """Adds the files into the children of the widget.
 

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -172,7 +172,7 @@ class ExplorerAppTest(unittest.TestCase):
         with mock.patch.multiple(
             app, fullPath=mock.DEFAULT, openBuilder=mock.DEFAULT
         ) as mocked:
-            app.fetchExperimentInfo()
+            app.fetchExperimentInfo(item)
         mocked["fullPath"].assert_called_with(item)
         mocked_experiment_info_thread_cls.assert_called_with(
             mocked["fullPath"].return_value,

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -158,14 +158,13 @@ class ExplorerAppTest(unittest.TestCase):
         self.assertEqual(fileItem.childCount(), 0)  # No child item for a file.
 
     @mock.patch("iquip.apps.explorer.ExperimentInfoThread")
-    def test_open_experiment(self, mocked_experiment_info_thread_cls):
+    def test_fetch_experiment_info(self, mocked_experiment_info_thread_cls):
         app = explorer.ExplorerApp(name="name", parent=QObject())
         item = QTreeWidgetItem(app.explorerFrame.fileTree)
-        app.explorerFrame.fileTree.setCurrentItem(item)
         with mock.patch.multiple(
             app, fullPath=mock.DEFAULT, openBuilder=mock.DEFAULT
         ) as mocked:
-            app.openExperiment()
+            app.fetchExperimentInfo()
         mocked["fullPath"].assert_called_with(item)
         mocked_experiment_info_thread_cls.assert_called_with(
             mocked["fullPath"].return_value,

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -157,6 +157,14 @@ class ExplorerAppTest(unittest.TestCase):
         self.assertEqual(fileItem.text(0), "experiment_file.py")
         self.assertEqual(fileItem.childCount(), 0)  # No child item for a file.
 
+    def test_open_button_clicked(self):
+        app = explorer.ExplorerApp(name="name", parent=QObject())
+        item = QTreeWidgetItem(app.explorerFrame.fileTree)
+        app.explorerFrame.fileTree.setCurrentItem(item)
+        with mock.patch.object(app, "fetchExperimentInfo") as mocked_fetch_experiment_info:
+            app.openButtonClicked()
+        mocked_fetch_experiment_info.assert_called_once_with(item)
+
     @mock.patch("iquip.apps.explorer.ExperimentInfoThread")
     def test_fetch_experiment_info(self, mocked_experiment_info_thread_cls):
         app = explorer.ExplorerApp(name="name", parent=QObject())

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -265,11 +265,11 @@ class ExplorerFunctionalTest(unittest.TestCase):
         # Once when the app is created, once explicitly.
         self.assertEqual(mocked_load_file_tree.call_count, 2)
 
-    @mock.patch("iquip.apps.explorer.ExplorerApp.openExperiment")
-    def test_open_button_clicked(self, mocked_open_experiment):
+    @mock.patch("iquip.apps.explorer.ExplorerApp.openButtonClicked")
+    def test_open_button_clicked(self, mocked_open_button_clicked):
         app = explorer.ExplorerApp(name="name", parent=QObject())
         QTest.mouseClick(app.explorerFrame.openButton, Qt.LeftButton)
-        mocked_open_experiment.assert_called_once()
+        mocked_open_button_clicked.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -183,12 +183,14 @@ class ExplorerAppTest(unittest.TestCase):
         )
 
     @mock.patch("iquip.apps.explorer.ExperimentInfoThread")
-    def test_open_experiment_not_selected(self, mocked_experiment_info_thread_cls):
+    def test_fetch_experiment_info_for_directory(self, mocked_experiment_info_thread_cls):
         app = explorer.ExplorerApp(name="name", parent=QObject())
+        item = QTreeWidgetItem(app.explorerFrame.fileTree)
+        QTreeWidgetItem(item)  # Add a child item to make "item" a directory.
         with mock.patch.multiple(
             app, fullPath=mock.DEFAULT, openBuilder=mock.DEFAULT
         ) as mocked:
-            app.openExperiment()
+            app.fetchExperimentInfo(item)
         mocked["fullPath"].assert_not_called()
         mocked_experiment_info_thread_cls.assert_not_called()
 

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -165,6 +165,13 @@ class ExplorerAppTest(unittest.TestCase):
             app.openButtonClicked()
         mocked_fetch_experiment_info.assert_called_once_with(item)
 
+    def test_open_button_clicked_not_selected(self):
+        app = explorer.ExplorerApp(name="name", parent=QObject())
+        QTreeWidgetItem(app.explorerFrame.fileTree)  # Add an item, but not selected
+        with mock.patch.object(app, "fetchExperimentInfo") as mocked_fetch_experiment_info:
+            app.openButtonClicked()
+        mocked_fetch_experiment_info.assert_not_called()
+
     @mock.patch("iquip.apps.explorer.ExperimentInfoThread")
     def test_fetch_experiment_info(self, mocked_experiment_info_thread_cls):
         app = explorer.ExplorerApp(name="name", parent=QObject())


### PR DESCRIPTION
This closes #210.

Now, you can open a builder by double-clicking an experiment entry.