### PR TITLE
Fetch dataset information using web socket

### DIFF
--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -1076,7 +1076,7 @@ class DataViewerApp(qiwis.BaseApp):
             type=Qt.QueuedConnection,
         )
         self.listThread.finished.connect(self.listThread.deleteLater)
-        self.listThread.start()
+        # self.listThread.start()
 
     @pyqtSlot(bool)
     def _toggleSync(self, checked: bool):
@@ -1117,7 +1117,7 @@ class DataViewerApp(qiwis.BaseApp):
             type=Qt.QueuedConnection,
         )
         self.fetcherThread.finished.connect(self.fetcherThread.deleteLater)
-        self.fetcherThread.start()
+        # self.fetcherThread.start()
         realtimePart.setStatus(enable=True)
 
     @pyqtSlot(np.ndarray, list, list)

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -951,15 +951,15 @@ class _DatasetFetcherThread(QThread):
         if not rawDataset:
             raise _DatasetFetcherThread.DatasetException("Failed to fetch the initial dataset.")
         dataset = np.array(rawDataset)
-        numberOfParameters = dataset.shape[1] if dataset.ndim > 1 else 0
+        numParameters = dataset.shape[1] if dataset.ndim > 1 else 0
         parameters = json.loads(self.websocket.recv())
         if not parameters:
-            parameters = list(map(str, range(numberOfParameters)))
-        rawUnits = self._get("dataset/master/", {"key": f"{self.name}.units"})
-        if rawUnits is None:
-            units = [None] * (numberOfParameters)
+            parameters = list(map(str, range(numParameters)))
+        rawUnits = json.loads(self.websocket.recv())
+        if rawUnits:
+            units = [unit if unit else None for unit in rawUnits]
         else:
-            units = [unit if unit else None for unit in rawUnits[1]]
+            units = [None] * numParameters
         self.initialized.emit(dataset, parameters, units)
         return timestamp
 

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -1010,7 +1010,7 @@ class DataViewerApp(qiwis.BaseApp):
         self.policy: Optional[SimpleScanDataPolicy] = None
         self.axis: Tuple[int, ...] = ()
         self.dataPointIndex: Tuple[int, ...] = ()
-        self.startDatasetListThread(),
+        self.startDatasetListThread()
         self.frame.syncToggled.connect(self._toggleSync)
         self.frame.sourceWidget.axisApplied.connect(self.setAxis)
         self.frame.dataPointWidget.dataTypeChanged.connect(self.setDataType)

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -1051,32 +1051,24 @@ class DataViewerApp(qiwis.BaseApp):
         self.policy: Optional[SimpleScanDataPolicy] = None
         self.axis: Tuple[int, ...] = ()
         self.dataPointIndex: Tuple[int, ...] = ()
+        self.startDatasetListThread(),
         self.frame.syncToggled.connect(self._toggleSync)
         self.frame.sourceWidget.axisApplied.connect(self.setAxis)
         self.frame.dataPointWidget.dataTypeChanged.connect(self.setDataType)
         self.frame.dataPointWidget.thresholdChanged.connect(self.setThreshold)
         self.frame.mainPlotWidget.dataClicked.connect(self.selectDataPoint)
         self.frame.sourceWidget.realtimeDatasetUpdateRequested.connect(
-            self.updateRealtimeDatasetList,
+            self.startDatasetListThread
         )
 
     @pyqtSlot()
-    def updateRealtimeDatasetList(self):
-        """Updates the currently available dataset names."""
-        realtimePart: _RealtimePart = self.frame.sourceWidget.stack.widget(
-            SourceWidget.ButtonId.REALTIME
-        )
-        realtimePart.updateButton.setEnabled(False)
-        self.frame.sourceWidget.datasetBox.clear()
+    def startDatasetListThread(self):
+        """Creates and starts a new _DatasetListThread instance."""
         self.listThread = _DatasetListThread(
             self.constants.proxy_ip,  # pylint: disable=no-member
             self.constants.proxy_port,  # pylint: disable=no-member
         )
         self.listThread.fetched.connect(self.frame.sourceWidget.datasetBox.addItems)
