### PR TITLE
Stage controller app

### DIFF
--- a/config_template.json
+++ b/config_template.json
@@ -64,6 +64,20 @@
             "cls": "DataViewerApp",
             "pos": "floating",
             "channel": ["MONITOR"]
+        },
+        "stage": {
+            "module": "iquip.apps.stage",
+            "cls": "StageControllerApp",
+            "pos": "right",
+            "args": {
+                "stages": {
+                    "stage_name": {
+                        "index": [0, 0],
+                        "target": ["localhost", 1234, "target_name"]
+                    }
+                },
+                "period": 0.5
+            }
         }
     },
     "constant": {

--- a/iquip/apps/stage.py
+++ b/iquip/apps/stage.py
@@ -446,12 +446,13 @@ class StageControllerApp(qiwis.BaseApp):
             widget.setConnected(connected)
 
     @pyqtSlot(str, Exception)
-    def handleClientError(self, key: str, _error: Exception):
+    def handleClientError(self, key: str, error: Exception):
         """Handles clientError signal.
         
         Args:
             See StageManager.clientError signal.
         """
+        logger.error("Stage %s reported an error.", exc_info=error)
         self.handleConnectionChanged(key, False)
 
     @pyqtSlot(str, float)

--- a/iquip/apps/stage.py
+++ b/iquip/apps/stage.py
@@ -460,7 +460,7 @@ class StageControllerApp(qiwis.BaseApp):
         Args:
             See StageManager.clientError signal.
         """
-        logger.error("Stage %s reported an error.", exc_info=error)
+        logger.error("Stage %s reported an error.", key, exc_info=error)
         self.handleConnectionChanged(key, False)
 
     @pyqtSlot(str, float)

--- a/iquip/apps/stage.py
+++ b/iquip/apps/stage.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import functools
 import logging
-from typing import Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
-from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, Qt
+from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, Qt, QThread, QTimer
 from PyQt5.QtWidgets import (
-    QAbstractSpinBox, QDoubleSpinBox, QHBoxLayout, QPushButton, QVBoxLayout, QWidget,
+    QAbstractSpinBox, QDoubleSpinBox, QGridLayout, QGroupBox, QHBoxLayout, QPushButton, QVBoxLayout, QWidget,
 )
+
+import qiwis
 from sipyco.pc_rpc import Client
 
 logger = logging.getLogger(__name__)
@@ -336,3 +338,137 @@ class StageWidget(QWidget):  # pylint: disable=too-many-instance-attributes
     def _relativeNegativeMove(self):
         """Relative negative move button is clicked."""
         self.moveBy.emit(-self.relativeBox.value() / 1e3)
+
+
+class StageControllerFrame(QWidget):
+    """Frame for StageControllerApp.
+    
+    Attributes:
+        widgets: Dictionary whose keys are stage names and the values are the
+          corresponding stage widgets.
+    """
+
+    def __init__(
+        self,
+        stages: Dict[str, Dict[str, Any]],
+        parent: Optional[QWidget] = None,
+    ):
+        """Extended.
+        
+        Args:
+            See StageControllerApp.
+        """
+        super().__init__(parent=parent)
+        self.widgets: Dict[str, StageWidget] = {}
+        layout = QGridLayout(self)
+        for stage_name, stage_info in stages.items():
+            widget = StageWidget(self)
+            groupbox = QGroupBox(stage_name, self)
+            groupboxLayout = QHBoxLayout(groupbox)
+            groupboxLayout.addWidget(widget)
+            layout.addWidget(groupbox, *stage_info["index"])
+            self.widgets[stage_name] = widget
+
+
+class StageControllerApp(qiwis.BaseApp):
+    """App for monitoring and controlling motorized stages."""
+
+    def __init__(
+        self,
+        name: str,
+        stages: Dict[str, Dict[str, Any]],
+        parent: Optional[QObject] = None,
+    ):
+        """Extended.
+        
+        Args:
+            stages: Dictionary of stage information. Each key is the name of the
+              stage and the value is agian a dictionary, whose structure is:
+              {
+                "index": [row, column],
+                "target": ["ip", port, "target_name"]
+              }
+        """
+        super().__init__(name, parent=parent)
+        # setup threaded manager
+        self.thread = QThread()
+        self.manager = StageManager()
+        self.proxies = {key: StageProxy(self.manager, key) for key in stages}
+        self.manager.moveToThread(self.thread)
+        self.thread.finished.connect(self.manager.deleteLater)
+        self.thread.finished.connect(self.thread.deleteLater)
+        self.thread.start()
+        # timer for periodic position read
+        self.timer = QTimer(self)
+        self.timer.start(500)
+        # setup controller frame
+        self.frame = StageControllerFrame(stages)
+        for key, info in stages.items():
+            proxy = self.proxies[key]
+            widget = self.frame.widgets[key]
+            widget.tryConnect.connect(functools.partial(proxy.connectTarget, tuple(info["target"])))
+            widget.moveBy.connect(proxy.moveBy)
+            widget.moveTo.connect(proxy.moveTo)
+        # signal connection
+        self.timer.timeout.connect(self.readAllPositions, type=Qt.QueuedConnection)
+        self.manager.connectionChanged.connect(
+            self.handleConnectionChanged, type=Qt.QueuedConnection
+        )
+        self.manager.clientError.connect(
+            self.handleClientError, type=Qt.QueuedConnection
+        )
+        self.manager.positionReported.connect(
+            self.handlePositionReported, type=Qt.QueuedConnection
+        )
+
+    @pyqtSlot()
+    def readAllPositions(self):
+        """Requests positions of all connected stages."""
+        for key, widget in self.frame.widgets.items():
+            if widget.isConnected():
+                self.proxies[key].getPosition()
+
+    @pyqtSlot(str, bool)
+    def handleConnectionChanged(self, key: str, connected: bool):
+        """Handles connectionChanged signal.
+        
+        Args:
+            See StageManager.connectionChanged signal.
+        """
+        try:
+            widget = self.frame.widgets[key]
+        except KeyError:
+            logger.exception("Connection changed key does not exist.")
+        else:
+            widget.setConnected(connected)
+
+    @pyqtSlot(str, Exception)
+    def handleClientError(self, key: str, _error: Exception):
+        """Handles clientError signal.
+        
+        Args:
+            See StageManager.clientError signal.
+        """
+        self.handleConnectionChanged(key, False)
+
+    @pyqtSlot(str, float)
+    def handlePositionReported(self, key: str, position_m: float):
+        """Handles positionReported signal.
+        
+        Args:
+            See StageManager.positionReported signal.
+        """
+        try:
+            widget = self.frame.widgets[key]
+        except KeyError:
+            logger.exception("Position reported key does not exist.")
+        else:
+            widget.setPosition(position_m)
+
+    def __del__(self):
+        """Quits the thread before destructing."""
+        self.thread.quit()
+
+    def frames(self) -> Tuple[Tuple[str, StageControllerFrame]]:
+        """Overridden."""
+        return (("", self.frame),)

--- a/iquip/apps/stage.py
+++ b/iquip/apps/stage.py
@@ -408,7 +408,8 @@ class StageControllerApp(qiwis.BaseApp):
         for key, info in stages.items():
             proxy = self.proxies[key]
             widget = self.frame.widgets[key]
-            widget.tryConnect.connect(functools.partial(proxy.connectTarget, tuple(info["target"])))
+            widget.openTarget.connect(functools.partial(proxy.openTarget, tuple(info["target"])))
+            widget.closeTarget.connect(proxy.closeTarget)
             widget.moveBy.connect(proxy.moveBy)
             widget.moveTo.connect(proxy.moveTo)
         # signal connection

--- a/iquip/apps/stage.py
+++ b/iquip/apps/stage.py
@@ -8,7 +8,8 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, Qt, QThread, QTimer
 from PyQt5.QtWidgets import (
-    QAbstractSpinBox, QDoubleSpinBox, QGridLayout, QGroupBox, QHBoxLayout, QPushButton, QVBoxLayout, QWidget,
+    QAbstractSpinBox, QDoubleSpinBox, QGridLayout, QGroupBox, QHBoxLayout,
+    QPushButton, QVBoxLayout, QWidget,
 )
 
 import qiwis

--- a/iquip/apps/stage.py
+++ b/iquip/apps/stage.py
@@ -361,13 +361,13 @@ class StageControllerFrame(QWidget):
         super().__init__(parent=parent)
         self.widgets: Dict[str, StageWidget] = {}
         layout = QGridLayout(self)
-        for stage_name, stage_info in stages.items():
+        for name, info in stages.items():
             widget = StageWidget(self)
-            groupbox = QGroupBox(stage_name, self)
+            groupbox = QGroupBox(name, self)
             groupboxLayout = QHBoxLayout(groupbox)
             groupboxLayout.addWidget(widget)
-            layout.addWidget(groupbox, *stage_info["index"])
-            self.widgets[stage_name] = widget
+            layout.addWidget(groupbox, *info["index"])
+            self.widgets[name] = widget
 
 
 class StageControllerApp(qiwis.BaseApp):

--- a/iquip/apps/stage.py
+++ b/iquip/apps/stage.py
@@ -371,7 +371,15 @@ class StageControllerFrame(QWidget):
 
 
 class StageControllerApp(qiwis.BaseApp):
-    """App for monitoring and controlling motorized stages."""
+    """App for monitoring and controlling motorized stages.
+    
+    Attributes:
+        thread: Stage manager thread.
+        manager: StageManager object.
+        proxies: StageProxy dictionary whose keys are the stage names.
+        timer: QTimer object for periodic stage position read.
+        frame: Stage controller frame object.
+    """
 
     def __init__(
         self,

--- a/iquip/apps/stage.py
+++ b/iquip/apps/stage.py
@@ -365,8 +365,7 @@ class StageControllerFrame(QWidget):
         for name, info in stages.items():
             widget = StageWidget(self)
             groupbox = QGroupBox(name, self)
-            groupboxLayout = QHBoxLayout(groupbox)
-            groupboxLayout.addWidget(widget)
+            QHBoxLayout(groupbox).addWidget(widget)
             layout.addWidget(groupbox, *info["index"])
             self.widgets[name] = widget
 

--- a/iquip/apps/stage.py
+++ b/iquip/apps/stage.py
@@ -392,7 +392,7 @@ class StageControllerApp(qiwis.BaseApp):
         
         Args:
             stages: Dictionary of stage information. Each key is the name of the
-              stage and the value is agian a dictionary, whose structure is:
+              stage and the value is again a dictionary, whose structure is:
               {
                 "index": [row, column],
                 "target": ["ip", port, "target_name"]

--- a/iquip/apps/stage.py
+++ b/iquip/apps/stage.py
@@ -377,6 +377,7 @@ class StageControllerApp(qiwis.BaseApp):
         self,
         name: str,
         stages: Dict[str, Dict[str, Any]],
+        period: float = 0.5,
         parent: Optional[QObject] = None,
     ):
         """Extended.
@@ -388,6 +389,7 @@ class StageControllerApp(qiwis.BaseApp):
                 "index": [row, column],
                 "target": ["ip", port, "target_name"]
               }
