### PR TITLE
Improve builder UI compactly

### DIFF
--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -293,7 +293,6 @@ class _DateTimeEntry(_BaseEntry):
         return None
 
 
-# TODO(AIJUH): Add other scan type classes.
 class _ScanEntry(_BaseEntry):
     """Entry class for a scannable object.
     

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -9,8 +9,8 @@ import requests
 from PyQt5.QtCore import QDateTime, QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
     QAbstractButton, QButtonGroup, QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QGridLayout,
-    QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem, QPushButton, QRadioButton,
-    QSpinBox, QStackedWidget, QVBoxLayout, QWidget
+    QGroupBox, QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem, QPushButton,
+    QRadioButton, QSpinBox, QStackedWidget, QVBoxLayout, QWidget,
 )
 
 import qiwis
@@ -675,8 +675,6 @@ class BuilderFrame(QWidget):
     """Frame for showing the build arguments and requesting to submit it.
     
     Attributes:
-        experimentNameLabel: The label for showing the experiment name.
-        experimentClsNameLabel: The label for showing the class name of the experiment.
         argsListWidget: The list widget with the build arguments.
         scanListWidget: The list widget with the scannable arguments.
         reloadArgsButton: The button for reloading the build arguments.
@@ -698,8 +696,9 @@ class BuilderFrame(QWidget):
         """
         super().__init__(parent=parent)
         # widgets
-        self.experimentNameLabel = QLabel(f"Name: {experimentName}", self)
-        self.experimentClsNameLabel = QLabel(f"Class: {experimentClsName}", self)
+        clsBox = QGroupBox("Class", self)
+        clsBox.setToolTip(experimentName)
+        QHBoxLayout(clsBox).addWidget(QLabel(experimentClsName, self))
         self.argsListWidget = QListWidget(self)
         self.scanListWidget = QListWidget(self)
         self.reloadArgsButton = QPushButton("Reload", self)
@@ -707,8 +706,7 @@ class BuilderFrame(QWidget):
         self.submitButton = QPushButton("Submit", self)
         # layout
         layout = QVBoxLayout(self)
-        layout.addWidget(self.experimentNameLabel)
-        layout.addWidget(self.experimentClsNameLabel)
+        layout.addWidget(clsBox)
         layout.addWidget(self.argsListWidget)
         layout.addWidget(self.scanListWidget)
         layout.addWidget(self.reloadArgsButton)

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -10,7 +10,7 @@ from PyQt5.QtCore import QDateTime, QObject, Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
     QAbstractButton, QButtonGroup, QCheckBox, QComboBox, QDateTimeEdit, QDoubleSpinBox, QGridLayout,
     QGroupBox, QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem, QPushButton,
-    QRadioButton, QSpinBox, QStackedWidget, QVBoxLayout, QWidget,
+    QRadioButton, QSpinBox, QStackedWidget, QTabWidget, QVBoxLayout, QWidget,
 )
 
 import qiwis
@@ -677,8 +677,8 @@ class BuilderFrame(QWidget):
     Attributes:
         argsListWidget: The list widget with the build arguments.
         scanListWidget: The list widget with the scannable arguments.
-        reloadArgsButton: The button for reloading the build arguments.
         schedOptsListWidget: The list widget with the schedule options.
+        reloadArgsButton: The button for reloading the build arguments.
         submitButton: The button for submitting the experiment.
     """
 
@@ -701,8 +701,12 @@ class BuilderFrame(QWidget):
         QHBoxLayout(clsBox).addWidget(QLabel(experimentClsName, self))
         self.argsListWidget = QListWidget(self)
         self.scanListWidget = QListWidget(self)
-        self.reloadArgsButton = QPushButton("Reload", self)
         self.schedOptsListWidget = QListWidget(self)
+        tabWidget = QTabWidget(self)
+        tabWidget.addTab(self.argsListWidget, "args")
+        tabWidget.addTab(self.scanListWidget, "scan")
+        tabWidget.addTab(self.schedOptsListWidget, "sched")
+        self.reloadArgsButton = QPushButton("Reload", self)
         self.submitButton = QPushButton("Submit", self)
         # layout
         buttonLayout = QHBoxLayout()
@@ -710,9 +714,7 @@ class BuilderFrame(QWidget):
         buttonLayout.addWidget(self.submitButton)
         layout = QVBoxLayout(self)
         layout.addWidget(clsBox)
-        layout.addWidget(self.argsListWidget)
-        layout.addWidget(self.scanListWidget)
-        layout.addWidget(self.schedOptsListWidget)
+        layout.addWidget(tabWidget)
         layout.addLayout(buttonLayout)
 
 

--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -705,13 +705,15 @@ class BuilderFrame(QWidget):
         self.schedOptsListWidget = QListWidget(self)
         self.submitButton = QPushButton("Submit", self)
         # layout
+        buttonLayout = QHBoxLayout()
+        buttonLayout.addWidget(self.reloadArgsButton)
+        buttonLayout.addWidget(self.submitButton)
         layout = QVBoxLayout(self)
         layout.addWidget(clsBox)
         layout.addWidget(self.argsListWidget)
         layout.addWidget(self.scanListWidget)
-        layout.addWidget(self.reloadArgsButton)
         layout.addWidget(self.schedOptsListWidget)
-        layout.addWidget(self.submitButton)
+        layout.addLayout(buttonLayout)
 
 
 class _ExperimentSubmitThread(QThread):


### PR DESCRIPTION
This closes #254.

What I have implemented is:
- Leave only the class name label, and move the experiment name in its tooltip.
- Group three list widgets; arguments, scannables, and scheduling options.
- Group two buttons.

<img width=300 src="https://github.com/snu-quiqcl/iquip/assets/76851886/7dda64fe-ac29-4717-bc5e-f9231962153b">