### PR TITLE
Update fetching schedule to suit ARTIQ-PROXY

### DIFF
--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -1,4 +1,4 @@
-"""App module for showing the scheduled queue for experiments."""
+"""App module for showing the schedule for experiments."""
 
 import enum
 import functools
@@ -23,10 +23,10 @@ class DeleteType(enum.Enum):
 
 
 class _ScheduleThread(QThread):
-    """QThread for obtaining the current scheduled queue from the proxy server.
+    """QThread for obtaining the current schedule from the proxy server.
     
     Signals:
-        fetched(isChanged, updatedTime, schedule): The current scheduled queue is fetched.
+        fetched(isChanged, updatedTime, schedule): The current schedule is fetched.
           The "schedule" is a list with SubmittedExperimentInfo elements.
           The "updatedTime" is the time when the fetched schedule was updated.
           If a timeout occurs, i.e. the queue is not changed, the "isChanged" is set to False.
@@ -59,7 +59,7 @@ class _ScheduleThread(QThread):
     def run(self):
         """Overridden.
         
-        Fetches the current scheduled queue from the proxy server.
+        Fetches the current schedule from the proxy server.
 
         After finished, the fetched signal is emitted.
         """
@@ -72,7 +72,7 @@ class _ScheduleThread(QThread):
             response = response.json()
         except requests.exceptions.RequestException as e:
             if not isinstance(e, requests.exceptions.Timeout):
-                logger.exception("Failed to fetch the current scheduled queue.")
+                logger.exception("Failed to fetch the current schedule.")
             self.fetched.emit(False, self.updatedTime, [])
             return
         updatedTime, queue = response["updated_time"], response["queue"]
@@ -141,7 +141,7 @@ class _ExperimentDeleteThread(QThread):
 
 
 class ScheduleModel(QAbstractTableModel):
-    """Model for handling the scheduled queue as a table data."""
+    """Model for handling the schedule as a table data."""
 
     class InfoFieldId(enum.IntEnum):
         """Submitted experiment information field id.
@@ -213,11 +213,11 @@ class ScheduleModel(QAbstractTableModel):
 
 
 class SchedulerFrame(QWidget):
-    """Frame for showing the scheduled queue.
+    """Frame for showing the schedule.
     
     Attributes:
-        scheduleView: The table view for showing the scheduled queue.
-        scheduleModel: The model for handling the scheduled queue.
+        scheduleView: The table view for showing the schedule.
+        scheduleModel: The model for handling the schedule.
     """
 
     def __init__(self, parent: Optional[QWidget] = None):
@@ -234,14 +234,14 @@ class SchedulerFrame(QWidget):
 
 
 class SchedulerApp(qiwis.BaseApp):
-    """App for fetching and showing the scheduled queue.
+    """App for fetching and showing the schedule.
 
     Attributes:
         proxy_id: The proxy server IP address.
         proxy_port: The proxy server PORT number.
         scheduleThread: The most recently executed _ScheduleThread instance.
         experimentDeleteThread: The most recently executed _ExperimentDeleteThread instance.
-        schedulerFrame: The frame that shows the scheduled queue.
+        schedulerFrame: The frame that shows the schedule.
     """
 
     def __init__(self, name: str, parent: Optional[QObject] = None):

--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -34,7 +34,7 @@ class _ScheduleFetcherThread(QThread):
         port: The proxy server PORT number.
     """
 
-    fetched = pyqtSignal(bool, float, list)
+    fetched = pyqtSignal(list)
 
     def __init__(
         self,
@@ -281,34 +281,20 @@ class SchedulerApp(qiwis.BaseApp):
         self.deleteExperimentThread.finished.connect(self.deleteExperimentThread.deleteLater)
         self.deleteExperimentThread.start()
 
-    @pyqtSlot(bool, float, list)
-    def updateScheduleModel(
-        self,
-        isChanged: bool,
-        updatedTime: float,
-        schedule: Sequence[SubmittedExperimentInfo]
-    ):
+    @pyqtSlot(list)
+    def updateScheduleModel(self, schedule: Sequence[SubmittedExperimentInfo]):
         """Updates schedulerFrame.scheduleModel using the given schedule.
         
         Args:
             See _ScheduleFetcherThread signals section.
         """
-        if isChanged:
-            self.schedulerFrame.scheduleModel.setSchedule(schedule)
-        self.startScheduleFetcherThread(updatedTime)
+        self.schedulerFrame.scheduleModel.setSchedule(schedule)
 
-    def startScheduleFetcherThread(self, updatedTime: float = -1):
-        """Creates and starts a new _ScheduleFetcherThread instance.
-        
-        Args:
-            See _ScheduleFetcherThread attributes section.
-        """
-        self.scheduleFetcherThread = _ScheduleFetcherThread(
-            updatedTime,
-            self.proxy_ip,
-            self.proxy_port,
-        )
-        self.scheduleFetcherThread.fetched.connect(self.updateScheduleModel, type=Qt.QueuedConnection)
+    def startScheduleFetcherThread(self):
+        """Creates and starts a new _ScheduleFetcherThread instance."""
+        self.scheduleFetcherThread = _ScheduleFetcherThread(self.proxy_ip, self.proxy_port)
+        self.scheduleFetcherThread.fetched.connect(self.updateScheduleModel,
+                                                   type=Qt.QueuedConnection)
         self.scheduleFetcherThread.finished.connect(self.scheduleFetcherThread.deleteLater)
         self.scheduleFetcherThread.start()
 


### PR DESCRIPTION
This closes #216.

Now, the updated scheduler app works well to communicate with the proxy server.

The implementation is similar to that of dataviewer app, but much simpler.
The schedule is almost shorter than datasets, so I didn't lock the GUI even if the previously fetched schedule is being drawn.
Also, if fetching schedules is stopped abnormally, we cannot restart it now.

If necessary, I will handle it when using web socket in snu-quiqcl/artiq-proxy#105.