+            period: Position reading period in seconds.
         """
         super().__init__(name, parent=parent)
         # setup threaded manager
@@ -400,7 +402,7 @@ class StageControllerApp(qiwis.BaseApp):
         self.thread.start()
         # timer for periodic position read
         self.timer = QTimer(self)
-        self.timer.start(500)
+        self.timer.start(round(period * 1000))
         # setup controller frame
         self.frame = StageControllerFrame(stages)
         for key, info in stages.items():


### PR DESCRIPTION
This closes #245, implementing the motorized stage controller app.

Key structure of this app:
- It uses a dedicated non-GUI `QThread` to actually control the stage RPC clients.
- `StageManager` lives in the non-GUI thread, and provides signals to control the RPC clients.
- `StageProxy` provides a convenient interface to control the RPC clients which live in a different thread (automatically converts method calls to signal emissions).
- Every proxied RPC call is non-blocking.

Probable issues:
1. There is no way to restart the manager thread if it crashes somehow. However the RPC errors will not cause such crash.
2. The move requests are non-blocking so rapid move requests interrupts the previous moves and even the server does not protect it, i.e., it does not wait for the previous move to be done. For example, when the relative move button is rapidly clicked 5 times with step size of 1um, it may actually move less than 5um.

![Screen Shot 2024-04-07 at 16 56 27](https://github.com/snu-quiqcl/iquip/assets/8445906/7c2d667c-da39-4dc4-b1c3-b553a757ed5b)
