### PR TITLE
Remove visualization feature

### DIFF
--- a/iquip/apps/builder.py
+++ b/iquip/apps/builder.py
@@ -876,14 +876,10 @@ class BuilderApp(qiwis.BaseApp):
             "ndecimals": 0,
             "type": "int"
         }
-        visualizeInfo = {
-            "default": False
-        }
         for widget in (
             _StringEntry("pipeline", pipelineInfo),
             _NumberEntry("priority", priorityInfo),
             _DateTimeEntry("timed"),
-            _BooleanEntry("visualize", visualizeInfo)
         ):
             item = QListWidgetItem(self.builderFrame.schedOptsListWidget)
             item.setSizeHint(widget.sizeHint())


### PR DESCRIPTION
This closes #283.

Now, the visualization checkbox in builder app is removed.

<img width=200 src="https://github.com/snu-quiqcl/iquip/assets/76851886/4dec444f-b85f-4bd3-8e2d-8cf24cc49549">
