### PR TITLE
Safe fetcher thread

### DIFF
--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -986,7 +986,12 @@ class DataViewerApp(qiwis.BaseApp):
         realtimePart: _RealtimePart = self.frame.sourceWidget.stack.widget(
             SourceWidget.ButtonId.REALTIME
         )
-        realtimePart.label.setText("Start synchronizing.")
+        if self.thread is not None and self.thread.isRunning():
+            logger.error("Tried to start dataset fetcher thread which is already running.")
+            realtimePart.setStatus(message="Stopping the running thread...")
+            self.thread.stop()
+            return
+        realtimePart.setStatus(message="Start synchronizing.")
         self.thread = _DatasetFetcherThread(
             self.frame.datasetName(),
             self.constants.proxy_ip,  # pylint: disable=no-member

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -996,11 +996,12 @@ class DataViewerApp(qiwis.BaseApp):
         self.thread.modified.connect(self.modifyDataset, type=Qt.QueuedConnection)
         self.thread.stopped.connect(realtimePart.setStatus, type=Qt.QueuedConnection)
         self.thread.finished.connect(
-            functools.partial(realtimePart.setStatus, sync=False),
-            type=Qt.QueuedConnection
+            functools.partial(realtimePart.setStatus, sync=False, enable=True),
+            type=Qt.QueuedConnection,
         )
         self.thread.finished.connect(self.thread.deleteLater)
         self.thread.start()
+        realtimePart.button.setEnabled(True)
 
     @pyqtSlot(np.ndarray, list, list)
     def setDataset(

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -921,7 +921,7 @@ class _DatasetFetcherThread(QThread):
         if timestamp < 0:
             self.stopped.emit("Failed to get dataset.")
             return
-        url = "dataset/master/modification"
+        url = "dataset/master/modification/"
         params = {"key": self.name, "timestamp": timestamp, "timeout": 10}
         while self._running:
             response = self._get(url, params, timeout=12)

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -978,7 +978,14 @@ class DataViewerApp(qiwis.BaseApp):
         if checked:
             self.synchronize()
         elif self.thread is not None:
-            self.thread.stop()
+            try:
+                self.thread.stop()
+            except RuntimeError:
+                logger.exception("Failed to stop the dataset fetcher thread.")
+                realtimePart = self.frame.sourceWidget.stack.widget(
+                    SourceWidget.ButtonId.REALTIME
+                )
+                realtimePart.setStatus(message="Error occurred.", sync=False, enable=True)
 
     @pyqtSlot()
     def synchronize(self):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -977,15 +977,15 @@ class DataViewerApp(qiwis.BaseApp):
         """
         if checked:
             self.synchronize()
-        elif self.thread is not None:
-            try:
-                self.thread.stop()
-            except RuntimeError:
-                logger.exception("Failed to stop the dataset fetcher thread.")
-                realtimePart = self.frame.sourceWidget.stack.widget(
-                    SourceWidget.ButtonId.REALTIME
-                )
-                realtimePart.setStatus(message="Error occurred.", sync=False, enable=True)
+            return
+        try:
+            self.thread.stop()
+        except RuntimeError:
+            logger.exception("Failed to stop the dataset fetcher thread.")
+            realtimePart = self.frame.sourceWidget.stack.widget(
+                SourceWidget.ButtonId.REALTIME
+            )
+            realtimePart.setStatus(message="Error occurred.", sync=False, enable=True)
 
     @pyqtSlot()
     def synchronize(self):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -1041,12 +1041,11 @@ class DataViewerApp(qiwis.BaseApp):
             self.policy.dataset = appended
         else:
             self.policy.dataset = np.concatenate((self.policy.dataset, appended))
-        if not self.axis:
-            return
-        self.updateMainPlot(self.axis, self.frame.dataPointWidget.dataType())
+        if self.axis:
+            self.updateMainPlot(self.axis, self.frame.dataPointWidget.dataType())
         self.thread.mutex.lock()
-        self.thread.modifyDone.wakeAll()
         self.thread.mutex.unlock()
+        self.thread.modifyDone.wakeAll()
 
     @pyqtSlot(tuple)
     def setAxis(self, axis: Sequence[int]):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -274,7 +274,8 @@ class _RealtimePart(QWidget):
     """Part widget for configuring realtime mode of the source widget.
     
     Attributes:
-        button: Button for start/stop synchronization.
+        button: Button for start/stop synchronization. When the button is clicked,
+          it is disabled. It should be manually enabled after doing proper works.
         label: Status label for showing status including errors.
     
     Signals:
@@ -296,6 +297,7 @@ class _RealtimePart(QWidget):
         layout.addWidget(self.label)
         # signal connection
         self.button.toggled.connect(self._buttonToggled)
+        self.button.clicked.connect(functools.partial(self.button.setEnabled, False))
         self.button.clicked.connect(self.syncToggled)
 
     def setStatus(

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -986,11 +986,6 @@ class DataViewerApp(qiwis.BaseApp):
         realtimePart: _RealtimePart = self.frame.sourceWidget.stack.widget(
             SourceWidget.ButtonId.REALTIME
         )
-        if self.thread is not None and self.thread.isRunning():
-            logger.error("Tried to start dataset fetcher thread which is already running.")
-            realtimePart.setStatus(message="Stopping the running thread...")
-            self.thread.stop()
-            return
         realtimePart.setStatus(message="Start synchronizing.")
         self.thread = _DatasetFetcherThread(
             self.frame.datasetName(),

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -298,17 +298,25 @@ class _RealtimePart(QWidget):
         self.button.toggled.connect(self._buttonToggled)
         self.button.clicked.connect(self.syncToggled)
 
-    def setStatus(self, message: Optional[str] = None, sync: Optional[bool] = None):
+    def setStatus(
+        self,
+        message: Optional[str] = None,
+        sync: Optional[bool] = None,
+        enable: Optional[bool] = None,
+    ):
         """Sets the status message and synchronization button status.
         
         Args:
             message: New status message to display on the label. None for not changing.
             sync: New button checked status. None for not changing.
+            enable: New button enabled status. None for not changing.
         """
         if message is not None:
             self.label.setText(message)
         if sync is not None:
             self.button.setChecked(sync)
+        if enable is not None:
+            self.button.setEnabled(enable)
 
     @pyqtSlot(bool)
     def _buttonToggled(self, checked: bool):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -1001,7 +1001,7 @@ class DataViewerApp(qiwis.BaseApp):
         )
         self.thread.finished.connect(self.thread.deleteLater)
         self.thread.start()
-        realtimePart.button.setEnabled(True)
+        realtimePart.setStatus(enable=True)
 
     @pyqtSlot(np.ndarray, list, list)
     def setDataset(


### PR DESCRIPTION
This closes #209.

This also resolves some issues:
1. Missing a trailing slash "/" in "dataset/master/modification/". This induces a redirection for each request which slightly decrease the performance.
2. Deadlock occurred when there have been data modifications and `self.axis` is empty.
