### PR TITLE
Fetch RID list in remote part

### DIFF
--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -1016,6 +1016,7 @@ class DataViewerApp(qiwis.BaseApp):
         self.policy: Optional[SimpleScanDataPolicy] = None
         self.axis: Tuple[int, ...] = ()
         self.dataPointIndex: Tuple[int, ...] = ()
+        self.startDatasetListThread()
         realtimePart, remotePart = (self.frame.sourceWidget.stack.widget(buttonId)
                                     for buttonId in SourceWidget.ButtonId)
         realtimePart.syncToggled.connect(self._toggleSync)

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -1027,6 +1027,7 @@ class DataViewerApp(qiwis.BaseApp):
 
     @pyqtSlot(int)
     def switchSourceMode(self, id: int):
+        self.frame.sourceWidget.datasetBox.clear()
         if id == SourceWidget.ButtonId.REALTIME:
             self.startDatasetListThread()
         else:

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -16,11 +16,13 @@ import pyqtgraph as pg
 import qiwis
 from pyqtgraph.GraphicsScene import mouseEvents
 from PyQt5.QtWidgets import (
-    QWidget, QLabel, QPushButton, QRadioButton, QButtonGroup, QStackedWidget,
-    QAbstractSpinBox, QSpinBox, QDoubleSpinBox, QGroupBox, QSplitter,
-    QCheckBox, QComboBox, QHBoxLayout, QVBoxLayout, QGridLayout,
+    QAbstractSpinBox, QButtonGroup, QCheckBox, QComboBox, QDateEdit, QDoubleSpinBox, QGridLayout,
+    QGroupBox, QHBoxLayout, QLabel, QPushButton, QRadioButton, QSpinBox, QSplitter, QStackedWidget,
+    QVBoxLayout, QWidget,
 )
-from PyQt5.QtCore import pyqtSignal, pyqtSlot, QMutex, QObject, QThread, Qt, QWaitCondition
+from PyQt5.QtCore import (
+    pyqtSignal, pyqtSlot, QDate, QMutex, QObject, Qt, QThread, QWaitCondition
+)
 from websockets.sync.client import connect, ClientConnection
 from websockets.exceptions import ConnectionClosedOK, WebSocketException
 
@@ -349,11 +351,17 @@ class _RemotePart(QWidget):
     def __init__(self, parent: Optional[QWidget] = None):
         """Extended."""
         super().__init__(parent=parent)
+        currentDate = QDate.currentDate()
+        self.dateEdit = QDateEdit(currentDate, self)
+        self.dateEdit.setCalendarPopup(True)
+        self.dateEdit.setDisplayFormat("yyyy-MM-dd")
+        self.dateEdit.setMaximumDate(currentDate)
         self.spinbox = QSpinBox(self)
         self.spinbox.setMaximum(MAX_INT)
         self.spinbox.setButtonSymbols(QAbstractSpinBox.NoButtons)
         self.label = QLabel("Unknown", self)
         layout = QHBoxLayout(self)
+        layout.addWidget(self.dateEdit)
         layout.addWidget(self.spinbox)
         layout.addWidget(self.label)
         # signal connection

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -346,8 +346,9 @@ class _RemotePart(QWidget):
         ridComboBox: QComboBox for showing the RID list of the selected date (and hour).
 
     Signals:
-        dateHourChanged(date, hour): The target date and hour are changed. If the hour is not set,
-          it is set to None.
+        dateHourChanged(date, hour): The target date and hour are changed. 
+          The argument date is a string in ISO format.
+          The argument hour is a number from 0 to 23, or None if it is not set.
     """
 
     dateHourChanged = pyqtSignal(str, object)

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -1091,6 +1091,10 @@ class DataViewerApp(qiwis.BaseApp):
             self.startRealtimeDatasetListThread()
         else:
             self.realtimeListThread.stop()
+            remotePart: _RemotePart = self.frame.sourceWidget.stack.widget(
+                SourceWidget.ButtonId.REMOTE
+            )
+            remotePart.updateRidComboBox()
 
     def startRealtimeDatasetListThread(self):
         """Creates and starts a new _RealtimeListThread instance."""

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -810,11 +810,9 @@ class DataViewerFrame(QSplitter):
         mainPlotWidget: MainPlotWidget for the main plot.
     
     Signals:
-        syncToggled(checked): See _RealtimePart.syncToggled.
         dataRequested(rid): Data for the given rid is requested.
     """
 
