### PR TITLE
Implement NoScan and add BaseScan

### DIFF
--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -9,8 +9,8 @@ import requests
 from PyQt5.QtCore import QDateTime, QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
     QAbstractButton, QButtonGroup, QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QGridLayout,
-    QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem, QPushButton, QRadioButton, QSpinBox,
-    QStackedWidget, QVBoxLayout, QWidget
+    QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem, QPushButton, QRadioButton,
+    QSpinBox, QStackedWidget, QVBoxLayout, QWidget
 )
 
 import qiwis
@@ -307,6 +307,7 @@ class _ScanEntry(_BaseEntry):
         scanWidgets: The dictionary that contains each scan widget.
     """
     @unique
+    # pylint: disable=invalid-name
     class ScanType(IntEnum):
         """Enum class for mapping id to each scannable type."""
         NoScan = 0

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -308,7 +308,7 @@ class _ScanEntry(_BaseEntry):
     """
     def __init__(
         self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None
-        ): # pylint: disable=too-many-arguments
+        ): # pylint: disable=too-many-locals
         """Extended.
 
         Args:

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -2,8 +2,8 @@
 
 import json
 import logging
-from typing import Any, Dict, Optional, Tuple, Union
 from enum import IntEnum, unique
+from typing import Any, Dict, Optional, Tuple, Union
 
 import requests
 from PyQt5.QtCore import QDateTime, QObject, Qt, QThread, pyqtSignal, pyqtSlot
@@ -303,15 +303,17 @@ class _ScanEntry(_BaseEntry):
           "NoScan", "RangeScan", "CenterScan", and "ExplicitScan": The dictionary that contains 
             argument info of the corresponding scannable type.
         stackedWidget: The QStackedWidget that contains widgets of each scannable type.
-        scanButtonGroup: The QButtonGroup that groups QRadiobuttons for selecting scan widget.
+        scanButtonGroup: The QButtonGroup that groups QRadiobuttons for selecting scan widgets.
         scanWidgets: The dictionary that contains each scan widget.
     """
+
     @unique
     # pylint: disable=invalid-name
     class ScanType(IntEnum):
         """Enum class for mapping id to each scannable type."""
         NoScan = 0
         RangeScan = 1
+
     # pylint: disable=too-many-locals
     def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
         """Extended.
@@ -343,14 +345,14 @@ class _ScanEntry(_BaseEntry):
             scanWidget = scanCls(procdesc, self.state[ty])
             self.stackedWidget.addWidget(scanWidget)
             self.scanWidgets[ty] = scanWidget
-            button = QRadioButton(buttonName)
+            button = QRadioButton(buttonName, self)
             buttonLayout.addWidget(button)
             self.scanButtonGroup.addButton(button, buttonId)
         self.scanButtonGroup.buttonClicked.connect(self.scanTypeClicked)
         selected = self.state["selected"]
         self.stackedWidget.setCurrentWidget(self.scanWidgets[selected])
-        selectedEnum = _ScanEntry.ScanType[selected]
-        selectedButton = self.scanButtonGroup.button(selectedEnum.value)
+        selectedScanType = _ScanEntry.ScanType[selected]
+        selectedButton = self.scanButtonGroup.button(selectedScanType.value)
         selectedButton.setChecked(True)
         # layout
         scanLayout = QVBoxLayout()
@@ -378,7 +380,7 @@ class _ScanEntry(_BaseEntry):
             state["selected"] = defaults[0]["ty"]
             for default in defaults:
                 ty = default["ty"]
-                if ty not in ["NoScan", "RangeScan", "CenterScan", "ExplicitScan"]:
+                if ty not in ("NoScan", "RangeScan", "CenterScan", "ExplicitScan"):
                     logger.warning("Unknown scan type: %s", ty)
                 else:
                     state[ty] = default
@@ -406,15 +408,15 @@ class _ScanEntry(_BaseEntry):
 
     @pyqtSlot(QAbstractButton)
     def scanTypeClicked(self, selectedButton: QAbstractButton):
-        """Switches current scan widget at stacked layout in _ScanEntry.
+        """Switches current scan widget in the stacked layout.
         
-        Once the checked button at radiobutton group clicked, this is called.
+        Once a scan type button at radiobutton group clicked, this is called.
 
         Attributes:
-            selectedButton: A QRadioButton that is clicked.
+            selectedButton: The clicked QRadioButton.
         """
-        selectedEnum = _ScanEntry.ScanType(self.scanButtonGroup.id(selectedButton))
-        self.stackedWidget.setCurrentWidget(self.scanWidgets[selectedEnum.name])
+        selectedType = _ScanEntry.ScanType(self.scanButtonGroup.id(selectedButton))
+        self.stackedWidget.setCurrentWidget(self.scanWidgets[selectedType.name])
 
 
 class _BaseScan(QWidget):

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -403,8 +403,8 @@ class _ScanEntry(_BaseEntry):
         
         Returns the dictionary of the selected scannable arguments.
         """
-        selected = self.state["selected"]
-        return self.state[selected]
+        selectedWidget = self.stackedWidget.currentWidget()
+        return selectedWidget.scanArguments()
 
     @pyqtSlot(QAbstractButton)
     def scanTypeClicked(self, selectedButton: QAbstractButton):
@@ -415,8 +415,8 @@ class _ScanEntry(_BaseEntry):
         Attributes:
             selectedButton: The clicked QRadioButton.
         """
