### PR TITLE
Add code for argument information processing

### DIFF
--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -297,15 +297,15 @@ class _ScanEntry(QWidget):
     
     Attributes:
         name: The name of the scannable object.
-        state: Each key and its value are:
+        state: Each key and its value are as follows.
           "selected": The name of the selected scannable type.
           "NoScan": The dictionary that contains argument info of NoScan scannable type.
           "RangeScan": The dictionary that contains argument info of RangeScan scannable type.
           "CenterScan": The dictionary that contains argument info of CenterScan scannable type.
           "ExplicitScan": The dictionary that contains argument info of ExplicitScan scannable type.
-        stackWidget: The QstackWidget that contains widgets of each scan type.
+        stackWidget: The QstackWidget that contains widgets of each scannable type.
         layout: The layout of _ScanEntry widget.
-        radioButtons: The dictionary that contains buttons of each scan type for stackWidget.
+        radioButtons: The dictionary that contains buttons of each scannable type for stackWidget.
     """
     def __init__(
         self,
@@ -339,7 +339,7 @@ class _ScanEntry(QWidget):
         """Gets a dictionary that describes default parameters of all scannable types.
 
         Args:
-            argInfo: See argInfo in __ init __().
+            argInfo: See argInfo in __init__().
         """
         scale = argInfo["scale"]
         state = {
@@ -347,8 +347,8 @@ class _ScanEntry(QWidget):
             "NoScan": {"value": 0.0, "repetitions": 1},
             "RangeScan": {"start": 0.0, "stop": 100.0 * scale, "npoints": 10,
                           "randomize": False, "seed": None},
-            "CenterScan": {"center": 0. * scale, "span": 100. * scale,
-                           "step": 10. * scale, "randomize": False,
+            "CenterScan": {"center": 0. * scale,"step": 10. * scale,
+                           "span": 100. * scale, "randomize": False,
                            "seed": None},
             "ExplicitScan": {"sequence": []}
         }
@@ -369,14 +369,14 @@ class _ScanEntry(QWidget):
         """Gets a procdesc dictionary that describes common parameters of the scannable object.
 
         Args:
-            argInfo: See argInfo in __ init __().
+            argInfo: See argInfo in __init__().
         """
         procdesc = {
             "unit": argInfo["unit"],
             "scale": argInfo["scale"],
             "global_step": argInfo["global_step"],
             "global_min": argInfo["global_min"],
-            "global_max":  argInfo["global_max"],
+            "global_max": argInfo["global_max"],
             "ndecimals": argInfo["ndecimals"]
         }
         return procdesc

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -389,17 +389,6 @@ class _ScanEntry(QWidget):
         }
         return procdesc
 
-    def scan_type_toggled(self):
-        """Switches current scan widget at stacked layout in _ScanEntry.
-        
-        Once the checked button at radiobutton group changed, this is called.
-        """
-        for ty, button in self.radioButtons.items():
-            if button.isChecked():
-                self.stack.setCurrentWidget(self.widgets[ty])
-                self.state["selected"] = ty
-                break
-
 
 class BuilderFrame(QWidget):
     """Frame for showing the build arguments and requesting to submit it.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -347,7 +347,7 @@ class _ScanEntry(QWidget):
             "NoScan": {"value": 0.0, "repetitions": 1},
             "RangeScan": {"start": 0.0, "stop": 100.0 * scale, "npoints": 10,
                           "randomize": False, "seed": None},
