### PR TITLE
Select a class name when opening a builder

### DIFF
--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -341,6 +341,7 @@ class _ExperimentSubmitThread(QThread):
     
     Attributes:
         experimentPath: The path of the experiment file.
+        experimentClsName: The class name of the experiment.
         experimentArgs: The arguments of the experiment.
         schedOpts: The scheduler options; pipeline, priority, and timed.
         ip: The proxy server IP address.
@@ -352,6 +353,7 @@ class _ExperimentSubmitThread(QThread):
     def __init__(
         self,
         experimentPath: str,
+        experimentClsName: str,
         experimentArgs: Dict[str, Any],
         schedOpts: Dict[str, Any],
         ip: str,
@@ -365,6 +367,7 @@ class _ExperimentSubmitThread(QThread):
         """
         super().__init__(parent=parent)
         self.experimentPath = experimentPath
+        self.experimentClsName = experimentClsName
         self.experimentArgs = experimentArgs
         self.schedOpts = schedOpts
         self.ip = ip
@@ -377,11 +380,11 @@ class _ExperimentSubmitThread(QThread):
 
         Whenever the experiment is submitted well regardless of whether it runs successfully or not,
         the server returns the run identifier.
-        After submitted, the submitted signal is emitted.
         """
         try:
             params = {
                 "file": self.experimentPath,
+                "cls": self.experimentClsName,
                 "args": json.dumps(self.experimentArgs)
             }
         except TypeError:

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -561,10 +561,9 @@ class BuilderApp(qiwis.BaseApp):
         except ValueError:
             logger.exception("The submission is rejected because of an invalid argument.")
             return
-        if schedOpts["visualize"]:
-            schedOpts["cls"] = self.experimentClsName
         self.experimentSubmitThread = _ExperimentSubmitThread(
             self.experimentPath,
+            self.experimentClsName,
             experimentArgs,
             schedOpts,
             self.proxy_ip,

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -516,22 +516,17 @@ class BuilderApp(qiwis.BaseApp):
         self.experimentInfoThread.finished.connect(self.experimentInfoThread.deleteLater)
         self.experimentInfoThread.start()
 
-    def onReloaded(
-        self,
-        _experimentPath: str,
-        experimentClsName: str,
-        experimentInfo: ExperimentInfo
-    ):
+    @pyqtSlot(dict)
+    def onReloaded(self, experimentInfos: dict[str, ExperimentInfo]):
         """Clears the original arguments entry and re-initializes them.
         
         Args:
-            experimentClsName: The class name of the experiment.
-            experimentInfo: The experiment information. See protocols.ExperimentInfo.
+            See thread.ExperimentInfoThread.fetched signal.
         """
+        experimentInfo = experimentInfos[self.experimentClsName]
         for _ in range(self.builderFrame.argsListWidget.count()):
             item = self.builderFrame.argsListWidget.takeItem(0)
             del item
-        self.builderFrame.experimentClsNameLabel.setText(f"Class: {experimentClsName}")
         self.initArgsEntry(experimentInfo)
 
     def argumentsFromListWidget(self, listWidget: QListWidget) -> Dict[str, Any]:

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -520,7 +520,7 @@ class BuilderApp(qiwis.BaseApp):
         self.experimentInfoThread.start()
 
     @pyqtSlot(dict)
-    def onReloaded(self, experimentInfos: dict[str, ExperimentInfo]):
+    def onReloaded(self, experimentInfos: Dict[str, ExperimentInfo]):
         """Clears the original arguments entry and re-initializes them.
         
         Args:

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Tuple, Union
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSlot, pyqtSignal
 from PyQt5.QtWidgets import (
-    QPushButton, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
+    QInputDialog, QPushButton, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 )
 
 import qiwis
@@ -102,6 +102,7 @@ class ExplorerApp(qiwis.BaseApp):
     Attributes:
         proxy_id: The proxy server IP address.
         proxy_port: The proxy server PORT number.
+        selectedExperimentPath: The currently selected experiment path.
         explorerFrame: The frame that shows the file tree.
         fileFinderThread: The most recently executed _FileFinderThread instance.
         experimentInfoThread: The most recently executed ExperimentInfoThread instance.
@@ -112,6 +113,7 @@ class ExplorerApp(qiwis.BaseApp):
         super().__init__(name, parent=parent)
         self.proxy_ip = self.constants.proxy_ip  # pylint: disable=no-member
         self.proxy_port = self.constants.proxy_port  # pylint: disable=no-member
+        self.selectedExperimentPath: Optional[str] = None
         self.fileFinderThread: Optional[_FileFinderThread] = None
         self.experimentInfoThread: Optional[ExperimentInfoThread] = None
         self.explorerFrame = ExplorerFrame()
@@ -200,49 +202,64 @@ class ExplorerApp(qiwis.BaseApp):
     def fetchExperimentInfo(self, item: QTreeWidgetItem):
         """Fetches the given experiment info.
          
-        After fetched, it opens the builder of the experiment.
+        After fetched, self.selectExperimentCls() is called to select an experiment class.
 
         Once an experiment item is double-clicked or the openButton is clicked, this is called.
         If the given item is a directory, nothing happens.
         """
         if item.childCount():  # item is a directory
             return
-        experimentPath = self.fullPath(item)
+        self.selectedExperimentPath = self.fullPath(item)
         self.experimentInfoThread = ExperimentInfoThread(
-            experimentPath,
+            self.selectedExperimentPath,
             self.proxy_ip,
             self.proxy_port,
             self
         )
-        self.experimentInfoThread.fetched.connect(self.openBuilder, type=Qt.QueuedConnection)
+        self.experimentInfoThread.fetched.connect(self.selectExperimentCls,
+                                                  type=Qt.QueuedConnection)
         self.experimentInfoThread.finished.connect(self.experimentInfoThread.deleteLater)
         self.experimentInfoThread.start()
 
-    @pyqtSlot(str, str, ExperimentInfo)
+    @pyqtSlot(dict)
+    def selectExperimentCls(self, experimentInfos: dict[str, ExperimentInfo]):
+        """Selects an experiment class to be opened as a builder.
+        
+        After selected, self.openBuilder() is called to open a builder.
+
+        If there is only one class, it is selected automatically without showing a QInputDialog.
+        If no class is selected, nothing happens.
+        """
+        if len(experimentInfos) > 1:
+            cls, ok = QInputDialog().getItem(None, "Select an experiment class",
+                                             "Experiment class: ", experimentInfos, editable=False)
+            if not ok:
+                return
+        else:
+            cls = next(iter(experimentInfos))
+        self.openBuilder(cls, experimentInfos[cls])
+
     def openBuilder(
         self,
-        experimentPath: str,
         experimentClsName: str,
         experimentInfo: ExperimentInfo
     ):
         """Opens the experiment builder with its information.
         
-        This is the slot of apps.builder.ExperimentInfoThread.fetched.
         The experiment is guaranteed to be the correct experiment file.
 
         Args:
-            experimentPath: The path of the experiment file.
             experimentClsName: The class name of the experiment.
             experimentInfo: The experiment information. See protocols.ExperimentInfo.
         """
         self.qiwiscall.createApp(
-            name=f"builder - {experimentPath}",
+            name=f"builder - {self.selectedExperimentPath}:{experimentClsName}",
             info=qiwis.AppInfo(
                 module="iquip.apps.builder",
                 cls="BuilderApp",
                 pos="center",
                 args={
-                    "experimentPath": experimentPath,
+                    "experimentPath": self.selectedExperimentPath,
                     "experimentClsName": experimentClsName,
                     "experimentInfo": experimentInfo
                 }

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -229,6 +229,9 @@ class ExplorerApp(qiwis.BaseApp):
 
         If there is only one class, it is selected automatically without showing a QInputDialog.
         If no class is selected, nothing happens.
+
+        Args:
+            See thread.ExperimentInfoThread.fetched signal.
         """
         if len(experimentInfos) > 1:
             cls, ok = QInputDialog().getItem(None, "Select an experiment class",

--- a/iquip/apps/explorer.py
+++ b/iquip/apps/explorer.py
@@ -2,7 +2,7 @@
 
 import posixpath
 import logging
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSlot, pyqtSignal
@@ -222,7 +222,7 @@ class ExplorerApp(qiwis.BaseApp):
         self.experimentInfoThread.start()
 
     @pyqtSlot(dict)
-    def selectExperimentCls(self, experimentInfos: dict[str, ExperimentInfo]):
+    def selectExperimentCls(self, experimentInfos: Dict[str, ExperimentInfo]):
         """Selects an experiment class to be opened as a builder.
         
         After selected, self.openBuilder() is called to open a builder.

--- a/iquip/apps/thread.py
+++ b/iquip/apps/thread.py
@@ -15,8 +15,9 @@ class ExperimentInfoThread(QThread):
     """QThread for obtaining the experiment information from the proxy server.
     
     Signals:
-        fetched(experimentPath, experimentClsName, experimentInfo):
-          The experiment infomation is fetched.
+        fetched(experimentInfos): Experiments infomation of the given experiment path is fetched.
+          The experimentInfos is a dictionary with the experiments class name.
+          Each value is the ExperimentInfo instance of the experiment class.
     
     Attributes:
         experimentPath: The path of the experiment file.
@@ -24,7 +25,7 @@ class ExperimentInfoThread(QThread):
         port: The proxy server PORT number.
     """
 
-    fetched = pyqtSignal(str, str, ExperimentInfo)
+    fetched = pyqtSignal(dict)
 
     def __init__(
         self,
@@ -36,7 +37,7 @@ class ExperimentInfoThread(QThread):
         """Extended.
         
         Args:
-            experimentPath, ip, port: See the attributes section.
+            See the attributes section.
         """
         super().__init__(parent=parent)
         self.experimentPath = experimentPath
@@ -64,12 +65,9 @@ class ExperimentInfoThread(QThread):
             logger.exception("Failed to fetch the experiment information.")
             return
         if data:
-            experimentClsName = next(iter(data))
-            experimentInfo = data[experimentClsName]
-            self.fetched.emit(
-                self.experimentPath,
-                experimentClsName,
-                ExperimentInfo(**experimentInfo)
-            )
+            experimentInfos: dict[str, ExperimentInfo] = {}
+            for cls, info in data.items():
+                experimentInfos[cls] = ExperimentInfo(**info)
+            self.fetched.emit(experimentInfos)
         else:
             logger.info("The selected item is not an experiment file.")

--- a/iquip/apps/thread.py
+++ b/iquip/apps/thread.py
@@ -1,7 +1,7 @@
 """Module for common threads in apps."""
 
 import logging
-from typing import Optional
+from typing import Dict, Optional
 
 import requests
 from PyQt5.QtCore import QObject, QThread, pyqtSignal
@@ -65,7 +65,7 @@ class ExperimentInfoThread(QThread):
             logger.exception("Failed to fetch the experiment information.")
             return
         if data:
-            experimentInfos: dict[str, ExperimentInfo] = {}
+            experimentInfos: Dict[str, ExperimentInfo] = {}
             for cls, info in data.items():
                 experimentInfos[cls] = ExperimentInfo(**info)
             self.fetched.emit(experimentInfos)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -45,6 +45,8 @@ EXPERIMENT_INFO_2 = {
 
 EXPERIMENT_PATH = "experiment_path"
 
+EXPERIMENT_CLS_NAME = "experimentClsName"
+
 EXPERIMENT_ARGS = {"arg1": "arg_value1", "arg2": "arg_value2"}
 
 SCHED_OPTS = {"opt1": "opt_value1", "opt2": "opt_value2"}
@@ -241,6 +243,7 @@ class ExperimentSubmitThreadTest(unittest.TestCase):
             thread.wait()
         params = {
             "file": EXPERIMENT_PATH,
+            "cls": EXPERIMENT_CLS_NAME,
             "args": json.dumps(EXPERIMENT_ARGS),
             **SCHED_OPTS
         }
@@ -259,6 +262,7 @@ class ExperimentSubmitThreadTest(unittest.TestCase):
             thread.wait()
         params = {
             "file": EXPERIMENT_PATH,
+            "cls": EXPERIMENT_CLS_NAME,
             "args": json.dumps(EXPERIMENT_ARGS),
             **SCHED_OPTS
         }
@@ -293,6 +297,7 @@ def get_thread(
         experimentArgs = copy.deepcopy(EXPERIMENT_ARGS)
     return builder._ExperimentSubmitThread(
         experimentPath=EXPERIMENT_PATH,
+        experimentClsName=EXPERIMENT_CLS_NAME,
         experimentArgs=experimentArgs,
         schedOpts=SCHED_OPTS,
         ip=CONSTANTS.proxy_ip,
@@ -405,8 +410,9 @@ class BuilderAppTest(unittest.TestCase):
             experimentInfo=copy.deepcopy(EXPERIMENT_INFO)
         )
         experimentInfo = builder.ExperimentInfo(**EXPERIMENT_INFO_2)
+        experimentInfos = {"experimentClsName": experimentInfo}
         with mock.patch.object(app, "initArgsEntry") as mocked_init_args_entry:
-            app.onReloaded("experimentPath", "experimentClsName", experimentInfo)
+            app.onReloaded(experimentInfos)
         self.assertEqual(app.builderFrame.argsListWidget.count(), 0)
         mocked_init_args_entry.assert_called_once_with(experimentInfo)
 
@@ -432,6 +438,7 @@ class BuilderAppTest(unittest.TestCase):
         mocked_arguments_from_list_widget.assert_any_call(app.builderFrame.schedOptsListWidget)
         mocked_experiment_submit_thread_cls.assert_called_once_with(
             "experimentPath",
+            "experimentClsName",
             experimentArgs,
             schedOpts,
             CONSTANTS.proxy_ip,

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -197,11 +197,12 @@ class ExplorerAppTest(unittest.TestCase):
 
     def test_open_builder(self):
         app = explorer.ExplorerApp(name="name", parent=QObject())
+        app.selectedExperimentPath = "experimentPath"
         experimentInfo = protocols.ExperimentInfo("name", {"arg0": "value0"})
         with mock.patch.object(app, "qiwiscall") as mocked_qiwiscall:
-            app.openBuilder("experimentPath", "experimentClsName", experimentInfo)
+            app.openBuilder("experimentClsName", experimentInfo)
         mocked_qiwiscall.createApp.assert_called_with(
-            name="builder - experimentPath",
+            name="builder - experimentPath:experimentClsName",
             info=qiwis.AppInfo(
                 module="iquip.apps.builder",
                 cls="BuilderApp",


### PR DESCRIPTION
This closes #223.

I updated the followings:
- `thread.py`: `ExperimentInfoThread` to emit with all experiments class info of the given experiment path.
- `apps/explorer.py`: After the experiment info is fetched, show a `QInputDialog`.
- `apps/builder.py`: Similar to `explorer.py`.
- Unittests for explorer and builder app.

Now, once we clicked the open button in explorer app, a `QInputDialog` appears.

![image](https://github.com/snu-quiqcl/iquip/assets/76851886/788de5d9-2924-4029-bbab-d1d905a503ec)