-        selectedType = _ScanEntry.ScanType(self.scanButtonGroup.id(selectedButton))
-        self.stackedWidget.setCurrentWidget(self.scanWidgets[selectedType.name])
+        selectedScanType = _ScanEntry.ScanType(self.scanButtonGroup.id(selectedButton))
+        self.stackedWidget.setCurrentWidget(self.scanWidgets[selectedScanType.name])
 
 
 class _BaseScan(QWidget):
@@ -507,6 +507,7 @@ class _NoScan(_BaseScan):
         Returns the arguments of the no scan.
         """
         return {
+            "ty": "NoScan",
             "value": self.valueSpinBox.value(),
             "repetitions": self.repetitionsSpinBox.value()
         }
@@ -564,10 +565,12 @@ class _RangeScan(_BaseScan):
         Returns the arguments of the range scan.
         """
         return {
+            "ty": "RangeScan",
             "start": self.startSpinBox.value(),
             "stop": self.stopSpinBox.value(),
             "npoints": self.npointsSpinBox.value(),
-            "randomize": self.randomizeCheckBox.isChecked()
+            "randomize": self.randomizeCheckBox.isChecked(),
+            "seed": None
         }
 
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -306,8 +306,9 @@ class _ScanEntry(_BaseEntry):
         scanWidgetsDict: The dictionary that contains each scan widget.
         scanButtonsDict: The dictionary that describes id of QRadiobutton at scanButtonGroup.
     """
-    def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
-        # pylint: disable=too-many-arguments
+    def __init__(
+        self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None
+        ): # pylint: disable=too-many-arguments
         """Extended.
 
         Args:

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -403,14 +403,14 @@ class _ScanEntry(_BaseEntry):
         
         Returns the dictionary of the selected scannable arguments.
         """
-        selectedWidget = self.stackedWidget.currentWidget()
-        return selectedWidget.scanArguments()
+        selectedScanWidget = self.stackedWidget.currentWidget()
+        return selectedScanWidget.scanArguments()
 
     @pyqtSlot(QAbstractButton)
     def scanTypeClicked(self, selectedButton: QAbstractButton):
         """Switches current scan widget in the stacked layout.
         
-        Once a scan type button at radiobutton group clicked, this is called.
+        Once a scan type button in the button group is clicked, this is called.
 
         Attributes:
             selectedButton: The clicked QRadioButton.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -8,9 +8,9 @@ from typing import Any, Dict, Optional, Tuple, Union
 import requests
 from PyQt5.QtCore import QDateTime, QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
-    QButtonGroup, QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QGridLayout, QHBoxLayout,
-    QLabel, QLineEdit, QListWidget, QListWidgetItem, QPushButton, QRadioButton, QSpinBox,
-    QStackedWidget, QVBoxLayout, QWidget
+    QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QGridLayout, QHBoxLayout, QLabel,
+    QLineEdit, QListWidget, QListWidgetItem, QPushButton, QRadioButton, QSpinBox, QStackedWidget,
+    QVBoxLayout, QWidget
 )
 
 import qiwis
@@ -321,8 +321,8 @@ class _ScanEntry(_BaseEntry):
               ndecimals: The number of displayed decimals.
         """
         super().__init__(name, argInfo, parent=parent)
-        self.state = self.get_state()
-        procdesc = self.get_procdesc()
+        self.state = self.getState()
+        procdesc = self.getProcdesc()
         self.stackWidget = QStackedWidget(self)
         self.widgets = OrderedDict()
         self.widgets["NoScan"] = _NoScan(procdesc, self.state["NoScan"])
@@ -332,12 +332,10 @@ class _ScanEntry(_BaseEntry):
         self.radioButtons = OrderedDict()
         self.radioButtons["NoScan"] = QRadioButton("No scan")
         self.radioButtons["RangeScan"] = QRadioButton("Range")
-        scan_type = QButtonGroup(self)
         buttonLayout = QHBoxLayout()
         for _, b in enumerate(self.radioButtons.values()):
             buttonLayout.addWidget(b)
-            scan_type.addButton(b)
-            b.toggled.connect(self.scan_type_toggled)
+            b.toggled.connect(self.scanTypeToggled)
         selected = self.state["selected"]
         self.radioButtons[selected].setChecked(True)
         # layout
@@ -346,7 +344,7 @@ class _ScanEntry(_BaseEntry):
         scanLayout.addWidget(self.stackWidget)
         self.layout.addLayout(scanLayout)
 
-    def get_state(self) -> Dict[str, Any]:
+    def getState(self) -> Dict[str, Any]:
         """Gets a dictionary that describes default parameters of all scannable types."""
         scale = self.argInfo["scale"]
         state = {
@@ -372,7 +370,7 @@ class _ScanEntry(_BaseEntry):
                     state[ty] = default
         return state
 
-    def get_procdesc(self) -> Dict[str, Any]:
+    def getProcdesc(self) -> Dict[str, Any]:
         """Gets a procdesc dictionary that describes common parameters of the scannable object."""
         procdesc = {
             "unit": self.argInfo["unit"],
@@ -392,7 +390,7 @@ class _ScanEntry(_BaseEntry):
         selected = self.state["selected"]
         return self.state[selected]
 
-    def scan_type_toggled(self):
+    def scanTypeToggled(self):
         """Switches current scan widget at stacked layout in _ScanEntry.
         
         Once the checked button at radiobutton group changed, this is called.