-        self.listThread.finished.connect(
-            functools.partial(realtimePart.updateButton.setEnabled, True),
-            type=Qt.QueuedConnection,
-        )
         self.listThread.finished.connect(self.listThread.deleteLater)
         # self.listThread.start()
 

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -922,9 +922,6 @@ class _DatasetFetcherThread(QThread):
     modified = pyqtSignal(list)
     stopped = pyqtSignal(str)
 
-    class DatasetException(Exception):
-        """Exception for handling errors about the dataset."""
-
     def __init__(self, name: str, ip: str, port: int, parent: Optional[QObject] = None):
         """Extended.
         
@@ -980,11 +977,8 @@ class _DatasetFetcherThread(QThread):
                     self._initialize()
         except ConnectionClosedOK:
             self.stopped.emit("Stopped synchronizing.")
-        except (WebSocketException, _DatasetFetcherThread.DatasetException) as e:
-            if isinstance(e, WebSocketException):
-                msg = "Failed to synchronize the dataset."
-            else:
-                msg = str(e)
+        except WebSocketException:
+            msg = "Failed to synchronize the dataset."
             self.stopped.emit(msg)
             logger.exception(msg)
 

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -14,7 +14,6 @@ from typing import (
 import numpy as np
 import pyqtgraph as pg
 import qiwis
-import requests
 from pyqtgraph.GraphicsScene import mouseEvents
 from PyQt5.QtWidgets import (
     QWidget, QLabel, QPushButton, QRadioButton, QButtonGroup, QStackedWidget,

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -857,10 +857,10 @@ class DataViewerFrame(QSplitter):
 
 
 class _DatasetListThread(QThread):
-    """QThread for fetching the dataset name list from the proxy server.
+    """QThread for fetching the list of available datasets.
     
     Signals:
-        fetched(datasets): The dataset name list is fetched.
+        fetched(datasets): Fetched the dataset name list.
     
     Attributes:
         url: The web socket url.
@@ -872,8 +872,8 @@ class _DatasetListThread(QThread):
         """Extended.
         
         Args:
-            ip: The proxy server IP address.
-            port: The proxy server PORT number.
+            ip: IP address of the proxy server.
+            port: PORT number of the proxy server.
         """
         super().__init__(parent=parent)
         self.url = f"ws://{ip}:{port}/dataset/master/list/"
@@ -882,7 +882,7 @@ class _DatasetListThread(QThread):
         """Returns a new list excluding "*.parameters" and "*.units".
         
         Args:
-            names: The whole dataset name list which includes "*.parameters" and "*.units".
+            names: Dataset name list which includes "*.parameters" and "*.units".
         """
         return [name for name in names if not name.endswith((".parameters", ".units"))]
 

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -861,10 +861,10 @@ class DataViewerFrame(QSplitter):
 
 
 class _DatasetListThread(QThread):
-    """QThread for fetching the dataset list from the proxy server.
+    """QThread for fetching the dataset name list from the proxy server.
     
     Signals:
-        fetched(datasets): The dataset list is fetched.
+        fetched(datasets): The dataset name list is fetched.
     
     Attributes:
         url: The web socket url.
@@ -886,7 +886,7 @@ class _DatasetListThread(QThread):
         """Returns a new list excluding "*.parameters" and "*.units".
         
         Args:
-            names: Dataset name list which includes "*.parameters" and "*.units".
+            names: The whole dataset name list which includes "*.parameters" and "*.units".
         """
         return [name for name in names if not name.endswith((".parameters", ".units"))]
 

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -952,11 +952,9 @@ class _DatasetFetcherThread(QThread):
             raise _DatasetFetcherThread.DatasetException("Failed to fetch the initial dataset.")
         dataset = np.array(rawDataset)
         numberOfParameters = dataset.shape[1] if dataset.ndim > 1 else 0
-        _, parameters = self._get(
-            "dataset/master/",
-            {"key": f"{self.name}.parameters"},
-            (0, list(map(str, range(numberOfParameters)))),
-        )
+        parameters = json.loads(self.websocket.recv())
+        if not parameters:
+            parameters = list(map(str, range(numberOfParameters)))
         rawUnits = self._get("dataset/master/", {"key": f"{self.name}.units"})
         if rawUnits is None:
             units = [None] * (numberOfParameters)

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -947,12 +947,9 @@ class _DatasetFetcherThread(QThread):
             The received timestamp or -1 if it failed.
         """
         self.websocket.send(json.dumps(self.name))