-    syncToggled = pyqtSignal(bool)
     dataRequested = pyqtSignal(str)
 
     def __init__(self, parent: Optional[QWidget] = None):
@@ -844,8 +842,6 @@ class DataViewerFrame(QSplitter):
         # signal connection
         remotePart = self.sourceWidget.stack.widget(SourceWidget.ButtonId.REMOTE)
         remotePart.ridEditingFinished.connect(self.dataRequested)
-        realtimePart = self.sourceWidget.stack.widget(SourceWidget.ButtonId.REALTIME)
-        realtimePart.syncToggled.connect(self.syncToggled)
 
     def datasetName(self) -> str:
         """Returns the current dataset name in the line edit."""
@@ -1012,7 +1008,9 @@ class DataViewerApp(qiwis.BaseApp):
         self.axis: Tuple[int, ...] = ()
         self.dataPointIndex: Tuple[int, ...] = ()
         self.startDatasetListThread()
-        self.frame.syncToggled.connect(self._toggleSync)
+        realtimePart, remotePart = (self.frame.sourceWidget.stack.widget(buttonId)
+                                    for buttonId in SourceWidget.ButtonId)
+        realtimePart.syncToggled.connect(self._toggleSync)
         self.frame.sourceWidget.axisApplied.connect(self.setAxis)
         self.frame.dataPointWidget.dataTypeChanged.connect(self.setDataType)
         self.frame.dataPointWidget.thresholdChanged.connect(self.setThreshold)

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -1028,7 +1028,7 @@ class _RidListOfDateHourThread(QThread):
         ip: str,
         port: int,
         parent: Optional[QObject] = None
-    ):
+    ):  # pylint: disable=too-many-arguments
         """Extended.
         
         Args:
@@ -1085,9 +1085,14 @@ class DataViewerApp(qiwis.BaseApp):
         self.frame.mainPlotWidget.dataClicked.connect(self.selectDataPoint)
 
     @pyqtSlot(int)
-    def switchSourceMode(self, id: int):
+    def switchSourceMode(self, buttonId: int):
+        """Switches the source mode based on the clicked button.
+        
+        Args:
+            buttonId: ID of the clicked button in frame.sourceWidget.buttonGroup.
+        """
         self.frame.sourceWidget.datasetBox.clear()
-        if id == SourceWidget.ButtonId.REALTIME:
+        if buttonId == SourceWidget.ButtonId.REALTIME:
             self.startRealtimeDatasetListThread()
         else:
             self.realtimeListThread.stop()
@@ -1169,6 +1174,11 @@ class DataViewerApp(qiwis.BaseApp):
 
     @pyqtSlot(list)
     def updateRidList(self, rids: List[int]):
+        """Updates remotePart.ridComboBox with the fetched RID list.
+        
+        Args:
+            See _RidListOfDateHourThread.fetched signal.
+        """
         remotePart: _RemotePart = self.frame.sourceWidget.stack.widget(
             SourceWidget.ButtonId.REMOTE
         )

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -374,18 +374,9 @@ class _RemotePart(QWidget):
         layout.addWidget(self.ridComboBox)
         # signal connection
         self.dateEdit.dateChanged.connect(self.updateRidComboBox)
-        self.hourCheckBox.stateChanged.connect(self.enableHourSpinBox)
+        self.hourCheckBox.clicked.connect(self.hourSpinBox.setEnabled)
         self.hourCheckBox.stateChanged.connect(self.updateRidComboBox)
         self.hourSpinBox.valueChanged.connect(self.updateRidComboBox)
-
-    @pyqtSlot(int)
-    def enableHourSpinBox(self, state: int):
-        """Enables or disables the hourSpinBox according to the given state.
-        
-        Args:
-            state: Current state of hourCheckBox.
-        """
-        self.hourSpinBox.setEnabled(bool(state))
 
     @pyqtSlot()
     def updateRidComboBox(self):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -825,12 +825,7 @@ class DataViewerFrame(QSplitter):
         sourceWidget: SourceWidget for source selection.
         dataPointWidget: DataPointWidget for data point configuration.
         mainPlotWidget: MainPlotWidget for the main plot.
-    
-    Signals:
-        dataRequested(rid): Data for the given rid is requested.
     """