@@ -423,7 +421,7 @@ class _BaseScan(QWidget):
         self.scale = procdesc["scale"]
         self.layout = QGridLayout(self)
 
-    def apply_properties(self, widget: QDoubleSpinBox, procdesc: Dict[str, Any]):
+    def applyProperties(self, widget: QDoubleSpinBox, procdesc: Dict[str, Any]):
         """Adds properties to the spin box widget.
 
         Attributes:
@@ -443,7 +441,7 @@ class _BaseScan(QWidget):
         widget.setSuffix(unit)
         widget.setSingleStep(step / self.scale)
 
-    def get_scan_args(self) -> Dict[str, Any]:
+    def getScanArgs(self) -> Dict[str, Any]:
         """Returns the arguments of the scannable object.
         
         This must be overridden in the subclass.
@@ -474,7 +472,7 @@ class _NoScan(_BaseScan):
         """
         super().__init__(procdesc, parent=parent)
         self.valueSpinBox = QDoubleSpinBox(self)
-        self.apply_properties(self.valueSpinBox, procdesc)
+        self.applyProperties(self.valueSpinBox, procdesc)
         self.valueSpinBox.setValue(state["value"]/self.scale)
         repetitionsSpinBox = QSpinBox(self)
         repetitionsSpinBox.setMinimum(1)
@@ -486,7 +484,7 @@ class _NoScan(_BaseScan):
         self.layout.addWidget(QLabel("Repetitions:"), 1, 0)
         self.layout.addWidget(repetitionsSpinBox, 1, 1)
 
-    def get_scan_args(self) -> Dict[str, Any]:
+    def getScanArgs(self) -> Dict[str, Any]:
         """Overridden.
         
         Returns the arguments of the no scan.
@@ -524,14 +522,14 @@ class _RangeScan(_BaseScan):
         """
         super().__init__(procdesc, parent=parent)
         self.startSpinBox = QDoubleSpinBox(self)
-        self.apply_properties(self.startSpinBox, procdesc)
+        self.applyProperties(self.startSpinBox, procdesc)
         self.startSpinBox.setValue(state["start"] / self.scale)
         self.npointsSpinBox = QSpinBox(self)
         self.npointsSpinBox.setMinimum(1)
         self.npointsSpinBox.setMaximum((1 << 31) - 1)
         self.npointsSpinBox.setValue(state["npoints"])
         self.stopSpinBox = QDoubleSpinBox(self)
-        self.apply_properties(self.stopSpinBox, procdesc)
+        self.applyProperties(self.stopSpinBox, procdesc)
         self.stopSpinBox.setValue(state["stop"] / self.scale)
         self.randomizeCheckBox = QCheckBox("Randomize", self)
         self.randomizeCheckBox.setChecked(state["randomize"])
@@ -544,7 +542,7 @@ class _RangeScan(_BaseScan):
         self.layout.addWidget(self.stopSpinBox, 2, 1)
         self.layout.addWidget(self.randomizeCheckBox, 3, 1)
 
-    def get_scan_args(self) -> Dict[str, Any]:
+    def getScanArgs(self) -> Dict[str, Any]:
         """Overridden.
         
         Returns the arguments of the range scan.

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -470,7 +470,7 @@ class _NoScan(_BaseScan):
             procdesc: See the __init__() in _BaseScan.
             state:
               valueSpinBox: The repeated value in the NoScan sequence.
-              repetitions: A number to repeat the value in the NoScan sequence.
+              repetitionsSpinBox: A number to repeat the value in the NoScan sequence.
         """
         super().__init__(procdesc, parent=parent)
         self.valueSpinBox = QDoubleSpinBox(self)


### PR DESCRIPTION
This closes #256
##
1. `_NoScan` class has been added. It has two arguments, `value` and `repetitions`. 
2. Implment scan type selection in the `_ScanEntry` class. You can choose RangeScan or NoScan at our iquip GUI. Two widgets are contained at `stackWidget`. `radioButtons` is used to select between two scan type.
3. Added BaseScan that is base class for all scan widgets. Since some attributes and method are duplicated, it seems more efficient way.
##
Below is the image of current figure of builder GUI.
![image](https://github.com/snu-quiqcl/iquip/assets/43592775/828fd490-e755-4991-a2df-626702bc9f2f)