-        dataset = json.loads(self.websocket.recv())
-        if not dataset:
+        rawDataset = json.loads(self.websocket.recv())
+        if not rawDataset:
             raise _DatasetFetcherThread.DatasetException("Failed to fetch the initial dataset.")
-        if response is None or response[0] < 0:
-            return -1
-        timestamp, rawDataset = response
         dataset = np.array(rawDataset)
         numberOfParameters = dataset.shape[1] if dataset.ndim > 1 else 0
         _, parameters = self._get(

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -277,7 +277,6 @@ class _RealtimePart(QWidget):
     """Part widget for configuring realtime mode of the source widget.
     
     Attributes:
-        updateButton: Button for updating dataset list.
         syncButton: Button for start/stop synchronization. When the button is clicked,
           it is disabled. It should be manually enabled after doing proper works.
         label: Status label for showing status including errors.
@@ -292,12 +291,10 @@ class _RealtimePart(QWidget):
     def __init__(self, parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(parent=parent)
-        self.updateButton = QPushButton("Update datasets", self)
         self.syncButton = QPushButton("OFF", self)
         self.syncButton.setCheckable(True)
         self.label = QLabel(self)
         layout = QHBoxLayout(self)
-        layout.addWidget(self.updateButton)
         layout.addWidget(QLabel("Sync:", self))
         layout.addWidget(self.syncButton)
         layout.addWidget(self.label)
@@ -452,9 +449,6 @@ class SourceWidget(QWidget):
         self.axisBoxes["X"].currentIndexChanged.connect(self._handleXIndexChanged)
         self.axisApplyButton.clicked.connect(self._handleApplyClicked)
         self.buttonGroup.idClicked.connect(self.stack.setCurrentIndex)
-        self.stack.widget(SourceWidget.ButtonId.REALTIME).updateButton.clicked.connect(
-            self.realtimeDatasetUpdateRequested,
-        )
 
     def setParameters(self, parameters: Iterable[str], units: Iterable[Optional[str]]):
         """Sets the parameter and unit list.
@@ -1057,11 +1051,7 @@ class DataViewerApp(qiwis.BaseApp):
         self.frame.dataPointWidget.dataTypeChanged.connect(self.setDataType)
         self.frame.dataPointWidget.thresholdChanged.connect(self.setThreshold)
         self.frame.mainPlotWidget.dataClicked.connect(self.selectDataPoint)
-        self.frame.sourceWidget.realtimeDatasetUpdateRequested.connect(
-            self.startDatasetListThread
-        )
 
-    @pyqtSlot()
     def startDatasetListThread(self):
         """Creates and starts a new _DatasetListThread instance."""
         self.listThread = _DatasetListThread(

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -1068,9 +1068,23 @@ class DataViewerApp(qiwis.BaseApp):
             self.constants.proxy_ip,  # pylint: disable=no-member
             self.constants.proxy_port,  # pylint: disable=no-member
         )
-        self.listThread.fetched.connect(self.frame.sourceWidget.datasetBox.addItems)
+        self.listThread.fetched.connect(self._updateDatasetBox)
         self.listThread.finished.connect(self.listThread.deleteLater)
-        # self.listThread.start()
+        self.listThread.start()
+
+    @pyqtSlot(list)
+    def _updateDatasetBox(self, datasets: List[str]):
+        """Updates the dataset box with the new dataset name list.
+        
+        Args:
+            datasets: The new dataset name list.
+        """
+        box = self.frame.sourceWidget.datasetBox
+        currentName = box.currentText()
+        box.clear()
+        box.addItems(datasets)
+        if currentName in datasets:
+            box.setCurrentText(currentName)
 
     @pyqtSlot(bool)
     def _toggleSync(self, checked: bool):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -922,13 +922,7 @@ class _DatasetFetcherThread(QThread):
     modified = pyqtSignal(list)
     stopped = pyqtSignal(str)
 
-    def __init__(
-        self,
-        name: str,
-        ip: str,
-        port: int,
-        parent: Optional[QObject] = None,
-    ):
+    def __init__(self, name: str, ip: str, port: int, parent: Optional[QObject] = None):
         """Extended.
         
         Args:
@@ -942,31 +936,6 @@ class _DatasetFetcherThread(QThread):
         self.websocket: Optional[ClientConnection] = None
         self.mutex = QMutex()
         self.modifyDone = QWaitCondition()
-
-    def _get(
-        self,
-        path: str,
-        params: Dict[str, Any],
-        default: Any = None,
-        timeout: float = 10
-    ) -> Any:
-        """Returns the json()-ed response of a GET request.
-        
-        Args:
-            path: The API path, i.e., the request url is "http://{ip}:{port}/{path}".
-            params: Params argument for the GET request.
-            default: The return value of this method when an exception occurs
-              during the GET request.
-            timeout: Timeout argument for the GET request.
-        """
-        url = f"http://{self.ip}:{self.port}/{path}"
-        try:
-            response = requests.get(url, params=params, timeout=timeout)
-            response.raise_for_status()
-        except requests.exceptions.RequestException:
-            logger.exception("Failed to GET %s", url)
-            return default
-        return response.json()
 
     def _initialize(self) -> float:
         """Fetches the target dataset to initialize the local dataset.
@@ -999,6 +968,10 @@ class _DatasetFetcherThread(QThread):
 
     def run(self):
         """Overridden."""
+        try:
+            self.websocket = connect(self.url)
+        except WebSocketException:
+            logger.exception("Failed to fetch the dataset.")
         timestamp = self._initialize()
         if timestamp < 0:
             self.stopped.emit("Failed to get dataset.")

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -926,13 +926,13 @@ class _DatasetFetcherThread(QThread):
         
         Args:
             name: See the attributes section.
-            ip: The proxy server IP address.
-            port: The proxy server PORT number.
+            ip: IP address of the proxy server.
+            port: PORT number of the proxy server.
         """
         super().__init__(parent=parent)
         self.name = name
         self.url = f"ws://{ip}:{port}/dataset/master/modification/"
-        self.websocket: Optional[ClientConnection] = None
+        self.websocket: ClientConnection
         self.mutex = QMutex()
         self.modifyDone = QWaitCondition()
 

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -23,7 +23,7 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QMutex, QObject, QThread, Qt, QWaitCondition
 from websockets.sync.client import connect, ClientConnection
-from websockets.exceptions import WebSocketException
+from websockets.exceptions import ConnectionClosedOK, WebSocketException
 
 logger = logging.getLogger(__name__)
 
@@ -963,7 +963,6 @@ class _DatasetFetcherThread(QThread):
         """Stops the thread."""
         try:
             self.websocket.close()
-            self.stopped.emit("Stopped synchronizing.")
         except WebSocketException:
             logger.exception("Failed to stop synchronizing.")
 
@@ -981,6 +980,8 @@ class _DatasetFetcherThread(QThread):
                 else:  # dataset is overwritten or removed
                     self.websocket.close()
                     self._initialize()
+        except ConnectionClosedOK:
+            self.stopped.emit("Stopped synchronizing.")
         except (WebSocketException, _DatasetFetcherThread.DatasetException) as e:
             if isinstance(e, WebSocketException):
                 msg = "Failed to synchronize the dataset."

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -22,7 +22,7 @@ from PyQt5.QtWidgets import (
     QCheckBox, QComboBox, QHBoxLayout, QVBoxLayout, QGridLayout,
 )
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QMutex, QObject, QThread, Qt, QWaitCondition
-from websockets.sync.client import connect
+from websockets.sync.client import connect, ClientConnection
 from websockets.exceptions import WebSocketException
 
 logger = logging.getLogger(__name__)
@@ -911,8 +911,8 @@ class _DatasetFetcherThread(QThread):
     
     Attributes:
         name: The target dataset name.
-        ip: The proxy server IP address.
-        port: The proxy server PORT number.
+        url: The web socket url.
+        websocket: The web socket object.
         mutex: Mutex for wait condition modifyDone.
         modifyDone: Wait condition which should be notified when the dataset
           modification is done by the main GUI thread.
@@ -932,15 +932,16 @@ class _DatasetFetcherThread(QThread):
         """Extended.
         
         Args:
-            name, ip, port: See the attributes section.
+            name: See the attributes section.
+            ip: The proxy server IP address.
+            port: The proxy server PORT number.
         """
         super().__init__(parent=parent)
         self.name = name
-        self.ip = ip
-        self.port = port
+        self.url = f"ws://{ip}:{port}/dataset/master/modification/"
+        self.websocket: Optional[ClientConnection] = None
         self.mutex = QMutex()
         self.modifyDone = QWaitCondition()
-        self._running = True
 
     def _get(
         self,

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -945,8 +945,6 @@ class _DatasetFetcherThread(QThread):
         self.websocket = connect(self.url)
         self.websocket.send(json.dumps(self.name))
         rawDataset = json.loads(self.websocket.recv())
-        if not rawDataset:
-            raise _DatasetFetcherThread.DatasetException("Failed to fetch the initial dataset.")
         dataset = np.array(rawDataset)
         numParameters = dataset.shape[1] if dataset.ndim > 1 else 0
         parameters = json.loads(self.websocket.recv())

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -940,12 +940,8 @@ class _DatasetFetcherThread(QThread):
         self.mutex = QMutex()
         self.modifyDone = QWaitCondition()
 
-    def _initialize(self) -> float:
-        """Fetches the target dataset to initialize the local dataset.
-        
-        Returns:
-            The received timestamp or -1 if it failed.
-        """
+    def _initialize(self):
+        """Fetches the target dataset to initialize the local dataset."""
         self.websocket.send(json.dumps(self.name))
         rawDataset = json.loads(self.websocket.recv())
         if not rawDataset:
@@ -961,7 +957,6 @@ class _DatasetFetcherThread(QThread):
         else:
             units = [None] * numParameters
         self.initialized.emit(dataset, parameters, units)
-        return timestamp
 
     def stop(self):
         """Stops the thread."""
@@ -971,13 +966,13 @@ class _DatasetFetcherThread(QThread):
         """Overridden."""
         try:
             self.websocket = connect(self.url)
+            self._initialize()
         except WebSocketException:
             logger.exception("Failed to fetch the dataset.")
         except _DatasetFetcherThread.DatasetException as e:
             msg = str(e)
             self.stopped.emit(msg)
             logger.exception(msg)
-        timestamp = self._initialize()
         if timestamp < 0:
             self.stopped.emit("Failed to get dataset.")
             return

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -861,13 +861,13 @@ class DataViewerFrame(QSplitter):
 
 
 class _DatasetListThread(QThread):
-    """QThread for fetching the list of available datasets.
+    """QThread for fetching the dataset list from the proxy server.
     
     Signals:
-        fetched(datasets): Fetched the dataset name list.
+        fetched(datasets): The dataset list is fetched.
     
     Attributes:
-        url: The GET request url.
+        url: The web socket url.
     """
 
     fetched = pyqtSignal(list)
@@ -876,11 +876,11 @@ class _DatasetListThread(QThread):
         """Extended.
         
         Args:
-            ip: IP address of the proxy server.
-            port: PORT number of the proxy server.
+            ip: The proxy server IP address.
+            port: The proxy server PORT number.
         """
         super().__init__(parent=parent)
-        self.url = f"http://{ip}:{port}/dataset/master/list/"
+        self.url = f"ws://{ip}:{port}/dataset/master/list/"
 
     def _filter(self, names: List[str]) -> List[str]:
         """Returns a new list excluding "*.parameters" and "*.units".


### PR DESCRIPTION
Now, the dataviewer fetches dataset through web socket implemented in snu-quiqcl/artiq-proxy#117.

In GUI, the only modification is that the button to update dataset list is removed.

![image](https://github.com/snu-quiqcl/iquip/assets/76851886/19086bdf-e187-4c72-b734-09ce98153429)

I tested that
- the dataset list is updated in real-time.
- the selected dataset is fetched in real-time.
- clicking the stop button is reflected immediately.

For test, the following example experiment may be helpful.

```python
import time
from artiq.experiment import *

class DatasetTest(EnvExperiment):
    """Dataset Test"""

    def build(self):
        self.setattr_device("core")

    @kernel
    def run(self):
        self.set_dataset("test_a", [], broadcast=True)
        self.set_dataset("test_a.parameters", ["shot"], broadcast=True)
        self.set_dataset("test_a.units", [""], broadcast=True)
        time.sleep(5)

        for cnt in range(10):
            self.append_to_dataset("test_a", [cnt, cnt])
            time.sleep(1)
        time.sleep(5)

        self.set_dataset("test_a", [], broadcast=True)
        time.sleep(1)
        for cnt in range(10):
            self.append_to_dataset("test_a", [cnt, cnt])
            time.sleep(1)

```

This closes #236.