-
-    dataRequested = pyqtSignal(str)
 
     def __init__(self, parent: Optional[QWidget] = None):
         """Extended."""
@@ -856,9 +851,6 @@ class DataViewerFrame(QSplitter):
         self.addWidget(leftWidget)
         self.addWidget(mainPlotBox)
         self.addWidget(toolBox)
-        # signal connection
-        remotePart = self.sourceWidget.stack.widget(SourceWidget.ButtonId.REMOTE)
-        remotePart.ridEditingFinished.connect(self.dataRequested)
 
     def datasetName(self) -> str:
         """Returns the current dataset name in the line edit."""

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -356,21 +356,21 @@ class _RemotePart(QWidget):
         self.dateEdit.setCalendarPopup(True)
         self.dateEdit.setDisplayFormat("yyyy-MM-dd")
         self.dateEdit.setMaximumDate(currentDate)
-        self.spinbox = QSpinBox(self)
-        self.spinbox.setMaximum(MAX_INT)
-        self.spinbox.setButtonSymbols(QAbstractSpinBox.NoButtons)
-        self.label = QLabel("Unknown", self)
+        self.hourSpinbox = QSpinBox(self)
+        self.hourSpinbox.setRange(0, 23)
+        self.hourSpinbox.setSuffix("h")
+        self.ridComboBox = QComboBox(self)
         layout = QHBoxLayout(self)
         layout.addWidget(self.dateEdit)
-        layout.addWidget(self.spinbox)
-        layout.addWidget(self.label)
+        layout.addWidget(self.hourSpinbox)
+        layout.addWidget(self.ridComboBox)
         # signal connection
-        self.spinbox.editingFinished.connect(self._editingFinished)
+        self.hourSpinbox.editingFinished.connect(self._editingFinished)
 
     @pyqtSlot()
     def _editingFinished(self):
         """Emits the ridEditingFinished signal with the current RID."""
-        self.ridEditingFinished.emit(str(self.spinbox.value()))
+        self.ridEditingFinished.emit(str(self.hourSpinbox.value()))
 
 
 class MonitorStatusWidget(QWidget):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -338,8 +338,10 @@ class _RemotePart(QWidget):
     """Part widget for configuring remote mode of the source widget.
     
     Attributes:
-        spinbox: Spinbox for RID input.
-        label: Label for showing the execution time of the experiment.
+        dateEdit: QDateEdit for target date.
+        hourCheckBox: QCheckBox for enabling to select an hour.
+        hourSpinBox: QSpinBox for target hour.
+        ridComboBox: QComboBox for showing the RID list of the selected date (and hour).
 
     Signals:
         dateHourChanged(date, hour): The target date and hour are changed. If the hour is not set,

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -371,7 +371,7 @@ class _RemotePart(QWidget):
         layout.addWidget(self.hourSpinBox)
         layout.addWidget(self.ridComboBox)
         # signal connection
-        self.hourCheckBox.stateChanged(self.enableHourSpinBox)
+        self.hourCheckBox.stateChanged.connect(self.enableHourSpinBox)
 
     @pyqtSlot(int)
     def enableHourSpinBox(self, state: int):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -342,11 +342,11 @@ class _RemotePart(QWidget):
         label: Label for showing the execution time of the experiment.
 
     Signals:
-        ridEditingFinished(rid): The editingFinished signal of spinbox is emitted.
-          The current spinbox value is given as rid.
+        dateHourChanged(date, hour): The target date and hour are changed. If the hour is not set,
+          it is set to None.
     """
 
