### PR TITLE
Aijuh/237/basic scannable display

### DIFF
--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -98,8 +98,8 @@ class _BooleanEntry(_BaseEntry):
     
     Attributes:
         argInfo: Each key and its value are:
-            (optional) default: The boolean value. 
-              If not exist, the checkBox is set to False.
+          (optional) default: The boolean value. 
+            If not exist, the checkBox is set to False.
         checkBox: The checkbox showing the boolean value.
     """
 
@@ -125,9 +125,9 @@ class _EnumerationEntry(_BaseEntry):
     
     Attributes:
         argInfo: Each key and its value are:
-            choices: The pre-defined candidates.
-            (optional) default: The string value.
-              If not exist, the comboBox is set to the first candidate.
+          choices: The pre-defined candidates.
+          (optional) default: The string value.
+            If not exist, the comboBox is set to the first candidate.
         comboBox: The combobox showing the enumeration value.
     """
 
@@ -158,18 +158,18 @@ class _NumberEntry(_BaseEntry):
     
     Attributes:
         argInfo: Each key and its value are:
-            (optional) default: The number value.
-              If not exist, the spinBox is set to the min value.
-            unit: The unit of the value.
-            scale: The scale factor that is multiplied to the number value.
-            step: The step between values changed by the up and down button.
-            min: The minimum value. (default=0.0)
-            max: The maximum value. (default=99.99)
-              If min > max, then they are swapped.
-            ndecimals: The number of displayed decimals.
-            type: The type of the value.
-              If "int", value() returns an integer value.
-              Otherwise, it is regarded as a float value.
+          (optional) default: The number value.
+            If not exist, the spinBox is set to the min value.
+          unit: The unit of the value.
+          scale: The scale factor that is multiplied to the number value.
+          step: The step between values changed by the up and down button.
+          min: The minimum value. (default=0.0)
+          max: The maximum value. (default=99.99)
+            If min > max, then they are swapped.
+          ndecimals: The number of displayed decimals.
+          type: The type of the value.
+            If "int", value() returns an integer value.
+            Otherwise, it is regarded as a float value.
         spinBox: The spinbox showing the number value.
         warningLabel: The label showing a warning.
           If the given scale is not typical for the unit, it shows a warning.
@@ -225,8 +225,8 @@ class _StringEntry(_BaseEntry):
     
     Attributes:
         argInfo: Each key and its value are:
-            default: The string value.
-              If not exist, the lineEdit is set to an empty string.
+          default: The string value.
+            If not exist, the lineEdit is set to an empty string.
         lineEdit: The lineedit showing the string value.
     """
 
@@ -295,16 +295,16 @@ class _ScanEntry(QWidget):
     """Entry class for a Scannable object.
     
     Attributes:
-        name: The name of the experiment.
+        name: The name of the scannable object.
         argInfo: Each key and its value are:
-                default: The Dictionary that describes arguments of a specific scanning type.
-                unit: The unit of the number value.
-                scale: The scale factor that is multiplied to the number value.
-                global_step: The step between values changed by the up and down button.
-                global_min: The minimum value. (default=float("-inf"))
-                global_max: The maximum value. (default=float("inf"))
-                If min > max, then they are swapped.
-                ndecimals: The number of displayed decimals.
+          default: The Dictionary that describes arguments of a specific scanning type.
+          unit: The unit of the number value.
+          scale: The scale factor that is multiplied to the number value.
+          global_step: The step between values changed by the up and down button.
+          global_min: The minimum value. (default=float("-inf"))
+          global_max: The maximum value. (default=float("inf"))
+            If min > max, then they are swapped.
+          ndecimals: The number of displayed decimals.
     """
     def __init__(
         self,

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -319,9 +319,9 @@ class _ScanEntry(QWidget):
             argInfo: See the attributes section.
         """
         super().__init__(parent=parent)
+        """TODO: Add feature for argInfo processing and other Scan type classes."""
         self.name = name
         self.argInfo = argInfo
-    """TO DO: Add feature for argInfo processing and other Scan type classes."""
 
 
 class BuilderFrame(QWidget):
