### PR TITLE
Convert due date in ISO format

### DIFF
--- a/iquip/apps/scheduler.py
+++ b/iquip/apps/scheduler.py
@@ -1,5 +1,6 @@
 """App module for showing the schedule for experiments."""
 
+import datetime
 import enum
 import functools
 import json
@@ -177,6 +178,8 @@ class ScheduleModel(QAbstractTableModel):
                 f"{key}: {round(value, 9) if isinstance(value, (int, float)) else value}"
                 for key, value in data.items()
             ])
+        if column == ScheduleModel.InfoFieldId.DUE_DATE and data:
+            return datetime.datetime.fromtimestamp(data).isoformat()
         return data
 
     def headerData(self, section: int, orientation: Qt.Orientation, role: Qt.ItemDataRole) -> Any:


### PR DESCRIPTION
Previously the due date was displayed as a floating point timestamp number in the scheduler.
This closes #244.

![Screen Shot 2024-04-03 at 16 18 29](https://github.com/snu-quiqcl/iquip/assets/8445906/08860d3a-a1a9-4d7c-a00d-38baafeaa0b0)