-    ridEditingFinished = pyqtSignal(str)
+    dateHourChanged = pyqtSignal(str, object)
 
     def __init__(self, parent: Optional[QWidget] = None):
         """Extended."""
@@ -356,21 +356,34 @@ class _RemotePart(QWidget):
         self.dateEdit.setCalendarPopup(True)
         self.dateEdit.setDisplayFormat("yyyy-MM-dd")
         self.dateEdit.setMaximumDate(currentDate)
-        self.hourSpinbox = QSpinBox(self)
-        self.hourSpinbox.setRange(0, 23)
-        self.hourSpinbox.setSuffix("h")
+        self.hourCheckBox = QCheckBox(self)
+        self.hourSpinBox = QSpinBox(self)
+        self.hourSpinBox.setRange(0, 23)
+        self.hourSpinBox.setSuffix("h")
         self.ridComboBox = QComboBox(self)
         layout = QHBoxLayout(self)
         layout.addWidget(self.dateEdit)
-        layout.addWidget(self.hourSpinbox)
+        layout.addWidget(self.hourCheckBox)
+        layout.addWidget(self.hourSpinBox)
         layout.addWidget(self.ridComboBox)
         # signal connection
-        self.hourSpinbox.editingFinished.connect(self._editingFinished)
+        self.hourCheckBox.stateChanged(self.enableHourSpinBox)
+
+    @pyqtSlot(int)
+    def enableHourSpinBox(self, state: int):
+        """Enables or disables the hourSpinBox according to the given state.
+        
+        Args:
+            state: Current state of hourCheckBox.
+        """
+        self.hourSpinBox.setEnabled(bool(state))
 
     @pyqtSlot()
-    def _editingFinished(self):
-        """Emits the ridEditingFinished signal with the current RID."""
-        self.ridEditingFinished.emit(str(self.hourSpinbox.value()))
+    def updateRidComboBox(self):
+        """Emits the dateHourChanged signal for updating the ridComboBox."""
+        date = self.dateEdit.date().toString(Qt.ISODate)
+        hour = self.hourSpinBox.value() if self.hourCheckBox.isEnabled() else None
+        self.dateHourChanged.emit(date, hour)
 
 
 class MonitorStatusWidget(QWidget):

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -362,6 +362,7 @@ class _RemotePart(QWidget):
         self.dateEdit.setMaximumDate(currentDate)
         self.hourCheckBox = QCheckBox(self)
         self.hourSpinBox = QSpinBox(self)
+        self.hourSpinBox.setEnabled(False)
         self.hourSpinBox.setRange(0, 23)
         self.hourSpinBox.setSuffix("h")
         self.ridComboBox = QComboBox(self)
@@ -371,7 +372,10 @@ class _RemotePart(QWidget):
         layout.addWidget(self.hourSpinBox)
         layout.addWidget(self.ridComboBox)
         # signal connection
+        self.dateEdit.dateChanged.connect(self.updateRidComboBox)
         self.hourCheckBox.stateChanged.connect(self.enableHourSpinBox)
+        self.hourCheckBox.stateChanged.connect(self.updateRidComboBox)
+        self.hourSpinBox.valueChanged.connect(self.updateRidComboBox)
 
     @pyqtSlot(int)
     def enableHourSpinBox(self, state: int):
@@ -386,7 +390,7 @@ class _RemotePart(QWidget):
     def updateRidComboBox(self):
         """Emits the dateHourChanged signal for updating the ridComboBox."""
         date = self.dateEdit.date().toString(Qt.ISODate)
