### PR TITLE
Realtime dataset list

### DIFF
--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -17,7 +17,7 @@ import requests
 from pyqtgraph.GraphicsScene import mouseEvents
 from PyQt5.QtWidgets import (
     QWidget, QLabel, QPushButton, QRadioButton, QButtonGroup, QStackedWidget,
-    QAbstractSpinBox, QSpinBox, QDoubleSpinBox, QGroupBox, QSplitter, QLineEdit,
+    QAbstractSpinBox, QSpinBox, QDoubleSpinBox, QGroupBox, QSplitter,
     QCheckBox, QComboBox, QHBoxLayout, QVBoxLayout, QGridLayout,
 )
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QMutex, QObject, QThread, Qt, QWaitCondition

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -1001,6 +1001,7 @@ class DataViewerApp(qiwis.BaseApp):
     Attributes:
         frame: DataViewerFrame instance.
         fetcherThread: The most recently executed _DatasetFetcherThread instance.
+        listThread: The most recently executed _DatasetListThread instance.
         policy: Data policy instance. None if there is currently no data.
         axis: The current plot axis parameter indices. See SimpleScanDataPolicy.extract().
         dataPointIndex: The most recently selected data point index.

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -274,7 +274,7 @@ class _RealtimePart(QWidget):
     """Part widget for configuring realtime mode of the source widget.
     
     Attributes:
-        button: Button for start/stop synchronization. When the button is clicked,
+        syncButton: Button for start/stop synchronization. When the button is clicked,
           it is disabled. It should be manually enabled after doing proper works.
         label: Status label for showing status including errors.
     
@@ -288,17 +288,17 @@ class _RealtimePart(QWidget):
     def __init__(self, parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(parent=parent)
-        self.button = QPushButton("OFF", self)
-        self.button.setCheckable(True)
+        self.syncButton = QPushButton("OFF", self)
+        self.syncButton.setCheckable(True)
         self.label = QLabel(self)
         layout = QHBoxLayout(self)
         layout.addWidget(QLabel("Sync:", self))
-        layout.addWidget(self.button)
+        layout.addWidget(self.syncButton)
         layout.addWidget(self.label)
         # signal connection
-        self.button.toggled.connect(self._buttonToggled)
-        self.button.clicked.connect(functools.partial(self.button.setEnabled, False))
-        self.button.clicked.connect(self.syncToggled)
+        self.syncButton.toggled.connect(self._buttonToggled)
+        self.syncButton.clicked.connect(functools.partial(self.syncButton.setEnabled, False))
+        self.syncButton.clicked.connect(self.syncToggled)
 
     def setStatus(
         self,
@@ -316,9 +316,9 @@ class _RealtimePart(QWidget):
         if message is not None:
             self.label.setText(message)
         if sync is not None:
-            self.button.setChecked(sync)
+            self.syncButton.setChecked(sync)
         if enable is not None:
-            self.button.setEnabled(enable)
+            self.syncButton.setEnabled(enable)
 
     @pyqtSlot(bool)
     def _buttonToggled(self, checked: bool):
@@ -327,7 +327,7 @@ class _RealtimePart(QWidget):
         Args:
             checked: Whether the button is now checked.
         """
-        self.button.setText("ON" if checked else "OFF")
+        self.syncButton.setText("ON" if checked else "OFF")
 
 
 class _RemotePart(QWidget):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -840,7 +840,12 @@ class _DatasetListThread(QThread):
     fetched = pyqtSignal(list)
 
     def __init__(self, ip: str, port: int, parent: Optional[QObject] = None):
-        """Extended."""
+        """Extended.
+        
+        Args:
+            ip: IP address of the proxy server.
+            port: PORT number of the proxy server.
+        """
         super().__init__(parent=parent)
         self.url = f"http://{ip}:{port}/dataset/master/list/"
 

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -400,8 +400,8 @@ class SourceWidget(QWidget):
         """Extended."""
         super().__init__(parent=parent)
         self.datasetBox = QComboBox(self)
-        self.datasetBox.setPlaceholderText("Dataset")
         self.datasetBox.setEditable(True)
+        self.datasetBox.lineEdit().setPlaceholderText("Dataset")
         self.datasetBox.setInsertPolicy(QComboBox.NoInsert)
         self.axisBoxes = {axis: QComboBox(self) for axis in "XY"}
         self.axisBoxes["Y"].setEnabled(False)

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -371,7 +371,7 @@ class SourceWidget(QWidget):
           See SimpleScanDataPolicy.extract() for axis argument.
 
     Attributes:
-        datasetEdit: The line edit for entering dataset name.
+        datasetBox: The combo box for selecting a dataset.
         axisBoxes: The dict of the combo boxes for selecting the X, Y axis parameter.
           The user must select the X axis before the Y axis. Keys are "X" and "Y".
         axisApplyButton: The button for applying the current axis parameter selection.