-            "CenterScan": {"center": 0. * scale,"step": 10. * scale,
+            "CenterScan": {"center": 0. * scale, "step": 10. * scale,
                            "span": 100. * scale, "randomize": False,
                            "seed": None},
             "ExplicitScan": {"sequence": []}

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -297,8 +297,13 @@ class _ScanEntry(QWidget):
     
     Attributes:
         name: The name of the scannable object.
-        state: The dictionary that describes argument information of each scan type.
-        stackWidget: The QstackWidget that contains widget of each scan type.
+        state: Each key and its value are:
+          "selected": The name of the selected scannable type.
+          "NoScan": The dictionary that contains argument info of NoScan scannable type.
+          "RangeScan": The dictionary that contains argument info of RangeScan scannable type.
+          "CenterScan": The dictionary that contains argument info of CenterScan scannable type.
+          "ExplicitScan": The dictionary that contains argument info of ExplicitScan scannable type.
+        stackWidget: The QstackWidget that contains widgets of each scan type.
         layout: The layout of _ScanEntry widget.
         radioButtons: The dictionary that contains buttons of each scan type for stackWidget.
     """
@@ -307,13 +312,13 @@ class _ScanEntry(QWidget):
         name: str,
         argInfo: Dict[str, Any],
         parent: Optional[QWidget] = None
-        ):
+    ):
         """Extended.
 
         Args:
             name: See the attributes section.
             argInfo: Each key and its value are:
-              default: The dictionary that describes arguments of a scannable object.
+              default: The dictionary that describes arguments of the default scannable object.
               unit: The unit of the number value.
               scale: The scale factor that is multiplied to the number value.
               global_step: The step between values changed by the up and down button.
@@ -330,22 +335,20 @@ class _ScanEntry(QWidget):
         self.layout.addWidget(QLabel(name, self), 0, 0)
         self.layout.addWidget(self.stack, 1, 1)
 
-    def get_state(self, argInfo):
-        """Gets a state dictionary that describes key parameters of a scannable object.
-
-        Creates a default state dictionary and updates it using the argInfo.
+    def get_state(self, argInfo: Dict[str, Any]) -> Dict[str, Any]:
+        """Gets a dictionary that describes default parameters of all scannable types.
 
         Args:
-            argInfo: A dictionary that contains argument information of each scannable type.
+            argInfo: See argInfo in __ init __().
         """
         scale = argInfo["scale"]
         state = {
             "selected": "NoScan",
             "NoScan": {"value": 0.0, "repetitions": 1},
-            "RangeScan": {"start": 0.0, "stop": 100.0*scale, "npoints": 10,
+            "RangeScan": {"start": 0.0, "stop": 100.0 * scale, "npoints": 10,
                           "randomize": False, "seed": None},
-            "CenterScan": {"center": 0.*scale, "span": 100.*scale,
-                           "step": 10.*scale, "randomize": False,
+            "CenterScan": {"center": 0. * scale, "span": 100. * scale,
+                           "step": 10. * scale, "randomize": False,
                            "seed": None},
             "ExplicitScan": {"sequence": []}
         }
@@ -354,39 +357,27 @@ class _ScanEntry(QWidget):
             if not isinstance(defaults, list):
                 defaults = [defaults]
             state["selected"] = defaults[0]["ty"]
-            for default in reversed(defaults):
+            for default in defaults:
                 ty = default["ty"]
-                if ty == "NoScan":
-                    state[ty]["value"] = default["value"]
-                    state[ty]["repetitions"] = default["repetitions"]
-                elif ty == "RangeScan":
-                    state[ty]["start"] = default["start"]
-                    state[ty]["stop"] = default["stop"]
-                    state[ty]["npoints"] = default["npoints"]
-                    state[ty]["randomize"] = default["randomize"]
-                    state[ty]["seed"] = default["seed"]
-                elif ty == "CenterScan":
-                    for key in "center span step randomize seed".split():
-                        state[ty][key] = default[key]
-                elif ty == "ExplicitScan":
-                    state[ty]["sequence"] = default["sequence"]
+                if ty not in ["NoScan", "RangeScan", "CenterScan", "ExplicitScan"]:
+                    logger.warning("Unknown scan type: %s", ty)
                 else:
-                    logger.warning("unknown default type: %s", ty)
+                    state[ty] = default
         return state
 
-    def get_procdesc(self, argInfo):
-        """Gets a prodesc dictionary that describes common parameters of the scannable object.
+    def get_procdesc(self, argInfo: Dict[str, Any]) -> Dict[str, Any]:
+        """Gets a procdesc dictionary that describes common parameters of the scannable object.
 
         Args:
-            argInfo: A dictionary that contains argument information of the scannable object.
+            argInfo: See argInfo in __ init __().
         """
         procdesc = {
             "unit": argInfo["unit"],
             "scale": argInfo["scale"],
             "global_step": argInfo["global_step"],
-            "ndecimals": argInfo["ndecimals"],
             "global_min": argInfo["global_min"],
-            "global_max":  argInfo["global_max"]
+            "global_max":  argInfo["global_max"],
+            "ndecimals": argInfo["ndecimals"]
         }
         return procdesc
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -3,14 +3,12 @@
 import json
 import logging
 from typing import Any, Dict, Optional, Tuple, Union
-from collections import OrderedDict
 
 import requests
 from PyQt5.QtCore import QDateTime, QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
-    QButtonGroup, QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QGridLayout, QHBoxLayout,
-    QLabel, QLineEdit, QListWidget, QListWidgetItem, QPushButton, QRadioButton, QStackedWidget,
-    QVBoxLayout, QWidget
+    QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QGridLayout, QHBoxLayout, QLabel,
+    QLineEdit, QListWidget, QListWidgetItem, QPushButton, QStackedWidget, QVBoxLayout, QWidget
 )
 
 import qiwis