-        hour = self.hourSpinBox.value() if self.hourCheckBox.isEnabled() else None
+        hour = self.hourSpinBox.value() if self.hourCheckBox.isChecked() else None
         self.dateHourChanged.emit(date, hour)
 
 

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -1102,7 +1102,7 @@ class DataViewerApp(qiwis.BaseApp):
             self.constants.proxy_ip,  # pylint: disable=no-member
             self.constants.proxy_port,  # pylint: disable=no-member
         )
-        self.realtimeListThread.fetched.connect(self._updateDatasetBox)
+        self.realtimeListThread.fetched.connect(self._updateDatasetBox, type=Qt.QueuedConnection)
         self.realtimeListThread.finished.connect(self.realtimeListThread.deleteLater)
         self.realtimeListThread.start()
 
@@ -1163,9 +1163,17 @@ class DataViewerApp(qiwis.BaseApp):
             self.constants.proxy_ip,  # pylint: disable=no-member
             self.constants.proxy_port,  # pylint: disable=no-member
         )
-        self.ridListOfDateHourThread.fetched.connect()
+        self.ridListOfDateHourThread.fetched.connect(self.updateRidList, type=Qt.QueuedConnection)
         self.ridListOfDateHourThread.finished.connect(self.ridListOfDateHourThread.deleteLater)
         self.ridListOfDateHourThread.start()
+
+    @pyqtSlot(list)
+    def updateRidList(self, rids: List[int]):
+        remotePart: _RemotePart = self.frame.sourceWidget.stack.widget(
+            SourceWidget.ButtonId.REMOTE
+        )
+        remotePart.ridComboBox.clear()
+        remotePart.ridComboBox.addItems(list(map(str, rids)))
 
     @pyqtSlot(np.ndarray, list, list)
     def setDataset(

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -395,8 +395,7 @@ class SourceWidget(QWidget):
     Signals:
         axisApplied(axis): Axis parameter selection apply button is clicked.
           See SimpleScanDataPolicy.extract() for axis argument.
-        realtimeDatasetUpdateRequested(): The realtime dataset list update
-          is requested.
+        modeClicked(id): The source mode with id is clicked.
 
     Attributes:
         datasetBox: The combo box for selecting a dataset.
@@ -408,7 +407,7 @@ class SourceWidget(QWidget):
     """
 
     axisApplied = pyqtSignal(tuple)
-    realtimeDatasetUpdateRequested = pyqtSignal()
+    modeClicked = pyqtSignal(int)
 
     class ButtonId(enum.IntEnum):
         """Source selection button id.
@@ -456,6 +455,7 @@ class SourceWidget(QWidget):
         self.axisBoxes["X"].currentIndexChanged.connect(self._handleXIndexChanged)
         self.axisApplyButton.clicked.connect(self._handleApplyClicked)
         self.buttonGroup.idClicked.connect(self.stack.setCurrentIndex)
+        self.buttonGroup.idClicked.connect(self.modeClicked)
 
     def setParameters(self, parameters: Iterable[str], units: Iterable[Optional[str]]):
         """Sets the parameter and unit list.

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -1068,7 +1068,6 @@ class DataViewerApp(qiwis.BaseApp):
         else:
             self.fetcherThread.stop()
 
-    @pyqtSlot()
     def synchronize(self):
         """Fetches the dataset from artiq master and updates the viewer."""
         realtimePart: _RealtimePart = self.frame.sourceWidget.stack.widget(


### PR DESCRIPTION
This is a part of #258.

What I have implemented is:
- Add widgets to select a target date and hour.
- Once any is changed, fetch the corresponding RID list.
- Reconstruct signals in dataviewer app.

![image](https://github.com/snu-quiqcl/iquip/assets/76851886/13382708-b3c9-4176-9c80-afa609bd5f8f)

The figure means that RIDs executed today are 765 to 769.