### PR TITLE
Fix transposed 2D image of dataviewer

### DIFF
--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -281,7 +281,7 @@ class ImageViewer(NDArrayViewer):  # pylint: disable=too-few-public-methods
         x, y = np.floor(dataPos.x()), np.floor(dataPos.y())
         w, h = self.image.width(), self.image.height()
         if 0 <= x < w and 0 <= y < h:
-            return int(x), int(y)
+            return int(y), int(x)  # row, column index
         return None
 
 

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -259,7 +259,7 @@ class ImageViewer(NDArrayViewer):  # pylint: disable=too-few-public-methods
           values should be linearly increasing sequences.
         """
         super().setData(data, axes)
-        self.image.setImage(data)
+        self.image.setImage(data.T)
         vaxis, haxis = axes
         self.plotItem.setLabel(axis="left", text=vaxis.name, units=vaxis.unit)
         self.plotItem.setLabel(axis="bottom", text=haxis.name, units=haxis.unit)


### PR DESCRIPTION
The 2D image was transposed as [`pyqtgraph.ImageItem.setImage()`](https://pyqtgraph.readthedocs.io/en/latest/api_reference/graphicsItems/imageitem.html#pyqtgraph.ImageItem.setImage) takes a column-major data instead of row-major, which is the standard for `numpy`.

This resolves #299.