### PR TITLE
Filter datasets starting with `__`

### DIFF
--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -39,7 +39,7 @@ def filter_dataset_list(names: List[str]) -> List[str]:
         names: Dataset name list.
     """
     return [
-        name for name in names 
+        name for name in names
         if not (name.startswith("__") or name.endswith((".parameters", ".units")))
     ]
 

--- a/iquip/apps/dataviewer.py
+++ b/iquip/apps/dataviewer.py
@@ -33,12 +33,15 @@ logger = logging.getLogger(__name__)
 MAX_INT = 2**31 - 1
 
 def filter_dataset_list(names: List[str]) -> List[str]:
-    """Returns a new list excluding "*.parameters" and "*.units".
+    """Returns a new list excluding "__*", "*.parameters", and "*.units".
     
     Args:
-        names: Dataset name list which includes "*.parameters" and "*.units".
+        names: Dataset name list.
     """
-    return [name for name in names if not name.endswith((".parameters", ".units"))]
+    return [
+        name for name in names 
+        if not (name.startswith("__") or name.endswith((".parameters", ".units")))
+    ]
 
 
 def p_1(threshold: int, array: np.ndarray) -> float:


### PR DESCRIPTION
This closes #324.

I just updated `filter_dataset_list()` to filter `__*` in `iquip/apps/dataviewer.py`.