@@ -301,7 +299,6 @@ class _ScanEntry(QWidget):
         state: The dictionary that describes argument information of each scan type.
         stackWidget: The QstackWidget that contains widget of each scan type.
         layout: The layout of _ScanEntry widget.
-        widgets: The dictionary that contains widget of each scan type inside stackWidget.
         radioButtons: The dictionary that contains buttons of each scan type for stackWidget.
     """
     def __init__(
@@ -326,35 +323,11 @@ class _ScanEntry(QWidget):
         """
         super().__init__(parent=parent)
         self.name = name
-        procdesc = self.get_procdesc(argInfo)
         self.state = self.get_state(argInfo)
         self.stack = QStackedWidget(self)
         self.layout = QGridLayout(self)
         self.layout.addWidget(QLabel(name, self), 0, 0)
         self.layout.addWidget(self.stack, 1, 1)
-
-        self.widgets = OrderedDict()
-        self.widgets["NoScan"] = _NoScan(procdesc, self.state["NoScan"])
-        self.widgets["RangeScan"] = _RangeScan(procdesc, self.state["RangeScan"])
-        self.widgets["CenterScan"] = _CenterScan(procdesc, self.state["CenterScan"])
-        self.widgets["ExplicitScan"] = _ExplicitScan(self.state["ExplicitScan"])
-        for widget in self.widgets.values():
-            self.stack.addWidget(widget)
-
-        self.radioButtons = OrderedDict()
-        self.radioButtons["NoScan"] = QRadioButton("No scan")
-        self.radioButtons["RangeScan"] = QRadioButton("Range")
-        self.radioButtons["CenterScan"] = QRadioButton("Center")
-        self.radioButtons["ExplicitScan"] = QRadioButton("Explicit")
-        scan_type = QButtonGroup(self)
-        buttonLayout = QGridLayout()
-        for n, b in enumerate(self.radioButtons.values()):
-            buttonLayout.addWidget(b, 0, n)
-            scan_type.addButton(b)
-            b.toggled.connect(self.scan_type_toggled)
-        self.layout.addLayout(buttonLayout, 0, 1)
-        selected = self.state["selected"]
-        self.radioButtons[selected].setChecked(True)
 
     def get_state(self, argInfo):
         """Gets a state dictionary that describes key parameters of a scannable object.
@@ -426,152 +399,6 @@ class _ScanEntry(QWidget):
                 self.stack.setCurrentWidget(self.widgets[ty])
                 self.state["selected"] = ty
                 break
-
-
-class _NoScan(QWidget):
-    """An widget for a NoScan type in Scannable Entry.
-
-    Attributes:
-        layout: The layout of _NoScan widget.
-        procdesc: The dummy attribute that will be discard at the next PR.
-        state: The dummy attribute that will be discard at next PR.
-    """
-    def __init__(
-        self,
-        procdesc: Dict[str, Any],
-        state: Dict[str, Any],
-        parent: Optional[QWidget] = None
-        ):
-        """Extended.
-
-        Args:
-            procdesc: Each key and its value are:
-              unit: The unit of the number value.
-              scale: The scale factor that is multiplied to the number value.
-              global_step: The step between values changed by the up and down button.
-              global_min: The minimum value. (default=float("-inf"))
-              global_max: The maximum value. (default=float("inf"))
-                If min > max, then they are swapped.
-              ndecimals: The number of displayed decimals.
-            state:
-              value: The repeated number value in scannable sequence.
-              repetitions: A number to repeat the value in scnnable sequence.
-        """
-        super().__init__(parent=parent)
-        self.layout = QGridLayout(self)
-        self.layout.addWidget(QLabel("NoScan:", self), 0, 0)
-        self.procdesc = procdesc
-        self.state = state
-
-
-class _RangeScan(QWidget):
-    """An widget for a RangeScan type in Scannable Entry.
-
-    Attributes:
-        layout: The layout of _RangeScan widget.
-        procdesc: The dummy attribute that will be discard at the next PR.
-        state: The dummy attribute that will be discard at next PR.
-    """
-    def __init__(
-        self,
-        procdesc: Dict[str, Any],
-        state: Dict[str, Any],
-        parent: Optional[QWidget] = None
-        ):
-        """Extended.
-
-        Args:
-            procdesc: Each key and its value are:
-              unit: The unit of the number value.
-              scale: The scale factor that is multiplied to the number value.
-              global_step: The step between values changed by the up and down button.
-              global_min: The minimum value. (default=float("-inf"))
-              global_max: The maximum value. (default=float("inf"))
-              If min > max, then they are swapped.
-              ndecimals: The number of displayed decimals.
-            state:
-              start: The start point of the scanning sequence.
-              stop: The end point of the scanning sequence.
-              npoints: The number of points to be genereated inside the scanning sequence.
-              randomize: A boolean value that determines 
-                whether or not to shuffle the scanning sequence.
-        """
-        super().__init__(parent=parent)
-        self.layout = QGridLayout(self)
-        self.layout.addWidget(QLabel("RangeScan:", self), 0, 0)
-        self.procdesc = procdesc
-        self.state = state
-
-
-class _CenterScan(QWidget):
-    """Widget for a CenterScan type in Scannable Entry.
-    
-    Attributes:
-        layout: The layout of _CenterScan widget.
-        procdesc: The dummy attribute that will be discard at the next PR.
-        state: The dummy attribute that will be discard at next PR.
-    """
-    def __init__(
-        self,
-        procdesc: Dict[str, Any],
-        state: Dict[str, Any],
-        parent: Optional[QWidget] = None
-        ):
-        """Extended.
-
-        Args:
-            procdesc: Each key and its value are:
-              unit: The unit of the number value.
-              scale: The scale factor that is multiplied to the number value.
-              global_step: The step between values changed by the up and down button.
-              global_min: The minimum value. (default=float("-inf"))
-              global_max: The maximum value. (default=float("inf"))
-              If min > max, then they are swapped.
-              ndecimals: The number of displayed decimals.
-            state:
-              span: The length of the scanning sequence.
-              step: The size of step between each number at the scanning sequence.
-              center: The center point of the scanning sequence.
-              randomize: A boolean value that determines 
-                whether or not to shuffle the scanning sequence.
-        """
-        super().__init__(parent=parent)
-        self.layout = QGridLayout(self)
-        self.layout.addWidget(QLabel("CenterScan:", self), 0, 0)
-        self.procdesc = procdesc
-        self.state = state
-
-
-class _ExplicitScan(QWidget):
-    """Widget for a ExplicitScan type in Scannable Entry.
-    
-    Attributes:
-        layout: The layout of _ExplicitScan widget.
-        state: The dummy attribute that will be discard at next PR.
-    """
-    def __init__(
-        self,
-        state: Dict[str, Any],
-        parent: Optional[QWidget] = None
-        ):
-        """Extended.
-
-        Args:
-            procdesc: Each key and its value are:
-              unit: The unit of the number value.
-              scale: The scale factor that is multiplied to the number value.
-              global_step: The step between values changed by the up and down button.
-              global_min: The minimum value. (default=float("-inf"))
-              global_max: The maximum value. (default=float("inf"))
-                If min > max, then they are swapped.
-              ndecimals: The number of displayed decimals.
-            state:
-              sequence: The sequnce that describes the scanning sequence.
-        """
-        super().__init__(parent=parent)
-        self.layout = QGridLayout(self)
-        self.layout.addWidget(QLabel("ExplicitScan:", self), 0, 0)
-        self.state = state
 
 
 class BuilderFrame(QWidget):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -291,6 +291,7 @@ class _DateTimeEntry(_BaseEntry):
         return None
 
 
+# TODO(AIJUH): Add other scan type classes.
 class _ScanEntry(QWidget):
     """Entry class for a scannable object.
     


### PR DESCRIPTION
This closes issue #238. 

Main part of this PR is to add code for processing argument information at _ScanEntry class.

## PR description
Scannable argInfo has following information.

![image](https://github.com/snu-quiqcl/iquip/assets/43592775/9fdcb43c-0037-445f-b3bf-0a5f2d99b478)

`default` is an dictionary that contains argument of each scan type. If scan type differs, its key and value are different. This information is called as `state` in this PR.
`unit`, `scale`, and etc are common to all scan type. This information is called as `procdesc` in this PR.
This information is used when widget for each scan type is created. 

For this PR, I did not implemented widget for each scan type. But this widget will use `state` and `procdesc` at the following PRs.

## Example image
![image](https://github.com/snu-quiqcl/iquip/assets/43592775/00a9996c-86e8-4f79-ac8c-b3c55a42ff8e)