@@ -393,13 +393,15 @@ class SourceWidget(QWidget):
     def __init__(self, parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(parent=parent)
-        self.datasetEdit = QLineEdit(self)
-        self.datasetEdit.setPlaceholderText("Dataset")
+        self.datasetBox = QComboBox(self)
+        self.datasetBox.setPlaceholderText("Dataset")
+        self.datasetBox.setEditable(True)
+        self.datasetBox.setInsertPolicy(QComboBox.NoInsert)
         self.axisBoxes = {axis: QComboBox(self) for axis in "XY"}
         self.axisBoxes["Y"].setEnabled(False)
         self.axisApplyButton = QPushButton("Apply", self)
         datasetLayout = QHBoxLayout()
-        datasetLayout.addWidget(self.datasetEdit)
+        datasetLayout.addWidget(self.datasetBox)
         for axis, combobox in self.axisBoxes.items():
             combobox.setPlaceholderText("(Disabled)")
             datasetLayout.addWidget(QLabel(f"{axis}:", self))
@@ -813,7 +815,7 @@ class DataViewerFrame(QSplitter):
 
     def datasetName(self) -> str:
         """Returns the current dataset name in the line edit."""
-        return self.sourceWidget.datasetEdit.text()
+        return self.sourceWidget.datasetBox.currentText()
 
 
 class _DatasetFetcherThread(QThread):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -274,6 +274,7 @@ class _RealtimePart(QWidget):
     """Part widget for configuring realtime mode of the source widget.
     
     Attributes:
+        updateButton: Button for updating dataset list.
         syncButton: Button for start/stop synchronization. When the button is clicked,
           it is disabled. It should be manually enabled after doing proper works.
         label: Status label for showing status including errors.
@@ -288,10 +289,12 @@ class _RealtimePart(QWidget):
     def __init__(self, parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(parent=parent)
+        self.updateButton = QPushButton("Update datasets", self)
         self.syncButton = QPushButton("OFF", self)
         self.syncButton.setCheckable(True)
         self.label = QLabel(self)
         layout = QHBoxLayout(self)
+        layout.addWidget(self.updateButton)
         layout.addWidget(QLabel("Sync:", self))
         layout.addWidget(self.syncButton)
         layout.addWidget(self.label)

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -981,7 +981,7 @@ class DataViewerApp(qiwis.BaseApp):
     
     Attributes:
         frame: DataViewerFrame instance.
-        thread: The most recently executed _DatasetFetcherThread instance.
+        fetcherThread: The most recently executed _DatasetFetcherThread instance.
         policy: Data policy instance. None if there is currently no data.
         axis: The current plot axis parameter indices. See SimpleScanDataPolicy.extract().
         dataPointIndex: The most recently selected data point index.

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -818,6 +818,34 @@ class DataViewerFrame(QSplitter):
         return self.sourceWidget.datasetBox.currentText()
 
 
+class _DatasetListThread(QThread):
+    """QThread for fetching the list of available datasets.
+    
+    Signals:
+        fetched(datasets): Fetched the dataset name list.
+    
+    Attributes:
+        url: The GET request url.
+    """
+
+    fetched = pyqtSignal(list)
+
+    def __init__(self, ip: str, port: int, parent: Optional[QObject] = None):
+        """Extended."""
+        super().__init__(parent=parent)
+        self.url = f"http://{ip}:{port}/dataset/master/list/"
+
+    def run(self):
+        """Overridden."""
+        try:
+            response = requests.get(self.url, timeout=5)
+            response.raise_for_status()
+        except requests.exceptions.RequestException:
+            logger.exception("Failed to GET %s", self.url)
+            return
+        self.fetched.emit(response.json())
+
+
 class _DatasetFetcherThread(QThread):
     """QThread for fetching the dataset from the proxy server.
     

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -844,6 +844,14 @@ class _DatasetListThread(QThread):
         super().__init__(parent=parent)
         self.url = f"http://{ip}:{port}/dataset/master/list/"
 
+    def _filter(self, names: List[str]) -> List[str]:
+        """Returns a new list excluding "*.parameters" and "*.units".
+        
+        Args:
+            names: Dataset name list which includes "*.parameters" and "*.units".
+        """
+        return [name for name in names if not name.endswith((".parameters", ".units"))]
+
     def run(self):
         """Overridden."""
         try:
@@ -852,7 +860,7 @@ class _DatasetListThread(QThread):
         except requests.exceptions.RequestException:
             logger.exception("Failed to GET %s", self.url)
             return
-        self.fetched.emit(response.json())
+        self.fetched.emit(self._filter(response.json()))
 
 
 class _DatasetFetcherThread(QThread):


### PR DESCRIPTION
Now it supports listing the realtime datasets.
I couldn't find a simple way to trigger the update, so I just added a button for it.
It filters out the auxiliary datasets "\*.parameters" and "\*.units".
It uses an editable `QComboBox`, and it auto-completes the text if it is in the item list.
![Screen Shot 2023-11-20 at 11 29 01](https://github.com/snu-quiqcl/iquip/assets/8445906/96cdb32b-f4ea-46a4-9e06-fb8317257fe9)
