### PR TITLE
Add center & explicit scan

### DIFF
--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -653,7 +653,7 @@ class _ExplicitScan(_BaseScan):
 
         Args:
             state: A key and its value is:
-              sequence: The sequnce that describes the ExplicitScan sequence.
+              sequence: The list that represents the ExplicitScan sequence.
         """
         super().__init__(procdesc, parent=parent)
         self.sequenceEdit = QLineEdit(self)

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -6,8 +6,7 @@ from enum import IntEnum, unique
 from typing import Any, Dict, Optional, Tuple, Union
 
 import requests
-from PyQt5.QtCore import QDateTime, QObject, QRegExp, Qt, QThread, pyqtSignal, pyqtSlot
-from PyQt5.QtGui import QRegExpValidator
+from PyQt5.QtCore import QDateTime, QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
     QAbstractButton, QButtonGroup, QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QGridLayout,
     QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem, QPushButton, QRadioButton,
@@ -437,6 +436,7 @@ class _BaseScan(QWidget):
           unit, scale, global_step, global_min, global_max, ndecimals: 
             See argInfo in _ScanEntry.__init__().
     """
+
     def __init__(self, procdesc: Dict[str, Any], parent: Optional[QWidget] = None):
         """Extended.
 
@@ -482,12 +482,13 @@ class _NoScan(_BaseScan):
         valueSpinBox: QDoubleSpinBox for value argument inside state.
         repetitionsSpinBox: QSpinBox for repetitions argument inside state.
     """
+
     def __init__(
         self,
         procdesc: Dict[str, Any],
         state: Dict[str, Any],
         parent: Optional[QWidget] = None
-        ):
+    ):
         """Extended.
 
         Args:
@@ -510,10 +511,7 @@ class _NoScan(_BaseScan):
         self.layout.addWidget(self.repetitionsSpinBox, 1, 1)
 
     def scanArguments(self) -> Dict[str, Any]:
-        """Overridden.
-        
-        Returns the arguments of the no scan.
-        """
+        """Overridden."""
         return {
             "ty": "NoScan",
             "value": self.valueSpinBox.value(),
@@ -530,12 +528,13 @@ class _RangeScan(_BaseScan):
         npointsSpinBox: QSpinBox for npoints argument inside state.
         randomizeCheckBox: QCheckBox for randomize argument inside state.
     """
+
     def __init__(
         self,
         procdesc: Dict[str, Any],
         state: Dict[str, Any],
         parent: Optional[QWidget] = None
-        ):
+    ):
         """Extended.
 
         Args:
@@ -568,10 +567,7 @@ class _RangeScan(_BaseScan):
         self.layout.addWidget(self.randomizeCheckBox, 3, 1)
 
     def scanArguments(self) -> Dict[str, Any]:
-        """Overridden.
-        
-        Returns the arguments of the range scan.
-        """
+        """Overridden."""
         return {
             "ty": "RangeScan",
             "start": self.startSpinBox.value(),
@@ -591,19 +587,20 @@ class _CenterScan(_BaseScan):
         stepSpinBox: QDoubleSpinBox for step argument inside state.
         randomizeCheckBox: QCheckBox for randomize argument inside state.
     """
+
     def __init__(
         self,
         procdesc: Dict[str, Any],
         state: Dict[str, Any],
         parent: Optional[QWidget] = None
-        ):
+    ):
         """Extended.
 
         Args:
             state: Each key and its value are:
               center: The center point for the CenterScan sequence.
-              span: The length of the RangeScan sequence.
-              step: The size of step between each number at the RangeScan sequence.
+              span: The length of the CenterScan sequence.
+              step: The size of step between each number in the CenterScan sequence.
               randomize: The boolean value that decides whether to shuffle the CenterScan sequence.
         """
         super().__init__(procdesc, parent=parent)
@@ -628,10 +625,7 @@ class _CenterScan(_BaseScan):
         self.layout.addWidget(self.randomizeCheckBox, 3, 1)
 
     def scanArguments(self) -> Dict[str, Any]:
-        """Overridden.
-        
-        Returns the arguments of the center scan.
-        """
+        """Overridden."""
         return {
             "ty": "CenterScan",
             "center": self.centerSpinBox.value(),
@@ -646,43 +640,35 @@ class _ExplicitScan(_BaseScan):
     """Widget for explicit scan in _ScanEntry.
 
     Attributes:
-        centerSpinBox: QDoubleSpinBox for center argument inside state.
-        spanSpinBox: QDoubleSpinBox for span argument inside state.
-        stepSpinBox: QSpinBox for step argument inside state.
-        randomizeCheckBox: QCheckBox for randomize argument inside state.
+        sequenceEdit: QLineEdit for sequence argument inside state.
     """
+
     def __init__(
         self,
         procdesc: Dict[str, Any],
         state: Dict[str, Any],
         parent: Optional[QWidget] = None
-        ):
+    ):
         """Extended.
 
         Args:
             state: A key and its value is:
-              sequence: The sequnce that describes ExplicitScan sequence.
+              sequence: The sequnce that describes the ExplicitScan sequence.
         """
         super().__init__(procdesc, parent=parent)
         self.sequenceEdit = QLineEdit(self)
         # layout
         self.layout.addWidget(QLabel("sequence:", self), 0, 0)
         self.layout.addWidget(self.sequenceEdit, 0, 1)
