### PR TITLE
Update scheduler arguments and copy experiment info

### DIFF
--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -285,10 +285,12 @@ class SchedulerApp(qiwis.BaseApp):
         """Sets a copy action in schedulerFrame.scheduleView and its header."""
         view = self.schedulerFrame.scheduleView
         header = view.verticalHeader()
-        action = QAction("Copy", self)
-        action.triggered.connect(self.copyExperimentInfo)
-        view.addAction(action)
-        header.addAction(action)
+        viewAction = QAction("Copy", view)
+        headerAction = QAction("Copy", header)
+        viewAction.triggered.connect(self.copyExperimentInfo)
+        headerAction.triggered.connect(functools.partial(self.copyExperimentInfo, True))
+        view.addAction(viewAction)
+        header.addAction(headerAction)
 
     @pyqtSlot()
     def copyExperimentInfo(self, allInfo: bool = False):

--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -282,11 +282,13 @@ class SchedulerApp(qiwis.BaseApp):
         self.startScheduleFetcherThread()
 
     def setCopyAction(self):
-        """Sets a copy action in schedulerFrame.scheduleView."""
+        """Sets a copy action in schedulerFrame.scheduleView and its header."""
         view = self.schedulerFrame.scheduleView
-        action = QAction("Copy", view)
+        header = view.verticalHeader()
+        action = QAction("Copy", self)
         action.triggered.connect(self.copyExperimentInfo)
         view.addAction(action)
+        header.addAction(action)
 
     @pyqtSlot()
     def copyExperimentInfo(self, allInfo: bool = False):

--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -262,8 +262,20 @@ class SchedulerApp(qiwis.BaseApp):
         button = self.schedulerFrame.button
         button.clicked.connect(functools.partial(button.setEnabled, False))
         button.clicked.connect(self.startScheduleFetcherThread)
+        self.setCopyAction()
         self.setDeleteActions()
         self.startScheduleFetcherThread()
+
+    def setCopyAction(self):
+        """Sets a copy action in schedulerFrame.scheduleView."""
+        view = self.schedulerFrame.scheduleView
+        action = QAction("Copy", view)
+        action.triggered.connect(self.copyExperimentInfo)
+        view.addAction(action)
+
+    @pyqtSlot()
+    def copyExperimentInfo(self):
+        pass
 
     def setDeleteActions(self):
         """Sets experiment deletion actions in schedulerFrame.scheduleView."""

--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -289,13 +289,20 @@ class SchedulerApp(qiwis.BaseApp):
         view.addAction(action)
 
     @pyqtSlot()
-    def copyExperimentInfo(self):
-        """Copies the selected experiment info to the system clipboard."""
+    def copyExperimentInfo(self, allInfo: bool = False):
+        """Copies the selected experiment info to the system clipboard.
+        
+        Args:
+            allInfo: Copies all info of the experiment, if True. Otherwise, copies only the item.
+        """
         index = self.schedulerFrame.scheduleView.currentIndex()
         if not index.isValid():
             return
-        row = index.row()
-        info = self.schedulerFrame.scheduleModel.experimentInfo(row)
+        model = self.schedulerFrame.scheduleModel
+        if allInfo:
+            info = model.experimentInfo(index.row())
+        else:
+            info = model.data(index)
         QGuiApplication.clipboard().setText(info)
 
     def setDeleteActions(self):

--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -213,6 +213,19 @@ class ScheduleModel(QAbstractTableModel):
         self._schedule = value
         self.endResetModel()
 
+    def experimentInfo(self, idx: int) -> str:
+        """Returns the specific experiment info.
+        
+        Args:
+            idx: The index of the experiment.
+
+        Returns:
+            The experiment info in string or an empty string if the idx is invalid.
+        """
+        if idx < 0 or idx >= len(self._schedule):
+            return ""
+        return str(self._schedule[idx])
+
 
 class SchedulerFrame(QWidget):
     """Frame for showing the schedule.

--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -213,18 +213,18 @@ class ScheduleModel(QAbstractTableModel):
         self._schedule = value
         self.endResetModel()
 
-    def experimentInfo(self, idx: int) -> str:
+    def experimentInfo(self, row: int) -> str:
         """Returns the specific experiment info.
         
         Args:
-            idx: The index of the experiment.
+            row: The row of the experiment.
 
         Returns:
-            The experiment info in string or an empty string if the idx is invalid.
+            The experiment info in string or an empty string if the row is invalid.
         """
-        if idx < 0 or idx >= len(self._schedule):
+        if row < 0 or row >= self.rowCount():
             return ""
-        return str(self._schedule[idx])
+        return str(self._schedule[row])
 
 
 class SchedulerFrame(QWidget):
@@ -294,6 +294,7 @@ class SchedulerApp(qiwis.BaseApp):
         if not index.isValid():
             return
         row = index.row()
+        info = self.schedulerFrame.scheduleModel.experimentInfo(row)
 
     def setDeleteActions(self):
         """Sets experiment deletion actions in schedulerFrame.scheduleView."""

--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -245,6 +245,7 @@ class SchedulerFrame(QWidget):
         self.scheduleModel = ScheduleModel(self)
         self.scheduleView.setModel(self.scheduleModel)
         self.scheduleView.setContextMenuPolicy(Qt.ActionsContextMenu)
+        self.scheduleView.verticalHeader().setContextMenuPolicy(Qt.ActionsContextMenu)
         self.button = QPushButton("Restart", self)
         self.button.setEnabled(False)
         # layout

--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -304,7 +304,7 @@ class SchedulerApp(qiwis.BaseApp):
         if allInfo:
             info = model.experimentInfo(index.row())
         else:
-            info = model.data(index)
+            info = str(model.data(index))
         QGuiApplication.clipboard().setText(info)
 
     def setDeleteActions(self):

--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -9,6 +9,7 @@ import requests
 from PyQt5.QtCore import (
     pyqtSignal, pyqtSlot, QAbstractTableModel, QModelIndex, QObject, Qt, QThread, QVariant
 )
+from PyQt5.QtGui import QGuiApplication
 from PyQt5.QtWidgets import QAction, QPushButton, QTableView, QVBoxLayout, QWidget
 
 import qiwis
@@ -275,7 +276,11 @@ class SchedulerApp(qiwis.BaseApp):
 
     @pyqtSlot()
     def copyExperimentInfo(self):
-        pass
+        """Copies the selected experiment info to the system clipboard."""
+        index = self.schedulerFrame.scheduleView.currentIndex()
+        if not index.isValid():
+            return
+        row = index.row()
 
     def setDeleteActions(self):
         """Sets experiment deletion actions in schedulerFrame.scheduleView."""

--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -299,7 +299,7 @@ class SchedulerApp(qiwis.BaseApp):
         QGuiApplication.clipboard().setText(info)
 
     def setDeleteActions(self):
-        """Sets experiment deletion actions in schedulerFrame.scheduleView."""
+        """Sets experiment deletion actions in schedulerFrame.scheduleView and its header."""
         view = self.schedulerFrame.scheduleView
         header = view.verticalHeader()
         for deleteType in DeleteType:

--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -181,7 +181,13 @@ class ScheduleModel(QAbstractTableModel):
             return QVariant()
         row, column = index.row(), index.column()
         infoField = ScheduleModel.InfoFieldId(column).name.lower()
-        return getattr(self._schedule[row], infoField)
+        data = getattr(self._schedule[row], infoField)
+        if column == ScheduleModel.InfoFieldId.ARGUMENTS:
+            return ", ".join([
+                f"{key}: {round(value, 9) if isinstance(value, (int, float)) else value}"
+                for key, value in data.items()
+            ])
+        return data
 
     def headerData(self, section: int, orientation: Qt.Orientation, role: Qt.ItemDataRole) -> Any:
         """Overridden.

--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -295,6 +295,7 @@ class SchedulerApp(qiwis.BaseApp):
             return
         row = index.row()
         info = self.schedulerFrame.scheduleModel.experimentInfo(row)
+        QGuiApplication.clipboard().setText(info)
 
     def setDeleteActions(self):
         """Sets experiment deletion actions in schedulerFrame.scheduleView."""

--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -301,10 +301,12 @@ class SchedulerApp(qiwis.BaseApp):
     def setDeleteActions(self):
         """Sets experiment deletion actions in schedulerFrame.scheduleView."""
         view = self.schedulerFrame.scheduleView
+        header = view.verticalHeader()
         for deleteType in DeleteType:
-            action = QAction(deleteType.value.capitalize(), view)
+            action = QAction(deleteType.value.capitalize(), self)
             action.triggered.connect(functools.partial(self.deleteExperiment, deleteType))
             view.addAction(action)
+            header.addAction(action)
 
     @pyqtSlot(DeleteType)
     def deleteExperiment(self, deleteType: DeleteType):

--- a/iquip/protocols.py
+++ b/iquip/protocols.py
@@ -40,3 +40,7 @@ class SubmittedExperimentInfo:  # pylint: disable=too-many-instance-attributes
     file: Optional[str]
     content: Optional[str]
     arguments: Dict[str, Any]
+
+    def __str__(self) -> str:
+        """Overridden."""
+        return str(dataclasses.asdict(self))


### PR DESCRIPTION
I implemented the followings:
- Show number arguments up to 9 decimal points (ns scale)
- Make an user copy a specific experiment info through right-click

The example result is as below.

![image](https://github.com/snu-quiqcl/iquip/assets/76851886/13b63be8-9a19-4b85-bfbe-0cd216f4e4f1)

This closes #240.