@@ -493,8 +493,6 @@ class BuilderApp(qiwis.BaseApp):
             experimentInfo: The experiment information.
         """
         for argName, (argInfo, *_) in experimentInfo.arginfo.items():
-            # TODO(BECATRUE): The other types such as 'Scannable'
-            # will be implemented in Basic Runner project.
             argType = argInfo.pop("ty")
             entryCls = {
                 "BooleanValue": _BooleanEntry,

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -321,6 +321,7 @@ class _ScanEntry(QWidget):
         super().__init__(parent=parent)
         self.name = name
         self.argInfo = argInfo
+    """TO DO: Add feature for argInfo processing and other Scan type classes."""
 
 
 class BuilderFrame(QWidget):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-instance-attributes
 """App module for editting the build arguments and submitting the experiment."""
 
 import json
@@ -638,3 +639,31 @@ class BuilderApp(qiwis.BaseApp):
         """Overridden."""
         return (("", self.builderFrame),)
 
+class _ScanEntry(QWidget):
+    """Entry class for a Scannable argument.
+    
+    Attributes:
+        name: The name of the experiment.
+    """
+    def __init__(
+        self,
+        name: str,
+        #argInfo: Dict[str, Any],
+        parent: Optional[QWidget] = None
+        ):
+        """Extended.
+
+        Args:
+            name: The name of the experiment.
+            argInfo: Each key and its value are:
+                default: The Dictionary that describes arguments of a specific scanning type.
+                unit: The unit of the number value.
+                scale: The scale factor that is multiplied to the number value.
+                global_step: The step between values changed by the up and down button.
+                global_min: The minimum value. (default=float("-inf"))
+                global_max: The maximum value. (default=float("inf"))
+                If min > max, then they are swapped.
+                ndecimals: The number of displayed decimals.
+        """
+        super().__init__(parent=parent)
+        self.name = name

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -188,6 +188,7 @@ class _NumberEntry(_BaseEntry):
             minValue = 0.0
         if maxValue is None:
             maxValue = 99.99
+        # TODO(BECATRUE): A WARNING log will be added after implementing the logger app.
         if minValue is not None and maxValue is not None and minValue > maxValue:
             minValue, maxValue = maxValue, minValue
         self.spinBox.setMinimum(minValue / scale)
@@ -289,21 +290,13 @@ class _DateTimeEntry(_BaseEntry):
             return self.dateTimeEdit.dateTime().toString(Qt.ISODate)
         return None
 
-
+# TODO(AIJUH): Add feature for argInfo processing and other Scan type classes.
 class _ScanEntry(QWidget):
-    """Entry class for a Scannable object.
+    """Entry class for a scannable object.
     
     Attributes:
         name: The name of the scannable object.
-        argInfo: Each key and its value are:
-          default: The Dictionary that describes arguments of a specific scanning type.
-          unit: The unit of the number value.
-          scale: The scale factor that is multiplied to the number value.
-          global_step: The step between values changed by the up and down button.
-          global_min: The minimum value. (default=float("-inf"))
-          global_max: The maximum value. (default=float("inf"))
-            If min > max, then they are swapped.
-          ndecimals: The number of displayed decimals.
+        argInfo: The infomation of the arguments.
     """
     def __init__(
         self,
@@ -318,7 +311,6 @@ class _ScanEntry(QWidget):
             argInfo: See the attributes section.
         """
         super().__init__(parent=parent)
-        #TODO(AIJUH): Add feature for argInfo processing and other Scan type classes.
         self.name = name
         self.argInfo = argInfo
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -2,13 +2,15 @@
 
 import json
 import logging
+from collections import OrderedDict
 from typing import Any, Dict, Optional, Tuple, Union
 
 import requests
 from PyQt5.QtCore import QDateTime, QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
-    QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QHBoxLayout, QLabel, QLineEdit,
-    QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QWidget
+    QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QLabel, QLineEdit,
+    QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QHBoxLayout, QGridLayout,
+    QWidget, QStackedWidget, QRadioButton, QButtonGroup
 )
 
 import qiwis
@@ -297,10 +299,14 @@ class BuilderFrame(QWidget):
     Attributes:
         experimentNameLabel: The label for showing the experiment name.
         experimentClsNameLabel: The label for showing the class name of the experiment.
+        argsStackWidget: The stack widget that contains two list widget.
         argsListWidget: The list widget with the build arguments.
+        scanListWidget: The list widget with the scannable arguments.
         reloadArgsButton: The button for reloading the build arguments.
         schedOptsListWidget: The list widget with the schedule options.
         submitButton: The button for submitting the experiment.
+        radioButtons: The button dictionary that has scannable or NonScan buttons.
+        argType: The button group for selecting whether scannable or NonScan.
     """
 
     def __init__(
@@ -319,15 +325,28 @@ class BuilderFrame(QWidget):
         # widgets
         self.experimentNameLabel = QLabel(f"Name: {experimentName}", self)
         self.experimentClsNameLabel = QLabel(f"Class: {experimentClsName}", self)
+        self.argsStackWidget = QStackedWidget(self)
         self.argsListWidget = QListWidget(self)
+        self.scanListWidget = QListWidget(self)
         self.reloadArgsButton = QPushButton("Reload", self)
         self.schedOptsListWidget = QListWidget(self)
         self.submitButton = QPushButton("Submit", self)
+        self.radioButtons = OrderedDict()
+        self.radioButtons["NonScan"] = QRadioButton("NonScan")
+        self.radioButtons["Scannable"] = QRadioButton("Scannable")
+        self.argType = QButtonGroup(self)
         # layout
+        self.argsStackWidget.addWidget(self.argsListWidget)
+        self.argsStackWidget.addWidget(self.scanListWidget)
         layout = QVBoxLayout(self)
+        buttonLayout = QGridLayout()
         layout.addWidget(self.experimentNameLabel)
         layout.addWidget(self.experimentClsNameLabel)
-        layout.addWidget(self.argsListWidget)
+        for n, b in enumerate(self.radioButtons.values()):
+            buttonLayout.addWidget(b, 0, n)
+            self.argType.addButton(b)
+        layout.addLayout(buttonLayout)
+        layout.addWidget(self.argsStackWidget)
         layout.addWidget(self.reloadArgsButton)
         layout.addWidget(self.schedOptsListWidget)
         layout.addWidget(self.submitButton)

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -290,7 +290,8 @@ class _DateTimeEntry(_BaseEntry):
             return self.dateTimeEdit.dateTime().toString(Qt.ISODate)
         return None
 
-# TODO(AIJUH): Add feature for argInfo processing and other Scan type classes.
+
+# TODO(AIJUH): Add feature for argInfo processing and other scan type classes.
 class _ScanEntry(QWidget):
     """Entry class for a scannable object.
     

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -188,7 +188,6 @@ class _NumberEntry(_BaseEntry):
             minValue = 0.0
         if maxValue is None:
             maxValue = 99.99
-        # TODO(BECATRUE): A WARNING log will be added after implementing the logger app.
         if minValue is not None and maxValue is not None and minValue > maxValue:
             minValue, maxValue = maxValue, minValue
         self.spinBox.setMinimum(minValue / scale)
@@ -319,7 +318,7 @@ class _ScanEntry(QWidget):
             argInfo: See the attributes section.
         """
         super().__init__(parent=parent)
-        """TODO: Add feature for argInfo processing and other Scan type classes."""
+        #TODO(AIJUH): Add feature for argInfo processing and other Scan type classes.
         self.name = name
         self.argInfo = argInfo
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -7,8 +7,8 @@ from typing import Any, Dict, Optional, Tuple, Union
 import requests
 from PyQt5.QtCore import QDateTime, QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
-    QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QLabel, QLineEdit,
-    QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QHBoxLayout, QWidget
+    QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QHBoxLayout, QLabel, QLineEdit,
+    QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QWidget
 )
 
 import qiwis
@@ -503,12 +503,12 @@ class BuilderApp(qiwis.BaseApp):
                 "Scannable": _ScanEntry
             }[argType]
             widget = entryCls(argName, argInfo)
