### PR TITLE
Synchronize TTL status

### DIFF
--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -366,22 +366,6 @@ class _RemotePart(QWidget):
         self.ridEditingFinished.emit(str(self.spinbox.value()))
 
 
-class MonitorStatusWidget(QWidget):
-    """Widget for showing monitor status.
-    
-    Attributes:
-        statusLabel: The label for showing monitor status.
-    """
-
-    def __init__(self, parent: Optional[QWidget] = None):
-        """Extended."""
-        super().__init__(parent=parent)
-        self.statusLabel = QLabel("Not Overriding?", self)
-        # layout
-        layout = QVBoxLayout(self)
-        layout.addWidget(self.statusLabel)
-
-
 class SourceWidget(QWidget):
     """Widget for data source selection.
 
@@ -800,7 +784,6 @@ class DataViewerFrame(QSplitter):
     """Frame for data viewer app.
     
     Attributes:
-        monitorStatusWidget: MonitorStatusWidget for showing monitor status.
         sourceWidget: SourceWidget for source selection.
         dataPointWidget: DataPointWidget for data point configuration.
         mainPlotWidget: MainPlotWidget for the main plot.
@@ -816,22 +799,18 @@ class DataViewerFrame(QSplitter):
     def __init__(self, parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(parent=parent)
-        monitorStatusBox = QGroupBox("Monitor status", self)
         sourceBox = QGroupBox("Source", self)
         dataPointBox = QGroupBox("Data point", self)
         mainPlotBox = QGroupBox("Main plot", self)
         toolBox = QGroupBox("Tools", self)
-        self.monitorStatusWidget = MonitorStatusWidget(self)
         self.sourceWidget = SourceWidget(self)
         self.dataPointWidget = DataPointWidget(self)
         self.mainPlotWidget = MainPlotWidget(self)
-        QHBoxLayout(monitorStatusBox).addWidget(self.monitorStatusWidget)
         QHBoxLayout(sourceBox).addWidget(self.sourceWidget)
         QHBoxLayout(dataPointBox).addWidget(self.dataPointWidget)
         QHBoxLayout(mainPlotBox).addWidget(self.mainPlotWidget)
         leftWidget = QWidget(self)
         leftLayout = QVBoxLayout(leftWidget)
-        leftLayout.addWidget(monitorStatusBox)
         leftLayout.addWidget(sourceBox)
         leftLayout.addWidget(dataPointBox)
         self.addWidget(leftWidget)
@@ -846,18 +825,6 @@ class DataViewerFrame(QSplitter):
     def datasetName(self) -> str:
         """Returns the current dataset name in the line edit."""
         return self.sourceWidget.datasetBox.currentText()
-
-    def updateMonitorStatus(self, override: bool):
-        """Updates the monitor status viewer.
-        
-        Args:
-            override: Whether overriding is on or off.
-        """
-        label = self.monitorStatusWidget.statusLabel
-        if override:
-            label.setText("Overriding")
-        else:
-            label.setText("Not Overriding")
 
 
 class _DatasetListThread(QThread):
@@ -1257,18 +1224,6 @@ class DataViewerApp(qiwis.BaseApp):
         if dataType == DataPointWidget.DataType.AVERAGE:
             return np.mean
         return functools.partial(p_1, self.frame.dataPointWidget.threshold())
-
-    def receivedSlot(self, channelName: str, content: Any):
-        """Overridden.
-        
-        The channels covered are as follows:
-            monitor: Updates the monitor status viewer in source widget.
-        """
-        if channelName == self.constants.channels["monitor"]:  # pylint: disable=no-member
-            self.frame.updateMonitorStatus(content["override"])
-        else:
-            logger.warning("The message %s was ignored because handling for channel %s "
-                           "is not implemented.", content, channelName)
 
 
 class SimpleScanDataPolicy:

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -175,8 +175,10 @@ class TTLControllerFrame(QWidget):
         layout.addStretch()
         layout.addWidget(overrideButtonBox)
         # signal connection
-        self.overrideOnButton.clicked.connect(lambda: self.overrideChangeRequested.emit(True))
-        self.overrideOffButton.clicked.connect(lambda: self.overrideChangeRequested.emit(False))
+        self.overrideOnButton.clicked.connect(
+            functools.partial(self.overrideChangeRequested.emit, True))
+        self.overrideOffButton.clicked.connect(
+            functools.partial(self.overrideChangeRequested.emit, False))
 
 
 class _TTLStatusThread(QThread):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -1023,25 +1023,31 @@ class DeviceMonitorApp(qiwis.BaseApp):  # pylint: disable=too-many-instance-attr
             widget.switchClicked.connect(functools.partial(self._setDDSSwitch, device, channel))
         self._startTTLStatusThread()
 
-    @pyqtSlot(list, list)
-    def _setTTLOverride(self, devices: List[str], overrides: List[bool]):
+    @pyqtSlot(list, object)
+    def _setTTLOverride(self, devices: List[str], overrides: Union[bool, List[bool]]):
         """Sets the override of the target TTL channels through _TTLLevelThread.
         
         Args:
             See _TTLOverrideThread arguments section.
+            If overrides is a single bool, it is replaced with a list with the same values.
         """
+        if isinstance(overrides, bool):
+            overrides = [overrides] * len(devices)
         self.ttlOverrideThread = _TTLOverrideThread(devices, overrides,
                                                     self.proxy_ip, self.proxy_port)
         self.ttlOverrideThread.finished.connect(self.ttlOverrideThread.deleteLater)
         self.ttlOverrideThread.start()
 
-    @pyqtSlot(list, list)
-    def _setTTLLevel(self, devices: List[str], levels: List[bool]):
+    @pyqtSlot(list, object)
+    def _setTTLLevel(self, devices: List[str], levels: Union[bool, List[bool]]):
         """Sets the level of the target TTL channels through _TTLLevelThread.
         
         Args:
             See _TTLLevelThread arguments section.
+            If levels is a single bool, it is replaced with a list with the same values.
         """
+        if isinstance(levels, bool):
+            levels = [levels] * len(devices)
         self.ttlLevelThread = _TTLLevelThread(devices, levels, self.proxy_ip, self.proxy_port)
         self.ttlLevelThread.finished.connect(self.ttlLevelThread.deleteLater)
         self.ttlLevelThread.start()

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -163,15 +163,16 @@ class TTLControllerFrame(QWidget):
             row, column = idx // numColumns, idx % numColumns
             self.ttlWidgets[name] = ttlWidget
             ttlWidgetLayout.addWidget(ttlWidget, row, column)
-        self.overrideOnButton = QPushButton(self)
-        self.overrideOffButton = QPushButton(self)
+        overrideButtonBox = QGroupBox("Override", self)
+        self.overrideOnButton = QPushButton("ON", self)
+        self.overrideOffButton = QPushButton("OFF", self)
         # layout
-        buttonLayout = QHBoxLayout()
-        buttonLayout.addWidget(self.overrideOnButton)
-        buttonLayout.addWidget(self.overrideOffButton)
+        overrideButtonLayout = QHBoxLayout(overrideButtonBox)
+        overrideButtonLayout.addWidget(self.overrideOnButton)
+        overrideButtonLayout.addWidget(self.overrideOffButton)
         layout = QVBoxLayout(self)
         layout.addLayout(ttlWidgetLayout)
-        layout.addLayout(buttonLayout)
+        layout.addWidget(overrideButtonBox)
         # signal connection
         self.overrideOnButton.clicked.connect(lambda: self.overrideChangeRequested.emit(True))
         self.overrideOffButton.clicked.connect(lambda: self.overrideChangeRequested.emit(False))

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Mapping, Optional, Tuple, Union
 
 import requests
 from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal, pyqtSlot
+from PyQt5.QtGui import QFont
 from PyQt5.QtWidgets import (
     QCheckBox, QDoubleSpinBox, QGridLayout, QGroupBox, QHBoxLayout,
     QLabel, QPushButton, QSlider, QVBoxLayout, QWidget
@@ -51,6 +52,8 @@ class TTLControllerWidget(QWidget):
         deviceLabel = QLabel(device, self)
         deviceLabel.setAlignment(Qt.AlignRight)
         self.label = QLabel("", self)
+        self.label.setAlignment(Qt.AlignCenter)
+        self.label.setFont(QFont("Arial", 20))
         self.button = QPushButton("", self)
         self.button.setCheckable(True)
         # layout

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -109,8 +109,6 @@ class TTLControllerFrame(QWidget):
 
     Signals:
         levelChangedRequested(level): Requested to change the level.
-        overrideChanged(override): Current override value is changed.
-        overrideChangedRequested(override): Requested to change the override value.
     """
 
     levelChangedRequested = pyqtSignal(bool)

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -1004,6 +1004,9 @@ class DeviceMonitorApp(qiwis.BaseApp):  # pylint: disable=too-many-instance-attr
         self.ddsControllerFrame = DDSControllerFrame(ddsInfo)
         self.ttlToName = {v: k for k, v in ttlInfo.items()}
         # signal connection
+        self.ttlControllerFrame.levelChangedRequested.connect(
+            functools.partial(self._setTTLLevel, None)
+        )
         self.ttlControllerFrame.overrideChangedRequested.connect(self._setTTLOverride)
         for name_, device in ttlInfo.items():
             self.ttlControllerFrame.ttlWidgets[name_].levelChangedRequested.connect(
@@ -1039,7 +1042,7 @@ class DeviceMonitorApp(qiwis.BaseApp):  # pylint: disable=too-many-instance-attr
         self.broadcast(channelName, content)
 
     @pyqtSlot(str, bool)
-    def _setTTLLevel(self, device: str, level: bool):
+    def _setTTLLevel(self, device: Optional[str], level: bool):
         """Sets the level of the target TTL channel through _TTLLevelThread.
         
         Args:

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -1135,7 +1135,7 @@ class DeviceMonitorApp(qiwis.BaseApp):  # pylint: disable=too-many-instance-attr
         """Creates and starts a new _TTLStatusThread instance."""
         devices = list(self.ttlToName)
         self.ttlStatusThread = _TTLStatusThread(self.proxy_ip, self.proxy_port, devices)
-        self.ttlStatusThread.fetched.connect(self._updateTTLStatus)
+        self.ttlStatusThread.fetched.connect(self._updateTTLStatus, type=Qt.QueuedConnection)
         self.ttlStatusThread.finished.connect(self.ttlStatusThread.deleteLater)
         self.ttlStatusThread.start()
 

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -103,13 +103,17 @@ class TTLControllerFrame(QWidget):
     Attributes:
         ttlWidgets: Dictionary with TTL controller widgets.
           Each key is a TTL channel name, and its value is the corresponding TTLControllerWidget.
-        button: Button for setting the override.
+        levelOnButton: Button for setting the level to on of all TTL devices.
+        levelOffButton: Button for setting the level to off of all TTL devices.
+        overrideButton: Button for setting the override of all TTL devices.
 
     Signals:
+        levelChangedRequested(level): Requested to change the level.
         overrideChanged(override): Current override value is changed.
         overrideChangedRequested(override): Requested to change the override value.
     """
 
+    levelChangedRequested = pyqtSignal(bool)
     overrideChanged = pyqtSignal(bool)
     overrideChangedRequested = pyqtSignal(bool)
 
@@ -139,16 +143,28 @@ class TTLControllerFrame(QWidget):
             row, column = idx // numColumns, idx % numColumns
             self.ttlWidgets[name] = ttlWidget
             ttlWidgetLayout.addWidget(ttlWidget, row, column)
-        self.button = QPushButton("", self)
-        self.button.setCheckable(True)
+        self.levelOnButton = QPushButton("ON", self)
+        # self.levelOnButton.setAlignment(Qt.AlignLeft)
+        self.levelOffButton = QPushButton("OFF", self)
+        # self.levelOffButton.setAlignment(Qt.AlignRight)
+        self.overrideButton = QPushButton("", self)
+        self.overrideButton.setCheckable(True)
         # layout
+        levelLayout = QHBoxLayout()
+        levelLayout.addWidget(self.levelOnButton)
+        levelLayout.addWidget(self.levelOffButton)
         layout = QVBoxLayout(self)
         layout.addLayout(ttlWidgetLayout)
-        layout.addWidget(self.button)
+        layout.addLayout(levelLayout)
+        layout.addWidget(self.overrideButton)
         # signal connection
+        self.levelOnButton.clicked.connect(lambda: self.levelChangedRequested.emit(True))
+        self.levelOffButton.clicked.connect(lambda: self.levelChangedRequested.emit(False))
         self.overrideChanged.connect(self._setButtonText)
-        self.button.clicked.connect(functools.partial(self.button.setEnabled, False))
-        self.button.clicked.connect(self.overrideChangedRequested)
+        self.overrideButton.clicked.connect(
+            functools.partial(self.overrideButton.setEnabled, False)
+        )
+        self.overrideButton.clicked.connect(self.overrideChangedRequested)
 
     @pyqtSlot(bool)
     def _setButtonText(self, override: bool):
@@ -158,11 +174,11 @@ class TTLControllerFrame(QWidget):
             override: Whether the override value is on or off.
         """
         if override:
-            self.button.setText("Overriding")
+            self.overrideButton.setText("Overriding")
         else:
-            self.button.setText("Not Overriding")
-        self.button.setChecked(override)
-        self.button.setEnabled(True)
+            self.overrideButton.setText("Not Overriding")
+        self.overrideButton.setChecked(override)
+        self.overrideButton.setEnabled(True)
 
 
 class _TTLStatusThread(QThread):

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -198,7 +198,7 @@ class _TTLStatusThread(QThread):
 
     fetched = pyqtSignal(dict)
 
-    def __init__(self, ip: str, port: int, devices: tuple[str], parent: Optional[QObject] = None):
+    def __init__(self, ip: str, port: int, devices: Tuple[str], parent: Optional[QObject] = None):
         """Extended.
         
         Args:
@@ -1114,7 +1114,7 @@ class DeviceMonitorApp(qiwis.BaseApp):  # pylint: disable=too-many-instance-attr
         self.ddsSwitchThread.start()
 
     @pyqtSlot(dict)
-    def _updateTTLStatus(self, status: dict[str, Any]):
+    def _updateTTLStatus(self, status: Dict[str, Any]):
         """Updates the TTL status.
         
         Args:

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -159,6 +159,33 @@ class TTLControllerFrame(QWidget):
         self.button.setEnabled(True)
 
 
+class _TTLStatusThread(QThread):
+    """QThread for fetching the TTL status from the proxy server.
+    
+    Signals:
+        fetched(status): The TTL status is fetched.
+          The "status" is a dictionary with three keys.
+            "outputs": A dictionary with a TTL name and its output value.
+            "levels": A dictionary with a TTL name and its level.
+            "overriding": The override value. If None, there is no change.
+    
+    Attributes:
+        url: The web socket url.
+    """
+
+    fetched = pyqtSignal(dict)
+
+    def __init__(self, ip: str, port: int, parent: Optional[QObject] = None):
+        """Extended.
+        
+        Args:
+            ip: The proxy server IP address.
+            port: The proxy server PORT number.
+        """
+        super().__init__(parent=parent)
+        self.url = f"ws://{ip}:{port}/ttl/status/"
+
+
 class _TTLOverrideThread(QThread):
     """QThread for setting the override of all TTL channels through the proxy server.
     

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -78,11 +78,11 @@ class TTLControllerWidget(QWidget):
         # signal connection
         self.outputChanged.connect(self._setLabelText)
         self.levelChanged.connect(functools.partial(self.levelButton.setEnabled, True))
-        self.levelChanged.connect(self._setLevelButtonText)
+        self.levelChanged.connect(self._setLevelButtonStatus)
         self.levelButton.clicked.connect(functools.partial(self.levelButton.setEnabled, False))
         self.levelButton.clicked.connect(self.levelChangeRequested)
         self.overrideChanged.connect(functools.partial(self.overrideButton.setEnabled, True))
-        self.overrideChanged.connect(self._setOverrideButtonText)
+        self.overrideChanged.connect(self._setOverrideButtonStatus)
         self.overrideButton.clicked.connect(
             functools.partial(self.overrideButton.setEnabled, False))
         self.overrideButton.clicked.connect(self.overrideChangeRequested)
@@ -100,8 +100,8 @@ class TTLControllerWidget(QWidget):
             self.label.setText("LOW")
 
     @pyqtSlot(bool)
-    def _setLevelButtonText(self, level: bool):
-        """Sets the level button text.
+    def _setLevelButtonStatus(self, level: bool):
+        """Sets the level button status.
 
         Args:
             level: Whether the current level is on or off.
@@ -113,8 +113,8 @@ class TTLControllerWidget(QWidget):
         self.levelButton.setChecked(level)
 
     @pyqtSlot(bool)
-    def _setOverrideButtonText(self, override: bool):
-        """Sets the override button text.
+    def _setOverrideButtonStatus(self, override: bool):
+        """Sets the override button status.
 
         Args:
             override: Whether the current override is on or off.

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -181,35 +181,33 @@ class _TTLStatusThread(QThread):
     """QThread for fetching the TTL status from the proxy server.
     
     Signals:
-        fetched(status): The TTL status is fetched.
-          The "status" is a dictionary with three keys.
-            "outputs": A dictionary with a TTL name and its output value.
-            "levels": A dictionary with a TTL name and its level.
-            "overriding": The override value. If None, there is no change.
-    
+        fetched(modifications): The modifications of TTL status is fetched.
+          The "modifications" is a dictionary with three keys; "probe", "level", and "override".
+          Its value is a dictionary whose key is a TTL name and value is the modified value.
+
     Attributes:
-        url: The web socket url.
-        devices: The tuple of TTL names.
+        url: Web socket url.
+        devices: List of TTL names.
     """
 
     fetched = pyqtSignal(dict)
 
-    def __init__(self, ip: str, port: int, devices: Tuple[str], parent: Optional[QObject] = None):
+    def __init__(self, ip: str, port: int, devices: List[str], parent: Optional[QObject] = None):
         """Extended.
         
         Args:
-            ip: The proxy server IP address.
-            port: The proxy server PORT number.
+            ip: proxy server IP address.
+            port: proxy server PORT number.
             devices: See attribute section.
         """
         super().__init__(parent=parent)
-        self.url = f"ws://{ip}:{port}/ttl/status/"
+        self.url = f"ws://{ip}:{port}/ttl/status/modification/"
         self.devices = devices
 
     def run(self):
         """Overridden.
         
-        Fetches the TTL status from the proxy server.
+        Fetches the modifications of TTL status from the proxy server.
 
         Whenever fetched, the fetched signal is emitted.
         """
@@ -220,15 +218,15 @@ class _TTLStatusThread(QThread):
                     status = json.loads(response)
                     self.fetched.emit(status)
         except WebSocketException:
-            logger.exception("Failed to fetch the TTL status.")
+            logger.exception("Failed to fetch the modifications of TTL status.")
 
 
 class _TTLOverrideThread(QThread):
     """QThread for setting the override of the target TTL channels through the proxy server.
     
     Attributes:
-        url: The POST request url.
-        data: The POST request body.
+        url: POST request url.
+        data: POST request body.
     """
 
     def __init__(
@@ -269,8 +267,8 @@ class _TTLLevelThread(QThread):
     """QThread for setting the level of the target TTL channels through the proxy server.
     
     Attributes:
-        url: The POST request url.
-        data: The POST request body.
+        url: POST request url.
+        data: POST request body.
     """
 
     def __init__(

--- a/iquip/apps/monitor.py
+++ b/iquip/apps/monitor.py
@@ -172,6 +172,7 @@ class TTLControllerFrame(QWidget):
         overrideButtonLayout.addWidget(self.overrideOffButton)
         layout = QVBoxLayout(self)
         layout.addLayout(ttlWidgetLayout)
+        layout.addStretch()
         layout.addWidget(overrideButtonBox)
         # signal connection
         self.overrideOnButton.clicked.connect(lambda: self.overrideChangeRequested.emit(True))


### PR DESCRIPTION
_(updated)_

For details, please refer to #246.

This was implemented to fit with snu-quiqcl/artiq-proxy#131.
Now, TTL output values, levels, and overrides are synchronized.
In addition, one can set override of each TTL device separately.

Note that in the past, the function to set override of all TTLs affected all TTLs defined in `config.json` of ARTIQ-PROXY, but now it only affects TTLs controlled in this IQUIP, i.e. defined in the config file of IQUIP.

![image](https://github.com/snu-quiqcl/iquip/assets/76851886/126302c0-e32d-4fea-8a04-5c1611e3d4fe)

This closes #246.