-        float_regexp = r"(([+-]?\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?)"
-        regexp = "(float)?( +float)* *".replace("float", float_regexp)
-        self.sequenceEdit.setValidator(QRegExpValidator(QRegExp(regexp)))
-        self.sequenceEdit.setText(" ".join([str(x) for x in state["sequence"]]))
+        self.sequenceEdit.setText(" ".join(str(x) for x in state["sequence"]))
 
     def scanArguments(self) -> Dict[str, Any]:
-        """Overridden.
-        
-        Returns the arguments of the explicit scan.
-        """
-        text = self.sequenceEdit.text()
-        explicitText = [float(x) for x in text.split()]
+        """Overridden."""
+        sequenceText = self.sequenceEdit.text()
+        sequence = [float(x) for x in sequenceText.split()]
         return {
             "ty": "ExplicitScan",
-            "sequence": explicitText
+            "sequence": sequence
         }
 
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -6,8 +6,8 @@ from enum import IntEnum, unique
 from typing import Any, Dict, Optional, Tuple, Union
 
 import requests
+from PyQt5.QtCore import QDateTime, QObject, QRegExp, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtGui import QRegExpValidator
-from PyQt5.QtCore import QDateTime, QObject, Qt, QThread, pyqtSignal, pyqtSlot, QRegExp
 from PyQt5.QtWidgets import (
     QAbstractButton, QButtonGroup, QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QGridLayout,
     QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem, QPushButton, QRadioButton,
@@ -317,7 +317,6 @@ class _ScanEntry(_BaseEntry):
         CenterScan = 2
         ExplicitScan = 3
 
-
     # pylint: disable=too-many-locals
     def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
         """Extended.
@@ -624,7 +623,7 @@ class _CenterScan(_BaseScan):
         self.layout.addWidget(self.centerSpinBox, 0, 1)
         self.layout.addWidget(QLabel("span:", self), 1, 0)
         self.layout.addWidget(self.spanSpinBox, 1, 1)
-        self.layout.addWidget(QLabel("stop:", self), 2, 0)
+        self.layout.addWidget(QLabel("step:", self), 2, 0)
         self.layout.addWidget(self.stepSpinBox, 2, 1)
         self.layout.addWidget(self.randomizeCheckBox, 3, 1)
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -6,7 +6,8 @@ from enum import IntEnum, unique
 from typing import Any, Dict, Optional, Tuple, Union
 
 import requests
-from PyQt5.QtCore import QDateTime, QObject, Qt, QThread, pyqtSignal, pyqtSlot
+from PyQt5.QtGui import QRegExpValidator
+from PyQt5.QtCore import QDateTime, QObject, Qt, QThread, pyqtSignal, pyqtSlot, QRegExp
 from PyQt5.QtWidgets import (
     QAbstractButton, QButtonGroup, QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QGridLayout,
     QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem, QPushButton, QRadioButton,
@@ -313,6 +314,9 @@ class _ScanEntry(_BaseEntry):
         """Enum class for mapping id to each scannable type."""
         NoScan = 0
         RangeScan = 1
+        CenterScan = 2
+        ExplicitScan = 3
+
 
     # pylint: disable=too-many-locals
     def __init__(self, name: str, argInfo: Dict[str, Any], parent: Optional[QWidget] = None):
@@ -336,7 +340,12 @@ class _ScanEntry(_BaseEntry):
         self.stackedWidget = QStackedWidget(self)
         buttonLayout = QHBoxLayout()
         self.scanButtonGroup = QButtonGroup(self)
-        scanDict = {"NoScan": (_NoScan, "No scan"), "RangeScan": (_RangeScan, "Range")}
+        scanDict = {
+            "NoScan": (_NoScan, "No scan"), 
+            "RangeScan": (_RangeScan, "Range"),
+            "CenterScan": (_CenterScan, "Center"), 
+            "ExplicitScan": (_ExplicitScan, "Explicit")
+        }
         self.scanWidgets = {}
         for scanType in _ScanEntry.ScanType:
             ty = scanType.name
@@ -571,6 +580,110 @@ class _RangeScan(_BaseScan):
             "npoints": self.npointsSpinBox.value(),
             "randomize": self.randomizeCheckBox.isChecked(),
             "seed": None
+        }
+
+
+class _CenterScan(_BaseScan):
+    """Widget for center scan in _ScanEntry.
+
+    Attributes:
+        centerSpinBox: QDoubleSpinBox for center argument inside state.
+        spanSpinBox: QDoubleSpinBox for span argument inside state.
+        stepSpinBox: QDoubleSpinBox for step argument inside state.
+        randomizeCheckBox: QCheckBox for randomize argument inside state.
+    """
+    def __init__(
+        self,
+        procdesc: Dict[str, Any],
+        state: Dict[str, Any],
+        parent: Optional[QWidget] = None
+        ):
+        """Extended.
+
+        Args:
+            state: Each key and its value are:
+              center: The center point for the CenterScan sequence.
+              span: The length of the RangeScan sequence.
+              step: The size of step between each number at the RangeScan sequence.
+              randomize: The boolean value that decides whether to shuffle the CenterScan sequence.
+        """
+        super().__init__(procdesc, parent=parent)
+        self.centerSpinBox = QDoubleSpinBox(self)
+        self.applyProperties(self.centerSpinBox)
+        self.centerSpinBox.setValue(state["center"] / self.scale)
+        self.spanSpinBox = QDoubleSpinBox(self)
+        self.applyProperties(self.spanSpinBox)
+        self.spanSpinBox.setValue(state["span"] / self.scale)
+        self.stepSpinBox = QDoubleSpinBox(self)
+        self.applyProperties(self.stepSpinBox)
+        self.stepSpinBox.setValue(state["step"] / self.scale)
+        self.randomizeCheckBox = QCheckBox("Randomize", self)
+        self.randomizeCheckBox.setChecked(state["randomize"])
+        # layout
+        self.layout.addWidget(QLabel("center:", self), 0, 0)
+        self.layout.addWidget(self.centerSpinBox, 0, 1)
+        self.layout.addWidget(QLabel("span:", self), 1, 0)
+        self.layout.addWidget(self.spanSpinBox, 1, 1)
+        self.layout.addWidget(QLabel("stop:", self), 2, 0)
+        self.layout.addWidget(self.stepSpinBox, 2, 1)
+        self.layout.addWidget(self.randomizeCheckBox, 3, 1)
+
+    def scanArguments(self) -> Dict[str, Any]:
+        """Overridden.
+        
+        Returns the arguments of the center scan.
+        """
+        return {
+            "ty": "CenterScan",
+            "center": self.centerSpinBox.value(),
+            "step": self.stepSpinBox.value(),
+            "span": self.spanSpinBox.value(),
+            "randomize": self.randomizeCheckBox.isChecked(),
+            "seed": None
+        }
+
+
+class _ExplicitScan(_BaseScan):
+    """Widget for explicit scan in _ScanEntry.
+
+    Attributes:
+        centerSpinBox: QDoubleSpinBox for center argument inside state.
+        spanSpinBox: QDoubleSpinBox for span argument inside state.
+        stepSpinBox: QSpinBox for step argument inside state.
+        randomizeCheckBox: QCheckBox for randomize argument inside state.
+    """
+    def __init__(
+        self,
+        procdesc: Dict[str, Any],
+        state: Dict[str, Any],
+        parent: Optional[QWidget] = None
+        ):
+        """Extended.
+
+        Args:
+            state: A key and its value is:
+              sequence: The sequnce that describes ExplicitScan sequence.
+        """
+        super().__init__(procdesc, parent=parent)
+        self.sequenceEdit = QLineEdit(self)
+        # layout
+        self.layout.addWidget(QLabel("sequence:", self), 0, 0)
+        self.layout.addWidget(self.sequenceEdit, 0, 1)
+        float_regexp = r"(([+-]?\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?)"
+        regexp = "(float)?( +float)* *".replace("float", float_regexp)
+        self.sequenceEdit.setValidator(QRegExpValidator(QRegExp(regexp)))
+        self.sequenceEdit.setText(" ".join([str(x) for x in state["sequence"]]))
+
+    def scanArguments(self) -> Dict[str, Any]:
+        """Overridden.
+        
+        Returns the arguments of the explicit scan.
+        """
+        text = self.sequenceEdit.text()
+        explicitText = [float(x) for x in text.split()]
+        return {
+            "ty": "ExplicitScan",
+            "sequence": explicitText
         }
 
 


### PR DESCRIPTION
This closes #229 

CenterScan and ExplicitScan widgets are added. Below is the image of current builder GUI. 
![image](https://github.com/snu-quiqcl/iquip/assets/43592775/97e73b92-cb58-4807-b036-b37833bdb6a4)

Center scan has `center`, `span`(length) and `step` as an argument. And Explicit scan has only one argument, `sequence`.
CenterScan widget has very similar similar to the RangeScan widget. And ExplicitScan is very simple, since it has only one argument `sequence`.

In terms of `RegExp`, I followed original code at artiq. 