-            listWidget = self.builderFrame.scanListWidget if argType == "Scannable" \
-                         else self.builderFrame.argsListWidget
+            listWidget = (self.builderFrame.scanListWidget if argType == "Scannable"
+                          else self.builderFrame.argsListWidget)
             item = QListWidgetItem(listWidget)
             item.setSizeHint(widget.sizeHint())
-            self.builderFrame.argsListWidget.addItem(item)
-            self.builderFrame.argsListWidget.setItemWidget(item, widget)
+            listWidget.addItem(item)
+            listWidget.setItemWidget(item, widget)
 
     def initSchedOptsEntry(self):
         """Initializes the scheduler options entry.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -303,8 +303,6 @@ class BuilderFrame(QWidget):
         reloadArgsButton: The button for reloading the build arguments.
         schedOptsListWidget: The list widget with the schedule options.
         submitButton: The button for submitting the experiment.
-        radioButtons: The button dictionary that has scannable or NonScan buttons.
-        argType: The button group for selecting whether scannable or NonScan.
     """
 
     def __init__(


### PR DESCRIPTION
This closes #237.

Add a new widget at builderFrame and builderApp for Scannable argument display.
Below image shows scannable widget when all features are added.
In this PR, only framework of Scannable widget is done. 



![temp_ra](https://github.com/snu-quiqcl/iquip/assets/43592775/89110afd-04ae-4d2a-a42f-2616e1adbbe1)

1. Add new widget for scannable entry at builderFrame.
3. Add dummy ScanEntry.

Additional code will be added at next PR.
